### PR TITLE
Fix critical Firestore rules: sharee could take over shared todos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Thumbs.db
 
 # Claude Code local settings
 .claude/settings.local.json
+firestore-debug.log

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,12 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8181
+    }
+  },
   "functions": [
     {
       "source": "functions",

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,17 +11,34 @@ service cloud.firestore {
       return isAuthenticated() && request.auth.uid == userId;
     }
 
+    // sharedWith/mentionedUsers gate read access (see the todos collection
+    // group rule below), so they must be lists when present — never maps or
+    // strings that could confuse the `in` membership checks.
+    function hasValidTodoUserLists() {
+      return (!('sharedWith' in request.resource.data) || request.resource.data.sharedWith is list)
+          && (!('mentionedUsers' in request.resource.data) || request.resource.data.mentionedUsers is list);
+    }
+
     // Rules for specific user documents and their subcollections
     match /users/{userId} {
       allow read: if isAuthenticated();
       allow write: if isOwner(userId); // Owner can write their own user doc
 
+      // Reads on todos are governed solely by the collection group rule below
+      // (/{path=**}/todos/{todoId}) — it also matches direct document reads.
       match /todos/{todoId} {
-        allow read, update: if isAuthenticated() && (
-                               isOwner(userId) ||
-                               (resource.data.sharedWith != null && request.auth.uid in resource.data.sharedWith)
-                             );
-        allow create, delete: if isOwner(userId);
+        // Owner may update anything (as long as the access-control lists stay
+        // lists); a sharee may only toggle `completed` — nothing else, so they
+        // can neither alter content nor extend/hijack sharedWith/mentionedUsers.
+        allow update: if (isOwner(userId) && hasValidTodoUserLists()) || (
+                         isAuthenticated() &&
+                         resource.data.sharedWith != null &&
+                         request.auth.uid in resource.data.sharedWith &&
+                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['completed']) &&
+                         request.resource.data.completed is bool
+                       );
+        allow create: if isOwner(userId) && hasValidTodoUserLists();
+        allow delete: if isOwner(userId);
       }
 
       // Contacts subcollection: users/{ownerId}/contacts/{contactEntryId}
@@ -70,7 +87,9 @@ service cloud.firestore {
       }
     }
 
-    // Collection group queries
+    // Single authoritative read rule for todos: covers collection group
+    // queries AND direct reads of users/{uid}/todos/{todoId} (path[1] is the
+    // owner's uid). Owner, sharees and mentioned users may read.
     match /{path=**}/todos/{todoId} {
        allow read: if isAuthenticated() && (
                        request.auth.uid == path[1] ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "zod": "^3.25.28"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.4",
         "@playwright/cli": "^0.1.13",
         "eslint": "8.57.0",
         "eslint-config-next": "14.1.0"
@@ -592,6 +593,23 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
       "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA=="
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
+      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "2.6.4",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "firebase": "^10.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.2",
@@ -2017,6 +2035,17 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -2707,6 +2736,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -3112,6 +3148,19 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3329,6 +3378,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4406,6 +4465,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -5851,6 +5927,27 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-mocks-http": {
@@ -7883,6 +7980,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -8224,6 +8328,13 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -8243,6 +8354,17 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:rules": "firebase emulators:exec --only firestore --project demo-rules-test \"node tests/firestore-rules.test.mjs\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -40,6 +41,7 @@
     "zod": "^3.25.28"
   },
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.4",
     "@playwright/cli": "^0.1.13",
     "eslint": "8.57.0",
     "eslint-config-next": "14.1.0"

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -1,0 +1,134 @@
+// Security-rules tests for todos (issue #12).
+// Run via: npm run test:rules  (wraps firebase emulators:exec)
+import { readFileSync } from 'node:fs';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} from '@firebase/rules-unit-testing';
+import {
+  doc,
+  getDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  collectionGroup,
+  query,
+  where,
+  getDocs,
+} from 'firebase/firestore';
+
+const ALICE = 'alice-uid';
+const BOB = 'bob-uid';
+const MALLORY = 'mallory-uid';
+const VICTIM = 'victim-uid';
+
+const TODO_PATH = `users/${ALICE}/todos/todo-1`;
+
+const seedTodo = {
+  text: 'original text',
+  content: { type: 'doc', content: [] },
+  completed: false,
+  sharedWith: [BOB],
+  mentionedUsers: [],
+  tags: [],
+};
+
+let failures = 0;
+async function check(name, promise) {
+  try {
+    await promise;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${err.message}`);
+  }
+}
+
+const testEnv = await initializeTestEnvironment({
+  projectId: 'demo-rules-test',
+  firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+});
+
+async function resetTodo() {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), TODO_PATH), seedTodo);
+  });
+}
+
+const db = (uid) => testEnv.authenticatedContext(uid).firestore();
+
+await resetTodo();
+
+console.log('Sharee permissions:');
+await check('sharee may toggle completed', assertSucceeds(
+  updateDoc(doc(db(BOB), TODO_PATH), { completed: true })));
+await check('sharee may not write non-bool completed', assertFails(
+  updateDoc(doc(db(BOB), TODO_PATH), { completed: 'yes' })));
+await check('sharee may not change text/content', assertFails(
+  updateDoc(doc(db(BOB), TODO_PATH), { text: 'defaced', content: {} })));
+await check('sharee may not change completed together with other fields', assertFails(
+  updateDoc(doc(db(BOB), TODO_PATH), { completed: true, text: 'defaced' })));
+await check('sharee may not extend sharedWith (takeover)', assertFails(
+  updateDoc(doc(db(BOB), TODO_PATH), { sharedWith: [BOB, MALLORY] })));
+await check('sharee may not inject mentionedUsers (feed spam)', assertFails(
+  updateDoc(doc(db(BOB), TODO_PATH), { mentionedUsers: [VICTIM] })));
+await check('sharee may not delete the todo', assertFails(
+  deleteDoc(doc(db(BOB), TODO_PATH))));
+await check('sharee may read the todo', assertSucceeds(
+  getDoc(doc(db(BOB), TODO_PATH))));
+
+console.log('Non-shared user:');
+await check('outsider may not read the todo', assertFails(
+  getDoc(doc(db(MALLORY), TODO_PATH))));
+await check('outsider may not update the todo', assertFails(
+  updateDoc(doc(db(MALLORY), TODO_PATH), { completed: true })));
+
+console.log('Owner permissions:');
+await resetTodo();
+await check('owner may edit content/text/mentions/tags', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO_PATH), {
+    text: 'new', content: { type: 'doc' }, mentionedUsers: [VICTIM], tags: ['x'],
+  })));
+await check('owner may share via sharedWith list', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO_PATH), { sharedWith: [BOB, MALLORY] })));
+await check('owner may not set sharedWith to a non-list', assertFails(
+  updateDoc(doc(db(ALICE), TODO_PATH), { sharedWith: 'everyone' })));
+await check('owner may not set mentionedUsers to a non-list', assertFails(
+  updateDoc(doc(db(ALICE), TODO_PATH), { mentionedUsers: 'everyone' })));
+await check('owner may create a todo', assertSucceeds(
+  setDoc(doc(db(ALICE), `users/${ALICE}/todos/todo-2`), seedTodo)));
+await check('owner may not create with non-list sharedWith', assertFails(
+  setDoc(doc(db(ALICE), `users/${ALICE}/todos/todo-3`), { ...seedTodo, sharedWith: 'all' })));
+await check('non-owner may not create in foreign collection', assertFails(
+  setDoc(doc(db(BOB), `users/${ALICE}/todos/todo-4`), seedTodo)));
+await check('owner may delete a todo', assertSucceeds(
+  deleteDoc(doc(db(ALICE), `users/${ALICE}/todos/todo-2`))));
+
+console.log('Reads (single authoritative collection group rule):');
+await resetTodo();
+await testEnv.withSecurityRulesDisabled(async (ctx) => {
+  await setDoc(doc(ctx.firestore(), `users/${ALICE}/todos/todo-mention`), {
+    ...seedTodo, sharedWith: [], mentionedUsers: [VICTIM],
+  });
+});
+await check('owner may read own todo directly', assertSucceeds(
+  getDoc(doc(db(ALICE), TODO_PATH))));
+await check('mentioned user may read the todo directly', assertSucceeds(
+  getDoc(doc(db(VICTIM), `users/${ALICE}/todos/todo-mention`))));
+await check('mentioned user may run collection group query', assertSucceeds(
+  getDocs(query(collectionGroup(db(VICTIM), 'todos'),
+    where('mentionedUsers', 'array-contains', VICTIM)))));
+await check('sharee may run collection group query', assertSucceeds(
+  getDocs(query(collectionGroup(db(BOB), 'todos'),
+    where('sharedWith', 'array-contains', BOB)))));
+await check('unauthenticated user may not read', assertFails(
+  getDoc(doc(testEnv.unauthenticatedContext().firestore(), TODO_PATH))));
+
+await testEnv.cleanup();
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll rules tests passed');


### PR DESCRIPTION
## Summary

Closes #12

A user listed in a todo's `sharedWith` could update **all** fields via direct Firestore SDK calls — rewrite content, hijack `sharedWith` (locking out the owner's revocation), and inject `mentionedUsers` to force content into arbitrary users' mention feeds. The UI-only `canEdit = isOwner` check provided no server-side protection.

## Changes

- **firestore.rules**: Sharee updates restricted to `affectedKeys().hasOnly(['completed'])` with `completed is bool`. Owner updates/creates validate `sharedWith`/`mentionedUsers` are lists. The two overlapping todo read rules consolidated into the single collection group rule (it also matches direct document reads).
- **firebase.json**: Registered `firestore.rules` — previously `firebase deploy --only firestore:rules` had no rules target configured at all. Pinned emulator port to 8181 (8080 commonly taken by Docker).
- **tests/firestore-rules.test.mjs** + `npm run test:rules`: 23 emulator-based rules tests reproducing the exploit (all blocked) and covering legitimate flows (sharee toggle, owner edit/share, mention reads, collection group queries).

## Test Plan

- [x] `firebase deploy --only firestore:rules --dry-run` — rules compile
- [x] `npm run test:rules` — all 23 tests pass (run with `firebase-tools@13` due to local Java 11; v15 needs Java 21)
- [x] `firebase deploy --only firestore:rules` — deployed to production (template-2-20926)

🤖 Generated with [Claude Code](https://claude.com/claude-code)