### PR TITLE
Stop PII exposure: user docs owner-only, email-free public profiles

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,9 +19,24 @@ service cloud.firestore {
           && (!('mentionedUsers' in request.resource.data) || request.resource.data.mentionedUsers is list);
     }
 
+    // Public, PII-free profile data (displayName/photoURL/emailHash — never
+    // the email itself). Cross-user lookups and search read this collection;
+    // the full user doc below stays owner-only.
+    match /publicProfiles/{userId} {
+      allow read: if isAuthenticated();
+      allow create, update: if isOwner(userId)
+        && request.resource.data.keys().hasOnly(['displayName', 'displayNameLower', 'photoURL', 'emailHash'])
+        && (!('displayName' in request.resource.data) || request.resource.data.displayName == null || request.resource.data.displayName is string)
+        && (!('displayNameLower' in request.resource.data) || request.resource.data.displayNameLower == null || request.resource.data.displayNameLower is string)
+        && (!('photoURL' in request.resource.data) || request.resource.data.photoURL == null || request.resource.data.photoURL is string)
+        && (!('emailHash' in request.resource.data) || request.resource.data.emailHash == null || request.resource.data.emailHash is string);
+      allow delete: if isOwner(userId);
+    }
+
     // Rules for specific user documents and their subcollections
     match /users/{userId} {
-      allow read: if isAuthenticated();
+      // Owner-only: contains PII (email, timezone, notification settings)
+      allow read: if isOwner(userId);
       allow write: if isOwner(userId); // Owner can write their own user doc
 
       // Reads on todos are governed solely by the collection group rule below

--- a/src/components/MentionsList.tsx
+++ b/src/components/MentionsList.tsx
@@ -104,7 +104,7 @@ export default function MentionsList() {
       const newOwnersInfo: Record<string, OwnerInfo> = {};
       const promises = ownerIdsToFetch.map(async (ownerId) => {
         try {
-          const userDocRef = doc(db, 'users', ownerId);
+          const userDocRef = doc(db, 'publicProfiles', ownerId);
           const userDoc = await getDoc(userDocRef);
           if (userDoc.exists()) {
             const data = userDoc.data();

--- a/src/components/ShareTodo.tsx
+++ b/src/components/ShareTodo.tsx
@@ -57,7 +57,7 @@ export default function ShareTodo({ todoId, userId }: ShareTodoProps) {
         sharedWith: arrayUnion(userToShare.uid)
       });
 
-      const userRef = doc(db, 'users', userToShare.uid);
+      const userRef = doc(db, 'publicProfiles', userToShare.uid);
       const userDoc = await getDoc(userRef);
       const userData = userDoc.exists() ? userDoc.data() : userToShare;
 

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -36,7 +36,8 @@ interface UserInfo {
   uid: string;
   displayName: string | null;
   photoURL: string | null;
-  email: string | null;
+  // publicProfiles carry no email; kept optional as a display fallback only
+  email?: string | null;
 }
 
 interface TodoProps {
@@ -139,9 +140,9 @@ export default function Todo({ id, content, text, completed, userId, sharedWith 
       try {
         const userPromises = [
           // Get owner info
-          getDoc(doc(db, 'users', userId)),
+          getDoc(doc(db, 'publicProfiles', userId)),
           // Get shared users info
-          ...(sharedWith ?? []).map(uid => getDoc(doc(db, 'users', uid)))
+          ...(sharedWith ?? []).map(uid => getDoc(doc(db, 'publicProfiles', uid)))
         ];
 
         const userDocs = await Promise.all(userPromises);

--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from 'react';
-import { collection, query, where, getDocs, orderBy, limit } from 'firebase/firestore';
-import { db } from '@/lib/firebase/firebase';
+import { findUserByEmail, searchUsersByDisplayName } from '@/lib/firebase/firebaseUtils';
 import Image from 'next/image';
 
 interface User {
@@ -34,47 +33,34 @@ export default function UserSearch({ onSelect, excludeUsers = [] }: UserSearchPr
 
       setIsLoading(true);
       try {
-        const usersRef = collection(db, 'users');
-        const searchTermLower = searchTerm.toLowerCase();
-        
-        // Suche nach E-Mail
-        const emailQuery = query(
-          usersRef,
-          where('email', '>=', searchTermLower),
-          where('email', '<=', searchTermLower + '\uf8ff'),
-          limit(5)
-        );
-        
-        // Suche nach Anzeigenamen
-        const nameQuery = query(
-          usersRef,
-          where('displayName', '>=', searchTermLower),
-          where('displayName', '<=', searchTermLower + '\uf8ff'),
-          limit(5)
-        );
-
-        const [emailSnapshot, nameSnapshot] = await Promise.all([
-          getDocs(emailQuery),
-          getDocs(nameQuery)
-        ]);
-
         const foundUsers = new Map<string, User>();
-        
-        // Füge E-Mail-Ergebnisse hinzu
-        emailSnapshot.docs.forEach(doc => {
-          const user = { uid: doc.id, ...doc.data() } as User;
-          if (!excludeUsers.includes(user.uid)) {
-            foundUsers.set(user.uid, user);
-          }
-        });
 
-        // Füge Namens-Ergebnisse hinzu
-        nameSnapshot.docs.forEach(doc => {
-          const user = { uid: doc.id, ...doc.data() } as User;
-          if (!excludeUsers.includes(user.uid)) {
-            foundUsers.set(user.uid, user);
+        if (searchTerm.includes('@')) {
+          // E-Mail: nur Exact-Match über den Hash — kein Präfix-Scan, damit
+          // die Nutzerbasis nicht enumeriert werden kann.
+          const profile = await findUserByEmail(searchTerm);
+          if (profile && !excludeUsers.includes(profile.uid)) {
+            foundUsers.set(profile.uid, {
+              uid: profile.uid,
+              displayName: profile.displayName,
+              email: searchTerm.trim().toLowerCase(),
+              photoURL: profile.photoURL,
+            });
           }
-        });
+        } else {
+          // Suche nach Anzeigenamen über die öffentlichen Profile (ohne E-Mail)
+          const profiles = await searchUsersByDisplayName(searchTerm, 5);
+          profiles.forEach(profile => {
+            if (!excludeUsers.includes(profile.uid)) {
+              foundUsers.set(profile.uid, {
+                uid: profile.uid,
+                displayName: profile.displayName,
+                email: null,
+                photoURL: profile.photoURL,
+              });
+            }
+          });
+        }
 
         setUsers(Array.from(foundUsers.values()));
       } catch (error) {

--- a/src/lib/contexts/AuthContext.tsx
+++ b/src/lib/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import { User } from "firebase/auth";
 import { auth, db } from "../firebase/firebase";
 import { doc, setDoc, getDoc, onSnapshot, Unsubscribe } from 'firebase/firestore';
 import { useRouter } from 'next/navigation';
+import { upsertPublicProfile } from '../firebase/firebaseUtils';
 import { useTheme } from './ThemeContext';
 import type { Theme as ThemeValue } from './ThemeContext';
 
@@ -36,6 +37,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       
       if (authUser) {
+        // Keep the public profile (displayName/photoURL/emailHash — no email)
+        // in sync on every login; also lazily migrates existing users.
+        upsertPublicProfile(authUser).catch((error) => {
+          console.error("Error syncing public profile:", error);
+        });
+
         const userDocRef = doc(db, 'users', authUser.uid);
         try {
           unsubscribeRef.current = onSnapshot(userDocRef, (docSnap) => {

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -53,7 +53,7 @@ export const deleteDocument = (collectionName: string, id: string) =>
   deleteDoc(doc(db, collectionName, id));
 
 // Helper function to generate a SHA-256 hash string from an email
-const generateIdFromEmail = async (email: string): Promise<string> => {
+export const generateIdFromEmail = async (email: string): Promise<string> => {
   const lowerCaseEmail = email.toLowerCase(); // Normalize to lowercase first
   const encoder = new TextEncoder();
   const data = encoder.encode(lowerCaseEmail);
@@ -71,21 +71,76 @@ const generateIdFromEmail = async (email: string): Promise<string> => {
   }
 };
 
-// --- User Profile Functions --- 
+// --- Public Profile Functions ---
+// users/{uid} is owner-readable only (PII like email lives there).
+// publicProfiles/{uid} is the cross-user source: displayName, photoURL and a
+// SHA-256 emailHash for exact-match lookup — never the email itself.
 
-export const saveUserProfile = async (userId: string, data: { email?: string | null; displayName?: string | null; photoURL?: string | null }) => {
-  const userRef = doc(db, 'users', userId);
-  const profileData = {
-    ...data,
-    displayNameLower: data.displayName ? data.displayName.toLowerCase() : null,
-  };
-  await setDoc(userRef, profileData, { merge: true });
+export interface PublicProfile {
+  uid: string;
+  displayName: string | null;
+  photoURL: string | null;
+}
+
+export const upsertPublicProfile = async (user: {
+  uid: string;
+  email?: string | null;
+  displayName?: string | null;
+  photoURL?: string | null;
+}) => {
+  const profileRef = doc(db, 'publicProfiles', user.uid);
+  await setDoc(profileRef, {
+    displayName: user.displayName ?? null,
+    displayNameLower: user.displayName ? user.displayName.toLowerCase() : null,
+    photoURL: user.photoURL ?? null,
+    emailHash: user.email ? await generateIdFromEmail(user.email) : null,
+  }, { merge: true });
 };
 
-export const getUserProfile = async (userId: string) => {
-  const userRef = doc(db, 'users', userId);
-  const docSnap = await getDoc(userRef);
-  return docSnap.exists() ? docSnap.data() : null;
+export const getPublicProfile = async (userId: string): Promise<PublicProfile | null> => {
+  const docSnap = await getDoc(doc(db, 'publicProfiles', userId));
+  if (!docSnap.exists()) return null;
+  const data = docSnap.data();
+  return {
+    uid: docSnap.id,
+    displayName: data.displayName ?? null,
+    photoURL: data.photoURL ?? null,
+  };
+};
+
+// Exact-match lookup by email hash: callers must already know the address,
+// so the user base cannot be enumerated via prefix scans.
+export const findUserByEmail = async (email: string): Promise<PublicProfile | null> => {
+  const emailHash = await generateIdFromEmail(email.trim());
+  const q = query(collection(db, 'publicProfiles'), where('emailHash', '==', emailHash), limit(1));
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) return null;
+  const docSnap = snapshot.docs[0];
+  const data = docSnap.data();
+  return {
+    uid: docSnap.id,
+    displayName: data.displayName ?? null,
+    photoURL: data.photoURL ?? null,
+  };
+};
+
+export const searchUsersByDisplayName = async (prefix: string, max = 5): Promise<PublicProfile[]> => {
+  const prefixLower = prefix.toLowerCase();
+  const q = query(
+    collection(db, 'publicProfiles'),
+    where('displayNameLower', '>=', prefixLower),
+    where('displayNameLower', '<=', prefixLower + '\uf8ff'),
+    limit(max)
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map(docSnap => {
+    const data = docSnap.data();
+    return {
+      uid: docSnap.id,
+      displayName: data.displayName ?? null,
+      photoURL: data.photoURL ?? null,
+    };
+  });
 };
 
 // --- Contact Management Functions --- 
@@ -97,13 +152,11 @@ export const sendContactRequest = async (targetEmailInput: string) => {
   const targetEmail = targetEmailInput.trim().toLowerCase();
   if (currentUser.email?.toLowerCase() === targetEmail) throw new Error("You cannot send a contact request to yourself.");
 
-  const usersRef = collection(db, 'users');
-  const q = query(usersRef, where('email', '==', targetEmail), limit(1));
-  const querySnapshot = await getDocs(q);
+  const targetProfile = await findUserByEmail(targetEmail);
 
   const currentUid = currentUser.uid;
 
-  if (querySnapshot.empty) {
+  if (!targetProfile) {
     // --- User does not exist: Initiate an Invite --- 
     console.log(`User with email ${targetEmail} not found. Initiating an invite.`);
     
@@ -131,10 +184,9 @@ export const sendContactRequest = async (targetEmailInput: string) => {
     return { status: 'invited', message: `User ${targetEmail} not found. An invitation has been initiated.` };
 
   } else {
-    // --- User exists: Proceed with normal contact request --- 
-    const targetUserDoc = querySnapshot.docs[0];
-    const targetUid = targetUserDoc.id;
-    const targetUserData = targetUserDoc.data();
+    // --- User exists: Proceed with normal contact request ---
+    const targetUid = targetProfile.uid;
+    const targetUserData = targetProfile;
 
     const contactRef = doc(db, 'users', currentUid, 'contacts', targetUid);
     const outgoingRequestRef = doc(db, 'users', currentUid, 'outgoingContactRequests', targetUid);
@@ -152,7 +204,7 @@ export const sendContactRequest = async (targetEmailInput: string) => {
       const batch = writeBatch(db);
       batch.set(contactRef, {
         uid: targetUid,
-        email: targetUserData.email || targetEmail,
+        email: targetEmail,
         displayName: targetUserData.displayName || null,
         photoURL: targetUserData.photoURL || null,
         addedAt: serverTimestamp(),
@@ -180,7 +232,9 @@ export const sendContactRequest = async (targetEmailInput: string) => {
       requesterDisplayName: currentUser.displayName,
       requesterPhotoURL: currentUser.photoURL,
     };
-    batch.set(outgoingRequestRef, requestData);
+    // targetEmail lives in the sender's own subcollection so the outgoing
+    // list can show it without reading the target's (now private) user doc.
+    batch.set(outgoingRequestRef, { ...requestData, targetEmail });
     batch.set(targetIncomingRequestRef, incomingData);
     await batch.commit();
     return { status: 'request_sent', message: `Contact request successfully sent to ${targetUserData.displayName || targetEmail}.` };
@@ -219,16 +273,13 @@ export const getOutgoingContactRequests = async (userId: string): Promise<Outgoi
       if (reqData.status !== 'invited') {
         // For non-invite statuses, docId should be a targetUserId
         try {
-          const userProfile = await getUserProfile(docId); // docId is targetUserId here
+          const userProfile = await getPublicProfile(docId); // docId is targetUserId here
           if (userProfile) {
             targetUserProfile = {
               displayName: userProfile.displayName,
-              email: userProfile.email,
+              email: resolvedTargetEmail ?? null,
               photoURL: userProfile.photoURL,
             };
-            // If targetEmail wasn't in the doc (e.g. older pending requests before this change),
-            // try to populate it from the fetched profile.
-            if (!resolvedTargetEmail) resolvedTargetEmail = userProfile.email;
           }
         } catch (profileError) {
           console.error(`Error fetching profile for target user ${docId}:`, profileError);

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -12,6 +12,7 @@ import {
   setDoc,
   updateDoc,
   deleteDoc,
+  collection,
   collectionGroup,
   query,
   where,
@@ -104,6 +105,40 @@ await check('non-owner may not create in foreign collection', assertFails(
   setDoc(doc(db(BOB), `users/${ALICE}/todos/todo-4`), seedTodo)));
 await check('owner may delete a todo', assertSucceeds(
   deleteDoc(doc(db(ALICE), `users/${ALICE}/todos/todo-2`))));
+
+console.log('User docs (PII) and public profiles:');
+await testEnv.withSecurityRulesDisabled(async (ctx) => {
+  await setDoc(doc(ctx.firestore(), `users/${ALICE}`), {
+    email: 'alice@example.com', displayName: 'Alice', theme: 'system',
+  });
+});
+await check('owner may read own user doc', assertSucceeds(
+  getDoc(doc(db(ALICE), `users/${ALICE}`))));
+await check('other users may not read a foreign user doc (PII)', assertFails(
+  getDoc(doc(db(BOB), `users/${ALICE}`))));
+await check('users collection may not be enumerated', assertFails(
+  getDocs(query(collection(db(BOB), 'users'),
+    where('email', '>=', 'a'), where('email', '<=', 'a')))));
+await check('owner may write own public profile', assertSucceeds(
+  setDoc(doc(db(ALICE), `publicProfiles/${ALICE}`), {
+    displayName: 'Alice', displayNameLower: 'alice', photoURL: null, emailHash: 'abc123',
+  })));
+await check('public profile may not contain extra fields (e.g. email)', assertFails(
+  setDoc(doc(db(ALICE), `publicProfiles/${ALICE}`), {
+    displayName: 'Alice', email: 'alice@example.com',
+  })));
+await check('user may not write a foreign public profile', assertFails(
+  setDoc(doc(db(BOB), `publicProfiles/${ALICE}`), { displayName: 'Mallory' })));
+await check('authenticated users may read public profiles', assertSucceeds(
+  getDoc(doc(db(BOB), `publicProfiles/${ALICE}`))));
+await check('authenticated users may query profiles by displayNameLower', assertSucceeds(
+  getDocs(query(collection(db(BOB), 'publicProfiles'),
+    where('displayNameLower', '>=', 'ali'), where('displayNameLower', '<=', 'ali')))));
+await check('authenticated users may query profiles by emailHash', assertSucceeds(
+  getDocs(query(collection(db(BOB), 'publicProfiles'),
+    where('emailHash', '==', 'abc123')))));
+await check('unauthenticated user may not read public profiles', assertFails(
+  getDoc(doc(testEnv.unauthenticatedContext().firestore(), `publicProfiles/${ALICE}`))));
 
 console.log('Reads (single authoritative collection group rule):');
 await resetTodo();


### PR DESCRIPTION
## Summary

Closes #14

Any signed-in user could read **all** user documents (email, timezone, notification settings) and harvest the entire user base via `UserSearch`'s email prefix range queries.

## Changes

- **firestore.rules**: `users/{userId}` reads restricted to the owner. New `publicProfiles/{userId}` collection holds only `displayName`, `displayNameLower`, `photoURL`, `emailHash` (field allowlist enforced in rules — an `email` field is rejected); readable by any authenticated user, writable only by the owner.
- **Email lookup = exact match via SHA-256 hash** (reuses the existing invite-hashing helper): to find a user you must already know their full address — prefix enumeration is impossible. Name search uses `displayNameLower` prefixes over the email-free profiles.
- **AuthContext** upserts the public profile on every login → existing users are migrated lazily.
- **Consumers switched to `publicProfiles`**: `UserSearch`, `Todo` (avatar row), `ShareTodo`, `MentionsList`, contact-request flow. Outgoing contact requests now store `targetEmail` in the sender's own subcollection (previously resolved by reading the target's user doc).
- Removed unused `saveUserProfile`/`getUserProfile`.
- **10 new rules tests** (43 total): foreign user-doc reads and `users` collection queries denied, profile field allowlist holds, hash/name lookups allowed.

## Deployment sequencing (important)

The **live app still reads foreign `users/` docs** — deploying these rules before the app would break search/sharing display in production. Order:
1. Merge this PR → Vercel deploys the new app
2. Then `firebase deploy --only firestore:rules`

Until existing users sign in again, their name/avatar won't resolve for others (UI falls back to placeholder); profiles fill in lazily on login.

## Test Plan

- [x] `npm run test:rules` — all 43 tests pass
- [x] `npx tsc --noEmit` + `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] After merge + Vercel deploy: `firebase deploy --only firestore:rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)