### PR TITLE
chore: retrigger Vercel production deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ This doesn't really matter, but is useful for the AI to understand more about th
 - **@modelcontextprotocol/sdk:** For MCP server implementation.
 - **Zod:** For schema validation in the MCP server.
 - **node-mocks-http:** For shimming Node.js HTTP objects in Next.js API routes for the MCP SDK.
+
+<!-- deploy: 2026-06-10 retrigger for 6fb181a -->


### PR DESCRIPTION
Vercel created no production deployment for merge commit 6fb181a (#26) — previews and earlier merges deployed fine. This no-op README comment re-triggers the pipeline so the #14 app changes go live before the Firestore rules are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)