### PR TITLE
Harden Tiptap link handling: protocol allowlist, no openOnClick

### DIFF
--- a/src/components/TiptapToolbar.tsx
+++ b/src/components/TiptapToolbar.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { Editor } from '@tiptap/react';
+import { normalizeLinkUrl } from '@/lib/tiptap/linkSecurity';
 import {
   FaBold,
   FaItalic,
@@ -61,7 +62,12 @@ const TiptapToolbar: React.FC<TiptapToolbarProps> = ({ editor }) => {
       editor.chain().focus().extendMarkRange('link').unsetLink().run();
       return;
     }
-    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+    const safeUrl = normalizeLinkUrl(url);
+    if (!safeUrl) {
+      window.alert('Only http(s) and mailto links are allowed.');
+      return;
+    }
+    editor.chain().focus().extendMarkRange('link').setLink({ href: safeUrl }).run();
   }, [editor]);
 
   if (!editor) {

--- a/src/lib/hooks/useTiptapConfig.ts
+++ b/src/lib/hooks/useTiptapConfig.ts
@@ -9,6 +9,7 @@ import BulletList from '@tiptap/extension-bullet-list';
 import OrderedList from '@tiptap/extension-ordered-list';
 import CodeBlock from '@tiptap/extension-code-block';
 import Link from '@tiptap/extension-link';
+import { ALLOWED_LINK_PROTOCOLS, isSafeLinkUrl } from '@/lib/tiptap/linkSecurity';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
 import Highlight from '@tiptap/extension-highlight';
@@ -145,7 +146,13 @@ export function useTiptapConfig({
     Link.configure({
       autolink: true,
       linkOnPaste: true,
-      openOnClick: !editable,
+      // Never open on click straight from the editor: shared todos can
+      // contain links authored by other users.
+      openOnClick: false,
+      // Explicit allowlist instead of relying on the library default
+      // (see issue #17): only http(s)/mailto, never javascript: & co.
+      protocols: ALLOWED_LINK_PROTOCOLS,
+      isAllowedUri: (url, ctx) => ctx.defaultValidate(url) && isSafeLinkUrl(url),
     }),
     Highlight,
     Mention.configure(mentionOptions),

--- a/src/lib/tiptap/linkSecurity.ts
+++ b/src/lib/tiptap/linkSecurity.ts
@@ -1,0 +1,29 @@
+// Shared URL validation for Tiptap link handling (issue #17).
+// Only http(s) and mailto are allowed — javascript:, data:, vbscript: etc.
+// must never end up in a stored link mark.
+
+export const ALLOWED_LINK_PROTOCOLS = ['http', 'https', 'mailto'];
+
+export function isSafeLinkUrl(url: string): boolean {
+  const trimmed = url.trim();
+  if (/^\s*javascript:/i.test(trimmed)) return false;
+  const match = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (!match) {
+    // Scheme-less inputs ("example.com", "/path") are fine — they resolve
+    // relative to the current origin or get a scheme prepended by callers.
+    return !trimmed.startsWith('//');
+  }
+  return ALLOWED_LINK_PROTOCOLS.includes(match[1].toLowerCase());
+}
+
+// Normalizes toolbar input: prepends https:// to scheme-less values like
+// "example.com" and returns null for anything that fails the allowlist.
+export function normalizeLinkUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  if (!isSafeLinkUrl(trimmed)) return null;
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) && !trimmed.startsWith('/')) {
+    return `https://${trimmed}`;
+  }
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

Closes #17

Link safety previously hung implicitly on the `@tiptap/extension-link` library default; `openOnClick` was enabled in the read-only editor and the toolbar's `window.prompt` URL went into `setLink` unvalidated.

## Changes

- **`useTiptapConfig.ts`**: `Link.configure` now sets `protocols: ['http','https','mailto']`, an `isAllowedUri` validator (defaultValidate + own javascript:-check) and `openOnClick: false` — shared todos contain links authored by other users. In the read-only display editor, anchors still navigate natively (with Tiptap's default `rel="noopener noreferrer nofollow"` + `target="_blank"`).
- **New `src/lib/tiptap/linkSecurity.ts`**: shared `isSafeLinkUrl`/`normalizeLinkUrl` helpers — block `javascript:`, `data:` and protocol-relative (`//`) URLs, prepend `https://` to scheme-less input.
- **`TiptapToolbar.tsx`**: prompt input is normalized/validated before `setLink`; invalid input shows an alert instead of being stored.
- Verified there is no `dangerouslySetInnerHTML`/`generateHTML` rendering of Tiptap content anywhere — everything renders via `<EditorContent>` as before.

## Test Plan

- [x] `npm run build` / `npx tsc --noEmit` / `npm run lint` — clean
- [ ] Manual: add link via toolbar (`example.com` → `https://example.com`), try `javascript:alert(1)` → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)