### PR TITLE
feat(theme): design tokens, oklch theme system & fonts (#39)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,22 +2,66 @@
 @tailwind components;
 @tailwind utilities;
 
+/* === Redesign design tokens (issue #39) ===========================
+ * Source of truth: docs/design_handoff_aido_redesign/README.md → "Design Tokens".
+ * Dark is the default (:root); light is an override on html[data-theme="light"].
+ * ThemeContext toggles BOTH data-theme (new token system) and the legacy
+ * .dark class (existing Tailwind dark: variants) so old and new UI stay in sync
+ * during the migration. Tailwind utilities map onto these vars in tailwind.config.ts.
+ */
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-rgb: 243, 244, 246;
+  --bg: oklch(0.22 0.02 270);
+  --bg-side: oklch(0.19 0.02 270);
+  --bg-card: oklch(0.26 0.02 270);
+  --bg-pop: oklch(0.28 0.02 270);
+  --row-hover: oklch(0.29 0.02 270);
+  --border: oklch(0.33 0.02 270);
+  --text: oklch(0.95 0.01 80);
+  --text-dim: oklch(0.62 0.02 270);
+  --check-border: oklch(0.5 0.03 270);
+  --accent: oklch(0.72 0.15 40);
+  --accent-soft: oklch(0.72 0.15 40 / 0.18);
+  --accent-text: oklch(0.83 0.09 40);
+  --mention: oklch(0.8 0.08 200);
+  --mention-bg: oklch(0.72 0.15 200 / 0.18);
+  --tag: oklch(0.8 0.08 40);
+  --wait-text: oklch(0.82 0.1 75);
+  --wait-bg: oklch(0.75 0.14 75 / 0.16);
+  --danger: oklch(0.68 0.18 25);
+
+  /* Translucent nav background for the mobile header/tab-bar blur (issue #43). */
+  --nav-bg: oklch(0.19 0.02 270 / 0.8);
+  --shadow: 0 8px 28px oklch(0 0 0 / 0.4);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
+html[data-theme="light"] {
+  --bg: oklch(0.965 0.008 80);
+  --bg-side: white;
+  --bg-card: white; /* Mobile uses oklch(0.99 0.004 80) — set by the mobile shell (issue #43). */
+  --bg-pop: white;
+  --row-hover: oklch(0.93 0.008 80);
+  --border: oklch(0.89 0.01 80);
+  --text: oklch(0.27 0.02 270);
+  --text-dim: oklch(0.55 0.02 270);
+  --check-border: oklch(0.78 0.02 80);
+  --accent-soft: oklch(0.72 0.15 40 / 0.14);
+  --accent-text: oklch(0.5 0.12 40);
+  --mention: oklch(0.5 0.12 200);
+  --mention-bg: oklch(0.72 0.15 200 / 0.14);
+  --tag: oklch(0.55 0.12 40);
+  --wait-text: oklch(0.5 0.12 75);
+  --danger: oklch(0.55 0.2 25);
+
+  --nav-bg: oklch(1 0 0 / 0.8);
+  --shadow: 0 8px 28px oklch(0 0 0 / 0.14);
 }
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: var(--font-nunito), ui-sans-serif, system-ui, sans-serif;
+  /* Theme transition per handoff. */
+  transition: background-color 0.25s, color 0.25s;
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,26 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Nunito, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/lib/contexts/AuthContext";
 import { ErrorProvider } from "@/lib/contexts/ErrorContext";
 import MainLayoutClientWrapper from "@/components/MainLayoutClientWrapper";
 import { ThemeProvider } from "@/lib/contexts/ThemeContext";
 
-const inter = Inter({ subsets: ["latin"] });
+// UI font (issue #39). Exposed as a CSS variable consumed by globals.css/Tailwind.
+const nunito = Nunito({
+  subsets: ["latin"],
+  weight: ["400", "600", "700", "800", "900"],
+  variable: "--font-nunito",
+  display: "swap",
+});
+
+// Monospace for #tags and numbers (issue #39).
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "600"],
+  variable: "--font-jetbrains-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Aido - Your Todo App",
@@ -20,7 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} bg-white dark:bg-gray-900 transition-colors duration-200`}>
+      <body className={`${nunito.variable} ${jetbrainsMono.variable}`}>
         <ThemeProvider>
           <AuthProvider>
             <ErrorProvider>

--- a/src/lib/contexts/ThemeContext.tsx
+++ b/src/lib/contexts/ThemeContext.tsx
@@ -6,6 +6,11 @@ import { usePathname } from 'next/navigation';
 // Export the Theme type
 export type Theme = 'light' | 'dark' | 'system';
 
+// Canonical localStorage key for the persisted preference (design handoff, issue #39).
+const STORAGE_KEY = 'aidoF-theme';
+// Legacy key used before the redesign — read once for migration, then superseded.
+const LEGACY_STORAGE_KEY = 'theme';
+
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
@@ -14,13 +19,16 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-// applyTheme now accepts pathname
+// applyTheme resolves the effective theme and applies it to <html>:
+//  - data-theme="light|dark" drives the redesign oklch tokens (globals.css).
+//  - the legacy .dark class keeps existing Tailwind `dark:` variants working
+//    until every screen is migrated. Both are toggled together so old and new
+//    UI never disagree about the active theme.
 const applyTheme = (theme: Theme, pathname: string): 'light' | 'dark' => {
   let effectiveTheme: 'light' | 'dark';
 
   // Force dark mode for the login page
   if (pathname === '/login') {
-    console.log("Applying forced dark theme for /login");
     effectiveTheme = 'dark';
   } else if (theme === 'system') {
     effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -28,13 +36,26 @@ const applyTheme = (theme: Theme, pathname: string): 'light' | 'dark' => {
     effectiveTheme = theme;
   }
 
-  // Apply the class to the html element
-  if (effectiveTheme === 'dark') {
-    document.documentElement.classList.add('dark');
-  } else {
-    document.documentElement.classList.remove('dark');
-  }
+  const root = document.documentElement;
+  root.setAttribute('data-theme', effectiveTheme);
+  root.classList.toggle('dark', effectiveTheme === 'dark');
+
   return effectiveTheme;
+};
+
+// Read the persisted preference (new key, falling back to the legacy key).
+// Runs only in the browser; defaults to 'system' on the server / first paint.
+const readStoredTheme = (): Theme => {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) ?? localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  } catch {
+    // Ignore storage access errors (e.g. privacy mode) and fall back to 'system'.
+  }
+  return 'system';
 };
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
@@ -42,12 +63,17 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
   const pathname = usePathname();
 
+  // Hydrate the preference from localStorage once on mount (cannot run on the server).
+  useEffect(() => {
+    setThemeState(readStoredTheme());
+  }, []);
+
   // Effect to apply theme based on state and path initially and on path change
   useEffect(() => {
     const initialResolvedTheme = applyTheme(theme, pathname);
     setResolvedTheme(initialResolvedTheme);
   // Dependencies: theme state AND pathname
-  }, [theme, pathname]); 
+  }, [theme, pathname]);
 
   // Listen for system theme changes only if theme is 'system' AND not on login page
   useEffect(() => {
@@ -63,19 +89,18 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   // Dependencies: theme state AND pathname
-  }, [theme, pathname]); 
+  }, [theme, pathname]);
 
   const setTheme = useCallback((newTheme: Theme) => {
     try {
       // Store the user's explicit choice, even if /login forces dark visually
-      localStorage.setItem('theme', newTheme);
-      setThemeState(newTheme);
-      // applyTheme is now handled by the state update useEffect
+      localStorage.setItem(STORAGE_KEY, newTheme);
     } catch (error) {
       console.error("Failed to set theme in localStorage", error);
     }
-  // No pathname dependency needed here, as the effect listening to [theme, pathname] handles application
-  }, []); 
+    setThemeState(newTheme);
+    // applyTheme is handled by the [theme, pathname] effect
+  }, []);
 
   const contextValue: ThemeContextType = {
     theme,       // The user's preference (light, dark, system)
@@ -96,4 +121,4 @@ export const useTheme = (): ThemeContextType => {
     throw new Error('useTheme must be used within a ThemeProvider');
   }
   return context;
-}; 
+};

--- a/src/lib/theme/colors.ts
+++ b/src/lib/theme/colors.ts
@@ -1,0 +1,39 @@
+/**
+ * Person/Space color palette from the design handoff (issue #39).
+ * Source: docs/design_handoff_aido_redesign/README.md → "Personen-/Space-Farben".
+ *
+ * Spaces store a color in the data model as an oklch hue (see issue #40,
+ * `Space.color (oklch-Hue)`); new spaces cycle through this palette.
+ */
+
+export interface SpaceColor {
+  /** oklch hue angle — the canonical value stored on a Space. */
+  hue: number;
+  /** Ready-to-use oklch() color string (lightness/chroma from the handoff). */
+  value: string;
+  /** Human-readable label from the handoff. */
+  label: string;
+}
+
+export const SPACE_COLORS: readonly SpaceColor[] = [
+  { hue: 200, value: "oklch(0.72 0.15 200)", label: "Teal" },
+  { hue: 40, value: "oklch(0.72 0.15 40)", label: "Koralle" },
+  { hue: 300, value: "oklch(0.65 0.14 300)", label: "Violett" },
+  { hue: 160, value: "oklch(0.7 0.13 160)", label: "Grün" },
+];
+
+/** Pick a palette entry by index, wrapping around (e.g. for the Nth new space). */
+export function getSpaceColor(index: number): SpaceColor {
+  const len = SPACE_COLORS.length;
+  return SPACE_COLORS[((index % len) + len) % len];
+}
+
+/**
+ * Build an oklch color string from a stored hue. Uses the palette's exact
+ * lightness/chroma when the hue is a known palette entry, otherwise falls back
+ * to the default lightness/chroma.
+ */
+export function spaceColorFromHue(hue: number): string {
+  const known = SPACE_COLORS.find((c) => c.hue === hue);
+  return known ? known.value : `oklch(0.72 0.15 ${hue})`;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,54 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      // Redesign design tokens (issue #39). Map onto the CSS variables defined
+      // in src/app/globals.css so utilities like `bg-bg-card`, `text-text-dim`,
+      // `border-border`, `bg-accent-soft`, `text-accent-text` follow the active theme.
+      colors: {
+        bg: {
+          DEFAULT: "var(--bg)",
+          side: "var(--bg-side)",
+          card: "var(--bg-card)",
+          pop: "var(--bg-pop)",
+        },
+        "row-hover": "var(--row-hover)",
+        border: "var(--border)",
+        text: {
+          DEFAULT: "var(--text)",
+          dim: "var(--text-dim)",
+        },
+        "check-border": "var(--check-border)",
+        accent: {
+          DEFAULT: "var(--accent)",
+          soft: "var(--accent-soft)",
+          text: "var(--accent-text)",
+        },
+        mention: {
+          DEFAULT: "var(--mention)",
+          bg: "var(--mention-bg)",
+        },
+        tag: "var(--tag)",
+        wait: {
+          text: "var(--wait-text)",
+          bg: "var(--wait-bg)",
+        },
+        danger: "var(--danger)",
+        "nav-bg": "var(--nav-bg)",
+      },
+      fontFamily: {
+        // Nunito for UI, JetBrains Mono for #tags and numbers (issue #39).
+        sans: ["var(--font-nunito)", "ui-sans-serif", "system-ui", "sans-serif"],
+        mono: [
+          "var(--font-jetbrains-mono)",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "monospace",
+        ],
+      },
+      boxShadow: {
+        soft: "var(--shadow)",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",


### PR DESCRIPTION
Setzt **#39** um — das Fundament für das aido-Redesign (Teil von #38).

## Was
- **Design-Tokens (oklch):** komplette Token-Tabelle aus dem Handoff in `globals.css`. Dark als Default (`:root`), Light als `html[data-theme="light"]`-Override.
- **Tailwind-Utilities:** Tokens als Utilities gemappt (`bg-bg-card`, `text-text-dim`, `border-border`, `bg-accent-soft`, `text-accent-text`, …) plus `shadow-soft`.
- **Fonts:** Nunito (UI, 400/600/700/800/900) und JetBrains Mono (#Tags/Zahlen, 400/600) via `next/font`, als CSS-Variablen + in `tailwind.fontFamily`.
- **ThemeContext:** schaltet jetzt `data-theme` **und** die bestehende `.dark`-Klasse synchron → bestehende `dark:`-Varianten laufen während der Migration weiter. Persistenz unter `localStorage['aidoF-theme']` (migriert vom alten `theme`-Key) und Hydration beim Mount. `/login` bleibt forced-dark.
- **Space-Farbpalette:** wiederverwendbare Konstante `src/lib/theme/colors.ts` (Teal/Koralle/Violett/Grün, zyklisch für neue Spaces).

## Kompatibilität / Migration
Bewusst **nicht brechend**: alte Screens nutzen weiterhin Tailwind `dark:`-Varianten (über die weiterhin gesetzte `.dark`-Klasse) und ihre eigenen Hintergründe. Neue Redesign-Komponenten konsumieren die Tokens via `data-theme`. Beide bleiben durch den ThemeContext synchron.

## Verifikation
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (nur vorbestehende Warnungen: `<img>`, `exhaustive-deps` in TodoList)
- `npm run build` ✅ (next/font lädt Nunito + JetBrains Mono, alle 13 Routen generiert)

Visuelle Abnahme gegen Screenshots `01`/`03` erfolgt mit den Shell-/Feature-Issues, da es noch keine Redesign-Oberfläche gibt.

## Hinweis
`src/globals.css` ist eine **verwaiste, nicht importierte** Datei mit alten Theme-Variablen (importiert wird `src/app/globals.css`). Kein Laufzeiteffekt — vorgemerkt fürs Cleanup-Issue **#49**, hier bewusst nicht angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
