### PR TITLE
feat(todos): space-scoped Todo + Daily model, rules & tests (#41)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -57,6 +57,18 @@ service cloud.firestore {
             && request.resource.data.color is number;
       }
 
+      // Membership of THIS space, looked up from the space doc — used by the
+      // nested todos/daily collections (where `resource` is the child, not the
+      // space). get()/exists() results are cached within a request.
+      function thisSpaceMembers() {
+        return get(/databases/$(database)/documents/spaces/$(spaceId)).data.members;
+      }
+      function isMemberOfThisSpace() {
+        return isAuthenticated()
+            && exists(/databases/$(database)/documents/spaces/$(spaceId))
+            && request.auth.uid in thisSpaceMembers();
+      }
+
       allow read: if isExistingMember();
 
       allow create: if isAuthenticated()
@@ -71,6 +83,47 @@ service cloud.firestore {
 
       allow delete: if isAuthenticated()
         && resource.data.createdBy == request.auth.uid;
+
+      // Todos belong to the space (issue #41): moved out of users/{uid}/todos so
+      // every space member can read AND write — full collaboration replaces the
+      // old "a sharee may only toggle completed" model. tags/mentions must be
+      // lists; createdBy is immutable; waitingOn must be null or a current member.
+      match /todos/{todoId} {
+        function hasValidTodoLists() {
+          return (!('tags' in request.resource.data) || request.resource.data.tags is list)
+              && (!('mentions' in request.resource.data) || request.resource.data.mentions is list);
+        }
+        function hasValidWaitingOn() {
+          return !('waitingOn' in request.resource.data)
+              || request.resource.data.waitingOn == null
+              || (request.resource.data.waitingOn is string
+                  && request.resource.data.waitingOn in thisSpaceMembers());
+        }
+
+        allow read: if isMemberOfThisSpace();
+        allow create: if isMemberOfThisSpace()
+          && request.resource.data.createdBy == request.auth.uid
+          && hasValidTodoLists()
+          && hasValidWaitingOn();
+        allow update: if isMemberOfThisSpace()
+          && request.resource.data.createdBy == resource.data.createdBy
+          && hasValidTodoLists()
+          && hasValidWaitingOn();
+        allow delete: if isMemberOfThisSpace();
+      }
+
+      // Daily "Heute" items (issue #41): short-lived, space-scoped, kept separate
+      // from todos. Any member may read/write; author is immutable.
+      match /daily/{dailyId} {
+        allow read: if isMemberOfThisSpace();
+        allow create: if isMemberOfThisSpace()
+          && request.resource.data.author == request.auth.uid
+          && request.resource.data.text is string
+          && request.resource.data.date is string;
+        allow update: if isMemberOfThisSpace()
+          && request.resource.data.author == resource.data.author;
+        allow delete: if isMemberOfThisSpace();
+      }
     }
 
     // Rules for specific user documents and their subcollections

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -21,9 +21,12 @@ import {
   orderBy,
   arrayUnion,
   arrayRemove,
+  type QueryDocumentSnapshot,
+  type DocumentData,
 } from "firebase/firestore";
 import { getSpaceColor } from "../theme/colors";
-import type { Space } from "../types";
+import { deriveTags, deriveMentions } from "../utils/textUtils";
+import type { Space, Todo, Daily, TiptapContent } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
 
@@ -120,6 +123,164 @@ export const removeSpaceMember = (spaceId: string, uid: string) =>
 // Only the creator may delete (enforced by firestore.rules).
 export const deleteSpace = (spaceId: string) =>
   deleteDoc(doc(db, SPACES_COLLECTION, spaceId));
+
+// --- Todos (space-scoped, issue #41) ---
+// Decision: todos live under spaces/{spaceId}/todos (moved out of
+// users/{uid}/todos) so every space member has full read/write access — see
+// firestore.rules. tags/mentions are derived from title/body on every write.
+
+const todosCol = (spaceId: string) =>
+  collection(db, SPACES_COLLECTION, spaceId, "todos");
+const todoRef = (spaceId: string, todoId: string) =>
+  doc(db, SPACES_COLLECTION, spaceId, "todos", todoId);
+
+const mapTodo = (d: QueryDocumentSnapshot<DocumentData>): Todo => {
+  const data = d.data();
+  return {
+    id: d.id,
+    spaceId: typeof data.spaceId === "string" ? data.spaceId : "",
+    title: typeof data.title === "string" ? data.title : "",
+    body: (data.body as TiptapContent | null) ?? null,
+    completed: data.completed === true,
+    waitingOn: typeof data.waitingOn === "string" ? data.waitingOn : null,
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    mentions: Array.isArray(data.mentions) ? data.mentions : [],
+    createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
+    createdAt: data.createdAt ?? null,
+    order: typeof data.order === "number" ? data.order : 0,
+  };
+};
+
+export const createTodo = async (
+  spaceId: string,
+  uid: string,
+  input: {
+    title: string;
+    body?: TiptapContent | null;
+    waitingOn?: string | null;
+    order?: number;
+  }
+): Promise<string> => {
+  if (!spaceId || !uid) throw new Error("Missing space or user.");
+  const body = input.body ?? null;
+  const ref = await addDoc(todosCol(spaceId), {
+    spaceId,
+    title: input.title.trim(),
+    body,
+    completed: false,
+    waitingOn: input.waitingOn ?? null,
+    tags: deriveTags(input.title, body),
+    mentions: deriveMentions(body),
+    createdBy: uid,
+    createdAt: serverTimestamp(),
+    order: input.order ?? 0,
+  });
+  return ref.id;
+};
+
+export const getTodosForSpace = async (spaceId: string): Promise<Todo[]> => {
+  if (!spaceId) return [];
+  const snapshot = await getDocs(query(todosCol(spaceId), orderBy("order", "asc")));
+  return snapshot.docs.map(mapTodo);
+};
+
+// Edit title/body together and re-derive tags/mentions from the new content.
+export const editTodoContent = (
+  spaceId: string,
+  todoId: string,
+  title: string,
+  body: TiptapContent | null
+) =>
+  updateDoc(todoRef(spaceId, todoId), {
+    title: title.trim(),
+    body,
+    tags: deriveTags(title, body),
+    mentions: deriveMentions(body),
+  });
+
+export const setTodoCompleted = (spaceId: string, todoId: string, completed: boolean) =>
+  updateDoc(todoRef(spaceId, todoId), { completed });
+
+export const setTodoWaitingOn = (
+  spaceId: string,
+  todoId: string,
+  waitingOn: string | null
+) => updateDoc(todoRef(spaceId, todoId), { waitingOn });
+
+export const setTodoOrder = (spaceId: string, todoId: string, order: number) =>
+  updateDoc(todoRef(spaceId, todoId), { order });
+
+export const deleteTodo = (spaceId: string, todoId: string) =>
+  deleteDoc(todoRef(spaceId, todoId));
+
+// --- Daily "Heute" items (space-scoped, issue #41) ---
+// Short-lived items, deliberately separate from todos (never appear in the list).
+
+const dailyCol = (spaceId: string) =>
+  collection(db, SPACES_COLLECTION, spaceId, "daily");
+const dailyRef = (spaceId: string, dailyId: string) =>
+  doc(db, SPACES_COLLECTION, spaceId, "daily", dailyId);
+
+// Local date as YYYY-MM-DD (lexicographically comparable for "older than today").
+export const todayString = (): string => {
+  const d = new Date();
+  const month = `${d.getMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getDate()}`.padStart(2, "0");
+  return `${d.getFullYear()}-${month}-${day}`;
+};
+
+const mapDaily = (d: QueryDocumentSnapshot<DocumentData>): Daily => {
+  const data = d.data();
+  return {
+    id: d.id,
+    spaceId: typeof data.spaceId === "string" ? data.spaceId : "",
+    text: typeof data.text === "string" ? data.text : "",
+    completed: data.completed === true,
+    date: typeof data.date === "string" ? data.date : "",
+    author: typeof data.author === "string" ? data.author : "",
+    createdAt: data.createdAt ?? null,
+  };
+};
+
+export const createDaily = async (
+  spaceId: string,
+  uid: string,
+  text: string,
+  date: string = todayString()
+): Promise<string> => {
+  if (!spaceId || !uid) throw new Error("Missing space or user.");
+  const ref = await addDoc(dailyCol(spaceId), {
+    spaceId,
+    text: text.trim(),
+    completed: false,
+    date,
+    author: uid,
+    createdAt: serverTimestamp(),
+  });
+  return ref.id;
+};
+
+// Open (not completed) daily items. Single-field filter → no composite index;
+// callers split into today's vs. "liegengeblieben" (date < today) client-side.
+export const getOpenDailyForSpace = async (spaceId: string): Promise<Daily[]> => {
+  if (!spaceId) return [];
+  const snapshot = await getDocs(
+    query(dailyCol(spaceId), where("completed", "==", false))
+  );
+  return snapshot.docs
+    .map(mapDaily)
+    .sort((a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0));
+};
+
+// "Liegengeblieben": an open daily item from before today.
+export const isStaleDaily = (d: Daily, today: string = todayString()): boolean =>
+  !d.completed && !!d.date && d.date < today;
+
+export const setDailyCompleted = (spaceId: string, dailyId: string, completed: boolean) =>
+  updateDoc(dailyRef(spaceId, dailyId), { completed });
+
+export const deleteDaily = (spaceId: string, dailyId: string) =>
+  deleteDoc(dailyRef(spaceId, dailyId));
 
 // Helper function to generate a SHA-256 hash string from an email
 export const generateIdFromEmail = async (email: string): Promise<string> => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,3 +19,48 @@ export interface Space {
   /** Server timestamp; null while a serverTimestamp() write is still pending. */
   createdAt: Timestamp | null;
 }
+
+/** Tiptap rich-text JSON (ProseMirror document). Loosely typed to avoid pulling
+ *  a hard @tiptap dependency into this shared types module. */
+export type TiptapContent = Record<string, unknown>;
+
+/**
+ * Todo — structured task in a space (issue #41). Lives under
+ * `spaces/{spaceId}/todos/{id}` (moved out of users/{uid}/todos so every space
+ * member has full access). `tags`/`mentions` are derived from title/body on write.
+ */
+export interface Todo {
+  id: string;
+  /** Redundant with the path, kept for convenience/denormalization. */
+  spaceId: string;
+  title: string;
+  /** Rich-text body as Tiptap JSON (the original TipTap use case). */
+  body: TiptapContent | null;
+  completed: boolean;
+  /** userId this todo is waiting on, or null. Drives the board "bei X" columns. */
+  waitingOn: string | null;
+  tags: string[];
+  mentions: string[];
+  /** Author; immutable after creation. */
+  createdBy: string;
+  createdAt: Timestamp | null;
+  /** Manual sort order (board drag & drop / list ordering). */
+  order: number;
+}
+
+/**
+ * Daily — short-lived "Heute" item (issue #41). Lives under
+ * `spaces/{spaceId}/daily/{id}`, deliberately separate from todos so it never
+ * appears in the main list.
+ */
+export interface Daily {
+  id: string;
+  spaceId: string;
+  text: string;
+  completed: boolean;
+  /** Local date as YYYY-MM-DD (lexicographically comparable). */
+  date: string;
+  /** userId of the author; immutable after creation. */
+  author: string;
+  createdAt: Timestamp | null;
+}

--- a/src/lib/utils/textUtils.ts
+++ b/src/lib/utils/textUtils.ts
@@ -44,4 +44,37 @@ export function extractMentionIds(node: any): string[] {
   }
   // Remove duplicates
   return [...new Set(ids)];
-} 
+}
+
+/**
+ * Recursively collects all `text` content from a Tiptap JSON node into a
+ * single string (used to scan a rich-text body for #hashtags).
+ */
+export function extractPlainText(node: any): string {
+  if (!node) return '';
+  let text = typeof node.text === 'string' ? node.text : '';
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      text += ' ' + extractPlainText(child);
+    }
+  }
+  return text;
+}
+
+/**
+ * Derives the unique #tags of a todo from its title and (Tiptap) body.
+ * Reuses extractHashtags so the redesign keeps the existing tag semantics.
+ */
+export function deriveTags(title: string, body?: any): string[] {
+  return [
+    ...new Set([
+      ...extractHashtags(title || ''),
+      ...extractHashtags(extractPlainText(body)),
+    ]),
+  ];
+}
+
+/** Derives the unique @mention UIDs of a todo from its (Tiptap) body. */
+export function deriveMentions(body?: any): string[] {
+  return extractMentionIds(body);
+}

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -241,6 +241,94 @@ await check('non-member may not delete the space', assertFails(
 await check('creator may delete the space', assertSucceeds(
   deleteDoc(doc(db(ALICE), SPACE_PATH))));
 
+console.log('Space todos & daily (issue #41):');
+const TS = 'space-todos';
+const TODO2_PATH = `spaces/${TS}/todos/t1`;
+const DAILY_PATH = `spaces/${TS}/daily/d1`;
+async function resetSpaceTodos() {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `spaces/${TS}`), {
+      name: 'S', color: 40, members: [ALICE, BOB], createdBy: ALICE, createdAt: 1 });
+    await setDoc(doc(ctx.firestore(), TODO2_PATH), {
+      spaceId: TS, title: 't', body: null, completed: false, waitingOn: null,
+      tags: [], mentions: [], createdBy: ALICE, createdAt: 1, order: 0 });
+    await setDoc(doc(ctx.firestore(), DAILY_PATH), {
+      spaceId: TS, text: 'milk', completed: false, date: '2020-01-01', author: ALICE, createdAt: 1 });
+  });
+}
+await resetSpaceTodos();
+
+console.log('  todo reads:');
+await check('space member may read a space todo', assertSucceeds(
+  getDoc(doc(db(BOB), TODO2_PATH))));
+await check('non-member may not read a space todo', assertFails(
+  getDoc(doc(db(MALLORY), TODO2_PATH))));
+await check('member may list space todos', assertSucceeds(
+  getDocs(collection(db(BOB), `spaces/${TS}/todos`))));
+await check('non-member may not list space todos', assertFails(
+  getDocs(collection(db(MALLORY), `spaces/${TS}/todos`))));
+
+console.log('  todo writes (full collaboration):');
+await check('member (non-creator) may create a todo', assertSucceeds(
+  setDoc(doc(db(BOB), `spaces/${TS}/todos/t2`), {
+    spaceId: TS, title: 'b', body: null, completed: false, waitingOn: null,
+    tags: [], mentions: [], createdBy: BOB, createdAt: 1, order: 1 })));
+await check('member may not create a todo authored by someone else', assertFails(
+  setDoc(doc(db(BOB), `spaces/${TS}/todos/t3`), {
+    spaceId: TS, title: 'x', completed: false, waitingOn: null,
+    tags: [], mentions: [], createdBy: ALICE, createdAt: 1, order: 1 })));
+await check('non-member may not create a todo', assertFails(
+  setDoc(doc(db(MALLORY), `spaces/${TS}/todos/t4`), {
+    spaceId: TS, title: 'x', completed: false, waitingOn: null,
+    tags: [], mentions: [], createdBy: MALLORY, createdAt: 1, order: 1 })));
+await check('member may not create a todo with non-list tags', assertFails(
+  setDoc(doc(db(ALICE), `spaces/${TS}/todos/t5`), {
+    spaceId: TS, title: 'x', completed: false, waitingOn: null,
+    tags: 'a', mentions: [], createdBy: ALICE, createdAt: 1, order: 1 })));
+await check('member (non-creator) may edit a todo (content + completed)', assertSucceeds(
+  updateDoc(doc(db(BOB), TODO2_PATH), { title: 'edited', completed: true })));
+await check('member may not change a todo createdBy (takeover)', assertFails(
+  updateDoc(doc(db(BOB), TODO2_PATH), { createdBy: BOB })));
+await check('non-member may not update a todo', assertFails(
+  updateDoc(doc(db(MALLORY), TODO2_PATH), { completed: true })));
+
+console.log('  waitingOn validation:');
+await check('member may set waitingOn to a space member', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { waitingOn: BOB })));
+await check('member may clear waitingOn (null)', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { waitingOn: null })));
+await check('member may not set waitingOn to a non-member', assertFails(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { waitingOn: MALLORY })));
+
+console.log('  todo delete:');
+await check('non-member may not delete a todo', assertFails(
+  deleteDoc(doc(db(MALLORY), TODO2_PATH))));
+await check('member may delete a todo', assertSucceeds(
+  deleteDoc(doc(db(BOB), TODO2_PATH))));
+
+console.log('  daily:');
+await check('member may read a daily item', assertSucceeds(
+  getDoc(doc(db(BOB), DAILY_PATH))));
+await check('non-member may not read a daily item', assertFails(
+  getDoc(doc(db(MALLORY), DAILY_PATH))));
+await check('member may create own daily item', assertSucceeds(
+  setDoc(doc(db(BOB), `spaces/${TS}/daily/d2`), {
+    spaceId: TS, text: 'x', completed: false, date: '2020-01-02', author: BOB, createdAt: 1 })));
+await check('member may not create a daily item authored by someone else', assertFails(
+  setDoc(doc(db(BOB), `spaces/${TS}/daily/d3`), {
+    spaceId: TS, text: 'x', completed: false, date: '2020-01-02', author: ALICE, createdAt: 1 })));
+await check('non-member may not create a daily item', assertFails(
+  setDoc(doc(db(MALLORY), `spaces/${TS}/daily/d4`), {
+    spaceId: TS, text: 'x', completed: false, date: '2020-01-02', author: MALLORY, createdAt: 1 })));
+await check('member (non-author) may toggle daily completed', assertSucceeds(
+  updateDoc(doc(db(BOB), DAILY_PATH), { completed: true })));
+await check('member may not change a daily author', assertFails(
+  updateDoc(doc(db(BOB), DAILY_PATH), { author: BOB })));
+await check('non-member may not delete a daily item', assertFails(
+  deleteDoc(doc(db(MALLORY), `spaces/${TS}/daily/d2`))));
+await check('member may delete a daily item', assertSucceeds(
+  deleteDoc(doc(db(ALICE), DAILY_PATH))));
+
 await testEnv.cleanup();
 
 if (failures > 0) {


### PR DESCRIPTION
Setzt **#41** um — Todos auf Spaces umgestellt + neue Daily-Collection, inkl. Rules & Tests (Teil von #38).

> ⚠️ **Gestapelt auf #40** (PR #51). Base ist `feature/40-spaces-data-model`. **Merge-Reihenfolge: #50 → #51 → dieser PR.**

## Architektur-Entscheidung (offene Frage aus dem Issue)
Todos ziehen von `users/{uid}/todos` **um nach `spaces/{spaceId}/todos`** (+ neue `spaces/{spaceId}/daily`). Grund: echte Space-Kollaboration — **jedes Mitglied liest *und* schreibt** alles im Space. Das ersetzt das alte „Sharee darf nur `completed` togglen"-Modell. Die Mitgliedschaft wird in den Rules per `get()` auf das Parent-Space-Dokument geprüft (Ergebnisse sind pro Request gecached).

Die alten `users/{uid}/todos`-Rules bleiben vorerst bestehen (alte App nutzt sie noch); Datenmigration → #48, Entfernen der Altpfade/-Rules → #49.

## Datenmodell (`src/lib/types.ts`)
```
Todo  { spaceId, title, body (Tiptap JSON), completed, waitingOn: userId|null,
        tags[], mentions[], createdBy, createdAt, order }
Daily { spaceId, text, completed, date: 'YYYY-MM-DD', author, createdAt }
```

## Helper
- **textUtils:** `extractPlainText`, `deriveTags(title, body)`, `deriveMentions(body)` — `tags`/`mentions` werden bei jedem Schreibvorgang aus Titel/Body abgeleitet (wiederverwendet `extractHashtags`/`extractMentionIds`).
- **firebaseUtils Todos:** `createTodo`, `getTodosForSpace`, `editTodoContent` (re-derived tags/mentions), `setTodoCompleted`, `setTodoWaitingOn`, `setTodoOrder`, `deleteTodo`.
- **firebaseUtils Daily:** `createDaily`, `getOpenDailyForSpace`, `isStaleDaily`, `setDailyCompleted`, `deleteDaily`, `todayString`.

## Rules
- `todos`/`daily` verschachtelt unter `spaces/{spaceId}`; Zugriff = Space-Mitgliedschaft (`get()` aufs Space-Doc).
- Volle Mitglieder-Lese/Schreibrechte; `createdBy` (Todo) bzw. `author` (Daily) **unveränderlich**.
- `tags`/`mentions` als `list` validiert; `waitingOn` muss `null` **oder ein aktuelles Space-Mitglied** sein.

## Verifikation
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (nur vorbestehende Warnungen)
- `npm run build` ✅
- `npm run test:rules` (via `firebase-tools@13`, Java 11) ✅ — **All rules tests passed** (Firestore + Storage), inkl. 28 neuer Todo/Daily-Assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
