### PR TITLE
feat(shell): desktop app shell — sidebar, space header, view toggle (#42)

### DIFF
--- a/src/app/(protected)/todos/page.tsx
+++ b/src/app/(protected)/todos/page.tsx
@@ -1,40 +1,12 @@
 'use client';
 
-// Remove useEffect and useRouter imports if not needed elsewhere
-// import { useEffect } from 'react';
-import { useAuth } from '@/lib/hooks/useAuth';
-import TodoList from '@/components/TodoList';
-// import { useRouter } from 'next/navigation';
+import AppShell from '@/components/shell/AppShell';
 
-export default function Home() {
-  // Auth state is now handled by ProtectedLayout
-  // const { user, loading } = useAuth(); 
-  // const router = useRouter();
-
-  // Remove the redirection useEffect
-  /*
-  useEffect(() => {
-    if (!loading && !user) {
-      router.push('/login');
-    }
-  }, [user, loading, router]);
-  */
-
-  // Remove the loading/redirect check, ProtectedLayout handles this
-  /*
-  if (loading || !user) {
-    return (
-      <div className="min-h-screen flex ...">Loading...</div>
-    );
-  }
-  */
-
-  // This component now assumes user is authenticated because of ProtectedLayout
-  return (
-    <main className="flex-1 p-4">
-      <div className="max-w-4xl mx-auto">
-        <TodoList />
-      </div>
-    </main>
-  );
-} 
+/**
+ * Redesigned workspace (issue #42). Auth is handled by ProtectedLayout; the old
+ * Navbar is hidden on this route (see MainLayoutClientWrapper) because the shell
+ * provides its own chrome. Routing unification across the app is issue #49.
+ */
+export default function TodosPage() {
+  return <AppShell />;
+}

--- a/src/components/MainLayoutClientWrapper.tsx
+++ b/src/components/MainLayoutClientWrapper.tsx
@@ -13,8 +13,11 @@ export default function MainLayoutClientWrapper({ children }: { children: React.
   const { user, loading } = useAuth();
   const pathname = usePathname();
 
-  // Paths where the Navbar should explicitly NOT be shown, regardless of auth state
-  const noNavPaths = ['/login', '/signin', '/signup']; // Add any other paths as needed
+  // Paths where the Navbar should explicitly NOT be shown, regardless of auth state.
+  // '/todos' is the redesigned workspace (issue #42) — it ships its own shell
+  // chrome (sidebar + space header), so the legacy Navbar is suppressed there.
+  // Full routing unification is issue #49.
+  const noNavPaths = ['/login', '/signin', '/signup', '/todos'];
 
   // Determine if the Navbar should be shown:
   // 1. Auth loading must be finished.

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+import { SpacesProvider } from "@/lib/contexts/SpacesContext";
+import DesktopShell from "./DesktopShell";
+
+/**
+ * Entry point for the redesigned workspace (issue #42). Provides the spaces
+ * state and renders the desktop shell. The responsive mobile shell is added in
+ * issue #43 (a layout switch will choose desktop vs. mobile here).
+ */
+export default function AppShell() {
+  return (
+    <SpacesProvider>
+      <DesktopShell />
+    </SpacesProvider>
+  );
+}

--- a/src/components/shell/Avatar.tsx
+++ b/src/components/shell/Avatar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+import { personColor } from "@/lib/theme/colors";
+
+/** Up to two uppercase initials from a display name ("Martin Videc" → "MV"). */
+export function initials(name?: string | null): string {
+  if (!name) return "?";
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+interface AvatarProps {
+  uid: string;
+  name?: string | null;
+  /** Pixel diameter (default 28). */
+  size?: number;
+  /** Draw a 2px ring in the page background (used for overlapping member stacks). */
+  ring?: boolean;
+  className?: string;
+}
+
+/**
+ * Circular avatar: initials on a deterministic person color (handoff: avatars
+ * are initials on a person color, not photos).
+ */
+export default function Avatar({ uid, name, size = 28, ring = false, className = "" }: AvatarProps) {
+  return (
+    <div
+      className={`flex shrink-0 items-center justify-center rounded-full font-bold text-white ${className}`}
+      style={{
+        width: size,
+        height: size,
+        fontSize: Math.round(size * 0.4),
+        backgroundColor: personColor(uid),
+        ...(ring ? { boxShadow: "0 0 0 2px var(--bg)" } : {}),
+      }}
+      title={name ?? undefined}
+    >
+      {initials(name)}
+    </div>
+  );
+}

--- a/src/components/shell/DesktopShell.tsx
+++ b/src/components/shell/DesktopShell.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import Sidebar from "./Sidebar";
+import SpaceHeader from "./SpaceHeader";
+import WorkspaceContent from "./WorkspaceContent";
+
+/**
+ * Desktop two-column layout (issue #42): fixed sidebar + scrolling main column.
+ * The main column width follows the active view (780px list / 1140px board).
+ */
+export default function DesktopShell() {
+  const { activeSpace, loading, view } = useSpaces();
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-bg text-text">
+      <Sidebar />
+
+      <main className="flex-1 overflow-y-auto">
+        <div
+          className="mx-auto flex flex-col gap-[18px]"
+          style={{ maxWidth: view === "board" ? 1140 : 780, padding: "30px 36px 90px" }}
+        >
+          {loading ? (
+            <div className="pt-20 text-center text-sm text-text-dim">Lädt …</div>
+          ) : activeSpace ? (
+            <>
+              <SpaceHeader />
+              <WorkspaceContent />
+            </>
+          ) : (
+            <div className="pt-20 text-center">
+              <p className="text-lg font-extrabold">Noch keine Spaces</p>
+              <p className="mt-1 text-sm text-text-dim">
+                Leg über „+ Neuer Space“ deinen ersten Space an.
+              </p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/shell/SegmentedControl.tsx
+++ b/src/components/shell/SegmentedControl.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+import { useSpaces, type SpaceView } from "@/lib/contexts/SpacesContext";
+
+const TABS: { id: SpaceView; label: string }[] = [
+  { id: "liste", label: "Liste" },
+  { id: "board", label: "Board" },
+];
+
+/**
+ * Liste | Board segmented control (issue #42). Active tab inverts to
+ * bg=var(--text)/color=var(--bg); the track sits on bg-card with a border.
+ */
+export default function SegmentedControl() {
+  const { view, setView } = useSpaces();
+
+  return (
+    <div className="flex shrink-0 gap-1 rounded-full border border-border bg-bg-card p-[3px]">
+      {TABS.map((tab) => {
+        const active = view === tab.id;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setView(tab.id)}
+            className="rounded-full px-4 py-1 text-sm font-extrabold transition-colors"
+            style={
+              active
+                ? { backgroundColor: "var(--text)", color: "var(--bg)" }
+                : { color: "var(--text-dim)" }
+            }
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import Avatar from "./Avatar";
+import ThemeToggle from "./ThemeToggle";
+
+/** aido logo: rounded accent square with two white "robot eyes". */
+function Logo() {
+  return (
+    <div
+      className="flex items-center justify-center gap-[3px]"
+      style={{ width: 28, height: 28, borderRadius: 9, backgroundColor: "var(--accent)" }}
+      aria-hidden
+    >
+      <span className="block rounded-full bg-white" style={{ width: 5, height: 5 }} />
+      <span className="block rounded-full bg-white" style={{ width: 5, height: 5 }} />
+    </div>
+  );
+}
+
+export default function Sidebar() {
+  const { user } = useAuth();
+  const { spaces, activeSpaceId, openCounts, setActiveSpace } = useSpaces();
+
+  return (
+    <aside
+      className="flex shrink-0 flex-col gap-1 border-r border-border bg-bg-side"
+      style={{ width: 256, padding: "22px 14px 18px" }}
+    >
+      {/* Brand + theme toggle */}
+      <div className="flex items-center gap-2 px-1">
+        <Logo />
+        <span className="text-[17px] font-black tracking-tight">aido</span>
+        <div className="ml-auto">
+          <ThemeToggle />
+        </div>
+      </div>
+
+      {/* Spaces section */}
+      <div
+        className="mt-5 px-3 text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim"
+      >
+        Spaces
+      </div>
+
+      <nav className="flex flex-col gap-1">
+        {spaces.map((space) => {
+          const active = space.id === activeSpaceId;
+          const count = openCounts[space.id];
+          return (
+            <button
+              key={space.id}
+              type="button"
+              onClick={() => setActiveSpace(space.id)}
+              className={`flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm transition-colors hover:bg-row-hover ${
+                active ? "bg-row-hover font-extrabold" : "font-semibold"
+              }`}
+            >
+              <span
+                className="shrink-0"
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: 4,
+                  backgroundColor: spaceColorFromHue(space.color),
+                }}
+              />
+              <span className="flex-1 truncate">{space.name}</span>
+              {typeof count === "number" && count > 0 && (
+                <span className="text-xs text-text-dim">{count}</span>
+              )}
+            </button>
+          );
+        })}
+
+        {/* "+ Neuer Space" — interactive creation lives in the spaces-management
+            issue (#47); here it is only the placeholder row. */}
+        <button
+          type="button"
+          disabled
+          className="flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-text-dim"
+        >
+          + Neuer Space
+        </button>
+      </nav>
+
+      {/* Footer: current user + settings */}
+      <div className="mt-auto flex items-center gap-2 border-t border-border pt-3">
+        <Avatar uid={user?.uid ?? "me"} name={user?.displayName} size={28} />
+        <span className="flex-1 truncate text-sm font-semibold">
+          {user?.displayName ?? "Account"}
+        </span>
+        <Link href="/settings" className="text-sm text-text-dim hover:text-text">
+          Settings
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/shell/SpaceHeader.tsx
+++ b/src/components/shell/SpaceHeader.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { getPublicProfile, type PublicProfile } from "@/lib/firebase/firebaseUtils";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import Avatar from "./Avatar";
+import SegmentedControl from "./SegmentedControl";
+
+/** Loads public profiles for a list of member uids (for avatar initials). */
+function useMemberProfiles(memberUids: string[]): Record<string, PublicProfile> {
+  const [profiles, setProfiles] = useState<Record<string, PublicProfile>>({});
+  const key = memberUids.join(",");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        memberUids.map(async (uid) => {
+          try {
+            return [uid, await getPublicProfile(uid)] as const;
+          } catch {
+            return [uid, null] as const;
+          }
+        })
+      );
+      if (cancelled) return;
+      const next: Record<string, PublicProfile> = {};
+      for (const [uid, profile] of entries) {
+        if (profile) next[uid] = profile;
+      }
+      setProfiles(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // key is the stable dependency derived from memberUids
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return profiles;
+}
+
+export default function SpaceHeader() {
+  const { activeSpace } = useSpaces();
+  const members = activeSpace?.members ?? [];
+  const profiles = useMemberProfiles(members);
+
+  if (!activeSpace) return null;
+
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className="shrink-0"
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: 5,
+          backgroundColor: spaceColorFromHue(activeSpace.color),
+        }}
+      />
+      <h1 className="text-2xl font-black">{activeSpace.name}</h1>
+
+      {/* Overlapping member avatars */}
+      <div className="flex items-center pl-2">
+        {members.map((uid, i) => (
+          <div key={uid} style={{ marginLeft: i === 0 ? 0 : -8 }}>
+            <Avatar uid={uid} name={profiles[uid]?.displayName} size={28} ring />
+          </div>
+        ))}
+      </div>
+
+      {/* "+ einladen" — invite popover lives in the spaces-management issue (#47). */}
+      <button
+        type="button"
+        disabled
+        className="rounded-full border border-dashed border-border px-3 py-1 text-sm text-text-dim"
+      >
+        + einladen
+      </button>
+
+      <div className="ml-auto">
+        <SegmentedControl />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/ThemeToggle.tsx
+++ b/src/components/shell/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "@/lib/contexts/ThemeContext";
+
+interface ThemeToggleProps {
+  /** Pill width (default 38, the desktop size; mobile uses 42 — issue #43). */
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Light/Dark pill toggle (issue #39/#42). The knob slides (margin-left 0.2s per
+ * the handoff). Sets an explicit 'light'/'dark' preference via ThemeContext.
+ */
+export default function ThemeToggle({ width = 38, height = 21 }: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+  const knob = height - 4;
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isDark}
+      aria-label="Theme umschalten"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="relative shrink-0 rounded-full"
+      style={{ width, height, backgroundColor: "var(--accent)" }}
+    >
+      <span
+        className="absolute top-1/2 block rounded-full bg-white"
+        style={{
+          width: knob,
+          height: knob,
+          marginLeft: isDark ? width - knob - 2 : 2,
+          transform: "translateY(-50%)",
+          transition: "margin-left 0.2s",
+        }}
+      />
+    </button>
+  );
+}

--- a/src/components/shell/WorkspaceContent.tsx
+++ b/src/components/shell/WorkspaceContent.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+
+/**
+ * Main-column content placeholders for the desktop shell (issue #42).
+ *
+ * The shell renders the Heute container chrome and the Liste/Board frame; the
+ * interactive content is built in the feature issues:
+ *   - Heute  → #44
+ *   - Liste  → #45
+ *   - Board  → #46
+ * These placeholders keep the layout faithful (spacing/containers) while those
+ * land, and are meant to be replaced by the feature components.
+ */
+export default function WorkspaceContent() {
+  const { view } = useSpaces();
+
+  return (
+    <>
+      {/* Heute container (chrome only; chat content → #44) */}
+      <section
+        className="flex flex-col gap-2"
+        style={{
+          background: "var(--accent-soft)",
+          borderRadius: 18,
+          padding: "16px 18px 14px",
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <div
+            className="flex items-center justify-center gap-[3px]"
+            style={{ width: 24, height: 24, borderRadius: 8, backgroundColor: "var(--accent)" }}
+            aria-hidden
+          >
+            <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
+            <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
+          </div>
+          <span className="text-[15px] font-black">Heute</span>
+          <span className="text-sm text-text-dim">
+            Kurzes für zwischendurch — landet nicht in der Liste
+          </span>
+          <span className="ml-auto text-sm text-accent-text">0 offen</span>
+        </div>
+        <p className="text-sm text-text-dim">Noch nichts für heute.</p>
+      </section>
+
+      {/* Todos / Board frame */}
+      <div className="flex flex-col gap-3">
+        <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">
+          {view === "board" ? "Board" : "Todos"}
+        </div>
+        <div
+          className="flex items-center justify-center text-sm text-text-dim"
+          style={{
+            border: "1px dashed var(--border)",
+            borderRadius: 16,
+            minHeight: view === "board" ? 240 : 120,
+          }}
+        >
+          {view === "board" ? "Board folgt." : "Noch keine Todos."}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+} from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { getSpacesForUser, getOpenTodoCount } from "@/lib/firebase/firebaseUtils";
+import type { Space } from "@/lib/types";
+
+export type SpaceView = "liste" | "board";
+
+interface SpacesContextType {
+  spaces: Space[];
+  loading: boolean;
+  activeSpaceId: string | null;
+  activeSpace: Space | null;
+  /** Open-todo counts per spaceId (best-effort; absent until loaded). */
+  openCounts: Record<string, number>;
+  view: SpaceView;
+  setActiveSpace: (id: string) => void;
+  setView: (view: SpaceView) => void;
+  refreshSpaces: () => Promise<void>;
+}
+
+const SpacesContext = createContext<SpacesContextType | undefined>(undefined);
+
+/**
+ * Holds the redesign's top-level workspace state (issue #42): the user's spaces,
+ * the active space, and the list/board view. Feature contexts (Heute/Liste/Board)
+ * key their own filters/drafts off `activeSpaceId`, which resets them on switch.
+ */
+export const SpacesProvider = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
+  const [spaces, setSpaces] = useState<Space[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
+  const [openCounts, setOpenCounts] = useState<Record<string, number>>({});
+  const [view, setView] = useState<SpaceView>("liste");
+
+  const refreshSpaces = useCallback(async () => {
+    if (!user) {
+      setSpaces([]);
+      setActiveSpaceId(null);
+      setOpenCounts({});
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const loaded = await getSpacesForUser(user.uid);
+    setSpaces(loaded);
+    // Keep the current selection if it still exists, else default to the first.
+    setActiveSpaceId((prev) =>
+      prev && loaded.some((s) => s.id === prev) ? prev : loaded[0]?.id ?? null
+    );
+    setLoading(false);
+
+    // Open-todo counts are best-effort: a failure must not break the shell.
+    const counts: Record<string, number> = {};
+    await Promise.all(
+      loaded.map(async (s) => {
+        try {
+          counts[s.id] = await getOpenTodoCount(s.id);
+        } catch {
+          /* ignore per-space count errors */
+        }
+      })
+    );
+    setOpenCounts(counts);
+  }, [user]);
+
+  useEffect(() => {
+    refreshSpaces();
+  }, [refreshSpaces]);
+
+  const activeSpace = spaces.find((s) => s.id === activeSpaceId) ?? null;
+
+  const value: SpacesContextType = {
+    spaces,
+    loading,
+    activeSpaceId,
+    activeSpace,
+    openCounts,
+    view,
+    setActiveSpace: setActiveSpaceId,
+    setView,
+    refreshSpaces,
+  };
+
+  return <SpacesContext.Provider value={value}>{children}</SpacesContext.Provider>;
+};
+
+export const useSpaces = (): SpacesContextType => {
+  const context = useContext(SpacesContext);
+  if (context === undefined) {
+    throw new Error("useSpaces must be used within a SpacesProvider");
+  }
+  return context;
+};

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -21,6 +21,7 @@ import {
   orderBy,
   arrayUnion,
   arrayRemove,
+  getCountFromServer,
   type QueryDocumentSnapshot,
   type DocumentData,
 } from "firebase/firestore";
@@ -182,6 +183,16 @@ export const getTodosForSpace = async (spaceId: string): Promise<Todo[]> => {
   if (!spaceId) return [];
   const snapshot = await getDocs(query(todosCol(spaceId), orderBy("order", "asc")));
   return snapshot.docs.map(mapTodo);
+};
+
+// Server-side count of open (not completed) todos — drives the sidebar/pill
+// "open" badge per space without fetching every todo.
+export const getOpenTodoCount = async (spaceId: string): Promise<number> => {
+  if (!spaceId) return 0;
+  const snapshot = await getCountFromServer(
+    query(todosCol(spaceId), where("completed", "==", false))
+  );
+  return snapshot.data().count;
 };
 
 // Edit title/body together and re-derive tags/mentions from the new content.

--- a/src/lib/theme/colors.ts
+++ b/src/lib/theme/colors.ts
@@ -37,3 +37,16 @@ export function spaceColorFromHue(hue: number): string {
   const known = SPACE_COLORS.find((c) => c.hue === hue);
   return known ? known.value : `oklch(0.72 0.15 ${hue})`;
 }
+
+/**
+ * Deterministic person color: hashes a userId to a stable palette entry so a
+ * given user always gets the same avatar color (handoff: avatars = initials on
+ * a person color).
+ */
+export function personColor(uid: string): string {
+  let hash = 0;
+  for (let i = 0; i < uid.length; i++) {
+    hash = (hash * 31 + uid.charCodeAt(i)) >>> 0;
+  }
+  return getSpaceColor(hash).value;
+}


### PR DESCRIPTION
Setzt **#42** um — das Desktop-Grundlayout der Redesign-Shell (Teil von #38).

> ⚠️ **Gestapelt auf #41** (PR #52). Base = `feature/41-todo-daily-data-model`. **Merge-Reihenfolge: #50 → #51 → #52 → dieser PR.**

## Was
Zweispaltiges Layout aus `Aido Final Kern.dc.html`: feste **Sidebar** links, scrollende **Hauptspalte** rechts. Löst die `Navbar`-Rolle auf `/todos` ab.

- **`SpacesContext`** — lädt die Spaces des Users, hält `activeSpace` + `view` (liste|board) und (best-effort) Offen-Zähler pro Space (`getOpenTodoCount` via `getCountFromServer`).
- **Shell-Komponenten** (`src/components/shell/`):
  - `DesktopShell` — 256px-Sidebar + `flex-1`-Hauptspalte; Container 780px (Liste) / 1140px (Board), `padding 30/36/90`, `gap 18`.
  - `Sidebar` — Logo (Akzent-Quadrat + zwei Roboter-Augen) + Wortmarke + `ThemeToggle`; „SPACES"-Label; Space-Zeilen (Farbquadrat 10×10 + Name + Offen-Zähler, aktiv `row-hover`/800); „+ Neuer Space" (Platzhalter); Footer (Avatar + Name + Settings-Link).
  - `SpaceHeader` — Farbquadrat 14×14 + Name `24/900` + überlappende Mitglieder-Avatare (28×28, `-8px`, 2px-Ring in `--bg`) + „+ einladen" (Platzhalter) + `SegmentedControl`.
  - `SegmentedControl` (Liste|Board, aktiver Tab invertiert), `ThemeToggle` (gleitende Pille), `Avatar` (Initialen auf Personenfarbe).
- **`WorkspaceContent`** — rendert die Heute-Container-Chrome + Liste/Board-Rahmen als **Platzhalter**; die interaktiven Inhalte kommen in #44 (Heute) / #45 (Liste) / #46 (Board).
- `personColor()` zu `theme/colors` ergänzt.

## Bewusst außerhalb des Scopes (= Platzhalter)
„+ Neuer Space" und „+ einladen" sind inert (Spaces-Verwaltung = **#47**). Heute/Liste/Board sind Platzhalter (#44–#46). Routing-Vereinheitlichung (Default-Route, alte Seiten) = **#49**; deshalb wird der alte `Navbar` vorerst nur auf `/todos` ausgeblendet.

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅ (`/todos` prerendert ohne Render-Fehler).
- **Pixel-Abnahme gegen Screenshots 01/02/03** steht noch aus: erfordert eingeloggte Session + vorhandenen Space (kommt mit #47/#48) — analog zu #39 dorthin verschoben. Gebaut strikt nach Handoff-Maßen/Tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
