### PR TITLE
feat(shell): mobile app shell — header, space pills, bottom tabs, sheets (#43)

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -2,17 +2,22 @@
 
 import React from "react";
 import { SpacesProvider } from "@/lib/contexts/SpacesContext";
+import { ToastProvider } from "@/lib/contexts/ToastContext";
 import DesktopShell from "./DesktopShell";
+import MobileShell from "./MobileShell";
 
 /**
- * Entry point for the redesigned workspace (issue #42). Provides the spaces
- * state and renders the desktop shell. The responsive mobile shell is added in
- * issue #43 (a layout switch will choose desktop vs. mobile here).
+ * Entry point for the redesigned workspace (issues #42/#43). Provides spaces +
+ * toast state and renders both shells; CSS handles the responsive switch
+ * (desktop is `md:flex`, mobile is `md:hidden`), avoiding hydration mismatch.
  */
 export default function AppShell() {
   return (
-    <SpacesProvider>
-      <DesktopShell />
-    </SpacesProvider>
+    <ToastProvider>
+      <SpacesProvider>
+        <DesktopShell />
+        <MobileShell />
+      </SpacesProvider>
+    </ToastProvider>
   );
 }

--- a/src/components/shell/BottomSheet.tsx
+++ b/src/components/shell/BottomSheet.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Mobile bottom sheet primitive (issue #43): rounded top (22px), drag grabber,
+ * dimmed overlay. Rendered absolutely inside the mobile shell root. Touch
+ * targets inside should stay ≥44px.
+ */
+export default function BottomSheet({ open, onClose, title, children }: BottomSheetProps) {
+  if (!open) return null;
+
+  return (
+    <div className="absolute inset-0 z-50 flex flex-col justify-end">
+      <div
+        className="absolute inset-0"
+        style={{ background: "oklch(0 0 0 / 0.45)" }}
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        className="relative bg-bg-pop text-text shadow-soft"
+        style={{
+          borderRadius: "22px 22px 0 0",
+          padding: "10px 18px calc(env(safe-area-inset-bottom, 0px) + 22px)",
+        }}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          className="mx-auto mb-3 rounded-full"
+          style={{ width: 38, height: 4, background: "var(--border)" }}
+        />
+        {title && <h2 className="mb-3 text-lg font-extrabold">{title}</h2>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/BottomTabs.tsx
+++ b/src/components/shell/BottomTabs.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+
+export type MobileTab = "heute" | "todos" | "board";
+
+function SpeechIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <path d="M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.8-.9L3 21l1.9-5.7a8.5 8.5 0 0 1-.9-3.8A8.38 8.38 0 0 1 12.5 3 8.38 8.38 0 0 1 21 11.5z" />
+    </svg>
+  );
+}
+function LinesIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden>
+      <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
+      <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
+    </svg>
+  );
+}
+function BarsIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <rect x="3" y="4" width="5" height="16" rx="1.5" /><rect x="10" y="4" width="5" height="10" rx="1.5" /><rect x="17" y="4" width="5" height="13" rx="1.5" />
+    </svg>
+  );
+}
+
+const TABS: { id: MobileTab; label: string; Icon: () => React.JSX.Element }[] = [
+  { id: "heute", label: "Heute", Icon: SpeechIcon },
+  { id: "todos", label: "Todos", Icon: LinesIcon },
+  { id: "board", label: "Board", Icon: BarsIcon },
+];
+
+interface BottomTabsProps {
+  tab: MobileTab;
+  onChange: (tab: MobileTab) => void;
+}
+
+/**
+ * Mobile bottom tab bar (issue #43): Heute · Todos · Board. The Todos tab shows
+ * the active space's open-todo count as a badge pin.
+ */
+export default function BottomTabs({ tab, onChange }: BottomTabsProps) {
+  const { activeSpaceId, openCounts } = useSpaces();
+  const openCount = activeSpaceId ? openCounts[activeSpaceId] : undefined;
+
+  return (
+    <nav
+      className="flex shrink-0 items-stretch border-t border-border"
+      style={{
+        background: "var(--nav-bg)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        padding: "8px 8px calc(env(safe-area-inset-bottom, 0px) + 10px)",
+      }}
+    >
+      {TABS.map(({ id, label, Icon }) => {
+        const active = tab === id;
+        const showBadge = id === "todos" && typeof openCount === "number" && openCount > 0;
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onChange(id)}
+            className="flex flex-1 flex-col items-center gap-1 py-1"
+            style={{ color: active ? "var(--accent)" : "var(--text-dim)", minHeight: 44 }}
+          >
+            <span className="relative">
+              <Icon />
+              {showBadge && (
+                <span
+                  className="absolute -right-2 -top-1 flex items-center justify-center rounded-full px-1 text-[10px] font-bold text-white"
+                  style={{ minWidth: 16, height: 16, background: "var(--accent)" }}
+                >
+                  {openCount}
+                </span>
+              )}
+            </span>
+            <span className="text-[11px] font-extrabold">{label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/shell/DesktopShell.tsx
+++ b/src/components/shell/DesktopShell.tsx
@@ -14,7 +14,7 @@ export default function DesktopShell() {
   const { activeSpace, loading, view } = useSpaces();
 
   return (
-    <div className="flex h-screen overflow-hidden bg-bg text-text">
+    <div className="hidden h-screen overflow-hidden bg-bg text-text md:flex">
       <Sidebar />
 
       <main className="flex-1 overflow-y-auto">

--- a/src/components/shell/MobileHeader.tsx
+++ b/src/components/shell/MobileHeader.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import Avatar from "./Avatar";
+import ThemeToggle from "./ThemeToggle";
+
+function Logo() {
+  return (
+    <div
+      className="flex items-center justify-center gap-[3px]"
+      style={{ width: 28, height: 28, borderRadius: 9, backgroundColor: "var(--accent)" }}
+      aria-hidden
+    >
+      <span className="block rounded-full bg-white" style={{ width: 5, height: 5 }} />
+      <span className="block rounded-full bg-white" style={{ width: 5, height: 5 }} />
+    </div>
+  );
+}
+
+interface MobileHeaderProps {
+  /** Opens the "+ Space" sheet (creation UI is the spaces-management issue #47). */
+  onAddSpace: () => void;
+}
+
+/**
+ * Fixed mobile header (issue #43): brand + member avatars + theme toggle, with a
+ * horizontally scrollable row of space pills underneath. Blurred nav background.
+ */
+export default function MobileHeader({ onAddSpace }: MobileHeaderProps) {
+  const { spaces, activeSpaceId, activeSpace, openCounts, setActiveSpace } = useSpaces();
+  const profiles = useMemberProfiles(activeSpace?.members ?? []);
+
+  return (
+    <header
+      className="flex shrink-0 flex-col gap-2 border-b border-border"
+      style={{
+        background: "var(--nav-bg)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        padding: "calc(env(safe-area-inset-top, 0px) + 12px) 16px 10px",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <Logo />
+        <span className="text-[17px] font-black">aido</span>
+        <div className="ml-auto flex items-center gap-2">
+          <div className="flex items-center">
+            {(activeSpace?.members ?? []).map((uid, i) => (
+              <div key={uid} style={{ marginLeft: i === 0 ? 0 : -8 }}>
+                <Avatar uid={uid} name={profiles[uid]?.displayName} size={26} ring />
+              </div>
+            ))}
+          </div>
+          <ThemeToggle width={42} height={24} />
+        </div>
+      </div>
+
+      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {spaces.map((space) => {
+          const active = space.id === activeSpaceId;
+          const count = openCounts[space.id];
+          return (
+            <button
+              key={space.id}
+              type="button"
+              onClick={() => setActiveSpace(space.id)}
+              className="flex shrink-0 items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-bold"
+              style={
+                active
+                  ? { background: "var(--accent-soft)", borderColor: "var(--accent)" }
+                  : { borderColor: "var(--border)", color: "var(--text-dim)" }
+              }
+            >
+              <span
+                style={{ width: 8, height: 8, borderRadius: 3, background: spaceColorFromHue(space.color) }}
+              />
+              <span className="whitespace-nowrap">{space.name}</span>
+              {typeof count === "number" && count > 0 && (
+                <span className="text-xs text-text-dim">{count}</span>
+              )}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          onClick={onAddSpace}
+          className="flex shrink-0 items-center whitespace-nowrap rounded-full border border-dashed border-border px-3 py-1.5 text-sm text-text-dim"
+        >
+          + Space
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import MobileHeader from "./MobileHeader";
+import BottomTabs, { type MobileTab } from "./BottomTabs";
+import BottomSheet from "./BottomSheet";
+
+/**
+ * Per-tab content placeholders (issue #43). Interactive content is built in the
+ * feature issues: Heute → #44, Todos → #45, Board → #46.
+ */
+function MobileContent({ tab }: { tab: MobileTab }) {
+  if (tab === "heute") {
+    return <p className="pt-8 text-center text-sm text-text-dim">Noch nichts für heute.</p>;
+  }
+  if (tab === "board") {
+    return <p className="pt-8 text-center text-sm text-text-dim">Board folgt.</p>;
+  }
+  return <p className="pt-8 text-center text-sm text-text-dim">Noch keine Todos.</p>;
+}
+
+/** Fixed Heute chat input bar (placeholder; the real composer lands in #44). */
+function HeuteInputBar() {
+  return (
+    <div className="shrink-0 px-4 pb-3 pt-1">
+      <div
+        className="flex items-center gap-2 rounded-full bg-bg-card"
+        style={{ padding: "8px 8px 8px 18px" }}
+      >
+        <span className="flex-1 text-sm text-text-dim">Sag&apos;s aido kurz …</span>
+        <span
+          className="flex items-center justify-center rounded-full text-white"
+          style={{ width: 30, height: 30, background: "var(--accent)" }}
+          aria-hidden
+        >
+          ↑
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mobile shell (issue #43): single column — fixed header, scrolling content,
+ * contextual Heute input, fixed bottom tabs; bottom sheets overlay the root.
+ * Shown only below the `md` breakpoint (desktop shell handles md+).
+ */
+export default function MobileShell() {
+  const { activeSpace, loading } = useSpaces();
+  const [tab, setTab] = useState<MobileTab>("todos");
+  const [addSpaceOpen, setAddSpaceOpen] = useState(false);
+
+  return (
+    <div className="relative flex h-screen flex-col overflow-hidden bg-bg text-text md:hidden">
+      <MobileHeader onAddSpace={() => setAddSpaceOpen(true)} />
+
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {loading ? (
+          <p className="pt-10 text-center text-sm text-text-dim">Lädt …</p>
+        ) : !activeSpace ? (
+          <div className="pt-16 text-center">
+            <p className="text-lg font-extrabold">Noch keine Spaces</p>
+            <p className="mt-1 text-sm text-text-dim">Leg über „+ Space“ deinen ersten Space an.</p>
+          </div>
+        ) : (
+          <MobileContent tab={tab} />
+        )}
+      </div>
+
+      {activeSpace && tab === "heute" && <HeuteInputBar />}
+
+      <BottomTabs tab={tab} onChange={setTab} />
+
+      {/* Space creation form lands in the spaces-management issue (#47). */}
+      <BottomSheet open={addSpaceOpen} onClose={() => setAddSpaceOpen(false)} title="Neuer Space">
+        <p className="pb-4 text-sm text-text-dim">Space anlegen — bald verfügbar.</p>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/src/components/shell/SpaceHeader.tsx
+++ b/src/components/shell/SpaceHeader.tsx
@@ -1,45 +1,11 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { getPublicProfile, type PublicProfile } from "@/lib/firebase/firebaseUtils";
+import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
 import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "./Avatar";
 import SegmentedControl from "./SegmentedControl";
-
-/** Loads public profiles for a list of member uids (for avatar initials). */
-function useMemberProfiles(memberUids: string[]): Record<string, PublicProfile> {
-  const [profiles, setProfiles] = useState<Record<string, PublicProfile>>({});
-  const key = memberUids.join(",");
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const entries = await Promise.all(
-        memberUids.map(async (uid) => {
-          try {
-            return [uid, await getPublicProfile(uid)] as const;
-          } catch {
-            return [uid, null] as const;
-          }
-        })
-      );
-      if (cancelled) return;
-      const next: Record<string, PublicProfile> = {};
-      for (const [uid, profile] of entries) {
-        if (profile) next[uid] = profile;
-      }
-      setProfiles(next);
-    })();
-    return () => {
-      cancelled = true;
-    };
-    // key is the stable dependency derived from memberUids
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
-
-  return profiles;
-}
 
 export default function SpaceHeader() {
   const { activeSpace } = useSpaces();

--- a/src/lib/contexts/ToastContext.tsx
+++ b/src/lib/contexts/ToastContext.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  ReactNode,
+} from "react";
+
+interface ToastContextType {
+  /** Show a transient confirmation toast (auto-hides after 2600ms). */
+  showToast: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+const AUTO_HIDE_MS = 2600;
+
+/**
+ * App-wide toast primitive (issue #43). Features call `showToast(...)` for
+ * short confirmations (e.g. "In die Liste übernommen."). Rendered fixed at the
+ * bottom center, above the mobile tab bar.
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [message, setMessage] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((msg: string) => {
+    setMessage(msg);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setMessage(null), AUTO_HIDE_MS);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {message && (
+        <div
+          className="fixed left-1/2 z-[60] -translate-x-1/2 rounded-full bg-bg-pop px-4 py-2 text-sm font-semibold shadow-soft"
+          style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + 86px)" }}
+          role="status"
+        >
+          {message}
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = (): ToastContextType => {
+  const context = useContext(ToastContext);
+  if (context === undefined) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+};

--- a/src/lib/hooks/useMemberProfiles.ts
+++ b/src/lib/hooks/useMemberProfiles.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getPublicProfile, type PublicProfile } from "@/lib/firebase/firebaseUtils";
+
+/**
+ * Loads public profiles for a list of member uids (for avatar initials / names).
+ * Shared by the desktop space header and the mobile header (issues #42/#43).
+ */
+export function useMemberProfiles(memberUids: string[]): Record<string, PublicProfile> {
+  const [profiles, setProfiles] = useState<Record<string, PublicProfile>>({});
+  const key = memberUids.join(",");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        memberUids.map(async (uid) => {
+          try {
+            return [uid, await getPublicProfile(uid)] as const;
+          } catch {
+            return [uid, null] as const;
+          }
+        })
+      );
+      if (cancelled) return;
+      const next: Record<string, PublicProfile> = {};
+      for (const [uid, profile] of entries) {
+        if (profile) next[uid] = profile;
+      }
+      setProfiles(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // `key` is the stable dependency derived from memberUids
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  return profiles;
+}


### PR DESCRIPTION
Setzt **#43** um — die Mobile-Shell (iPhone-Layout) parallel zur Desktop-Shell (Teil von #38).

> ⚠️ **Gestapelt auf #42** (PR #53). Base = `feature/42-desktop-shell`. **Merge-Reihenfolge: #50 → #51 → #52 → #53 → dieser PR.**

## Was
Einspaltiges Mobile-Layout aus `Aido Mobile.dc.html`. Responsive Umschaltung rein per **CSS** (`md:flex` Desktop / `md:hidden` Mobile) → kein Hydration-Mismatch, kein JS-Media-Query-Flash.

- **`MobileShell`** — Spalte: fixer Header → scrollender Content (`flex-1 overflow-y-auto`) → kontextuelle **Heute-Eingabe** (nur Heute-Tab) → fixe Bottom-Tabs; Bottom-Sheet als Overlay. Inhalte pro Tab sind Platzhalter (Heute #44 / Todos #45 / Board #46).
- **`MobileHeader`** — Logo + Wortmarke + Mitglieder-Avatare + Theme-Toggle (42×24); darunter horizontal scrollbare **Space-Pills** (aktiv `accent-soft` + Border `accent`) mit Offen-Zähler + „+ Space" (öffnet Sheet).
- **`BottomTabs`** — Heute · Todos · Board mit Inline-SVG-Icons + Labels (11/800), aktiv `color accent`, Offen-Badge am Todos-Tab.
- **`BottomSheet`**-Primitive — oben gerundet (22px), Grabber 38×4, Overlay `oklch(0 0 0 /0.45)`, Safe-Area-aware. **`Toast`**-Primitive (`ToastProvider`/`useToast`, Auto-Hide 2600ms) für Feature-Bestätigungen.
- `useMemberProfiles`-Hook extrahiert (geteilt von Desktop-`SpaceHeader` + `MobileHeader`).
- `DesktopShell` jetzt `md`-only; `AppShell` rendert beide Shells + `ToastProvider`.

## Abweichung vom Handoff (begründet)
Die mock-spezifischen Paddings **56px/30px** (Statusbar/Home-Indicator) sind durch **`env(safe-area-inset-*)`** ersetzt — das iOS-Frame ist laut Handoff nur Preview-Chrome; Safe-Area-Insets sind die korrekte Web-Entsprechung.

## Bewusste Grenzen (Platzhalter)
„+ Space" öffnet ein Platzhalter-Sheet (Anlegen = **#47**). Heute/Todos/Board-Inhalte = #44–#46. Heute-Eingabe ist eine inerte Pille (echter Composer = #44).

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅ (`/todos` prerendert mit beiden Shells, ohne Render-Fehler).
- **Pixel-Abnahme gegen Screenshots 04/05/06** steht noch aus (erfordert Login + Space; kommt mit #47/#48) — analog zu #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
