### PR TITLE
feat(spaces): Space data model, rules & rules-tests (#40)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -39,6 +39,40 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // Spaces (issue #40): the organizing unit that replaces "My Todos / Shared
+    // with me". Membership grants full access to everything in the space.
+    // Rights model: any member may read and update (rename, recolor, add/remove
+    // members — this is how "+ einladen" works); createdBy/createdAt are
+    // immutable so a member cannot take over or rewrite history; only the
+    // creator may delete the space. Finer-grained roles can be layered on later.
+    match /spaces/{spaceId} {
+      function isExistingMember() {
+        return isAuthenticated() && request.auth.uid in resource.data.members;
+      }
+      // members gates read access, so it must always be a list (never a map/
+      // string that could confuse the `in` membership checks).
+      function isValidSpace() {
+        return request.resource.data.members is list
+            && request.resource.data.name is string
+            && request.resource.data.color is number;
+      }
+
+      allow read: if isExistingMember();
+
+      allow create: if isAuthenticated()
+        && isValidSpace()
+        && request.resource.data.createdBy == request.auth.uid
+        && request.auth.uid in request.resource.data.members;
+
+      allow update: if isExistingMember()
+        && isValidSpace()
+        && request.resource.data.createdBy == resource.data.createdBy
+        && request.resource.data.createdAt == resource.data.createdAt;
+
+      allow delete: if isAuthenticated()
+        && resource.data.createdBy == request.auth.uid;
+    }
+
     // Rules for specific user documents and their subcollections
     match /users/{userId} {
       // Owner-only: contains PII (email, timezone, notification settings)

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -19,7 +19,11 @@ import {
   writeBatch,
   limit,
   orderBy,
+  arrayUnion,
+  arrayRemove,
 } from "firebase/firestore";
+import { getSpaceColor } from "../theme/colors";
+import type { Space } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
 
@@ -51,6 +55,71 @@ export const updateDocument = (collectionName: string, id: string, data: any) =>
 
 export const deleteDocument = (collectionName: string, id: string) =>
   deleteDoc(doc(db, collectionName, id));
+
+// --- Spaces (issue #40) ---
+// Top-level `spaces/{spaceId}`; membership grants full access. Rights model
+// (see firestore.rules): any member may read/update (rename, recolor, add/remove
+// members — the "+ einladen" flow); createdBy/createdAt are immutable; only the
+// creator may delete the space.
+
+const SPACES_COLLECTION = "spaces";
+
+// Create a space with the creator as the first member. The color is assigned
+// cyclically from the design palette based on how many spaces the user already
+// has, so the Nth space gets the Nth palette hue (wrapping around).
+export const createSpace = async (
+  uid: string,
+  name: string,
+  existingSpaceCount = 0
+): Promise<string> => {
+  if (!uid) throw new Error("User not authenticated.");
+  const ref = await addDoc(collection(db, SPACES_COLLECTION), {
+    name: name.trim(),
+    color: getSpaceColor(existingSpaceCount).hue,
+    members: [uid],
+    createdBy: uid,
+    createdAt: serverTimestamp(),
+  });
+  return ref.id;
+};
+
+// Load every space the user is a member of (oldest first, for stable ordering).
+export const getSpacesForUser = async (uid: string): Promise<Space[]> => {
+  if (!uid) return [];
+  const q = query(
+    collection(db, SPACES_COLLECTION),
+    where("members", "array-contains", uid)
+  );
+  const snapshot = await getDocs(q);
+  const spaces = snapshot.docs.map((d) => {
+    const data = d.data();
+    return {
+      id: d.id,
+      name: typeof data.name === "string" ? data.name : "",
+      color: typeof data.color === "number" ? data.color : getSpaceColor(0).hue,
+      members: Array.isArray(data.members) ? data.members : [],
+      createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
+      createdAt: data.createdAt ?? null,
+    } as Space;
+  });
+  // array-contains + orderBy would require a composite index, so sort client-side.
+  return spaces.sort(
+    (a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0)
+  );
+};
+
+export const renameSpace = (spaceId: string, name: string) =>
+  updateDoc(doc(db, SPACES_COLLECTION, spaceId), { name: name.trim() });
+
+export const addSpaceMember = (spaceId: string, uid: string) =>
+  updateDoc(doc(db, SPACES_COLLECTION, spaceId), { members: arrayUnion(uid) });
+
+export const removeSpaceMember = (spaceId: string, uid: string) =>
+  updateDoc(doc(db, SPACES_COLLECTION, spaceId), { members: arrayRemove(uid) });
+
+// Only the creator may delete (enforced by firestore.rules).
+export const deleteSpace = (spaceId: string) =>
+  deleteDoc(doc(db, SPACES_COLLECTION, spaceId));
 
 // Helper function to generate a SHA-256 hash string from an email
 export const generateIdFromEmail = async (email: string): Promise<string> => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,21 @@
+import type { Timestamp } from "firebase/firestore";
+
+/**
+ * Space — the organizing unit of the redesign (issue #40). Replaces the
+ * "My Todos / Shared with me" split: membership grants access to everything in
+ * the space. Stored top-level at `spaces/{spaceId}`; authority lives in
+ * firestore.rules.
+ */
+export interface Space {
+  /** Firestore document id. */
+  id: string;
+  name: string;
+  /** oklch hue angle; see src/lib/theme/colors.ts (data model: color = oklch-Hue). */
+  color: number;
+  /** userIds with access to the space. */
+  members: string[];
+  /** userId of the creator (immutable; only the creator may delete the space). */
+  createdBy: string;
+  /** Server timestamp; null while a serverTimestamp() write is still pending. */
+  createdAt: Timestamp | null;
+}

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -174,6 +174,73 @@ await check('sharee may run collection group query', assertSucceeds(
 await check('unauthenticated user may not read', assertFails(
   getDoc(doc(testEnv.unauthenticatedContext().firestore(), TODO_PATH))));
 
+console.log('Spaces (issue #40):');
+const SPACE_PATH = `spaces/space-1`;
+const seedSpace = {
+  name: 'Family', color: 40, members: [ALICE, BOB], createdBy: ALICE, createdAt: 1700000000000,
+};
+async function resetSpace() {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), SPACE_PATH), seedSpace);
+  });
+}
+await resetSpace();
+
+console.log('  reads:');
+await check('member may read a space', assertSucceeds(
+  getDoc(doc(db(ALICE), SPACE_PATH))));
+await check('second member may read a space', assertSucceeds(
+  getDoc(doc(db(BOB), SPACE_PATH))));
+await check('non-member may not read a space', assertFails(
+  getDoc(doc(db(MALLORY), SPACE_PATH))));
+await check('member may query own spaces by membership', assertSucceeds(
+  getDocs(query(collection(db(BOB), 'spaces'),
+    where('members', 'array-contains', BOB)))));
+await check('non-member may not list all spaces', assertFails(
+  getDocs(query(collection(db(MALLORY), 'spaces'),
+    where('members', 'array-contains', ALICE)))));
+
+console.log('  create:');
+await check('user may create a space with self as creator+member', assertSucceeds(
+  setDoc(doc(db(ALICE), 'spaces/space-new'), {
+    name: 'New', color: 200, members: [ALICE], createdBy: ALICE, createdAt: 1 })));
+await check('user may not create a space owned by someone else', assertFails(
+  setDoc(doc(db(MALLORY), 'spaces/space-forge'), {
+    name: 'X', color: 0, members: [MALLORY], createdBy: ALICE, createdAt: 1 })));
+await check('user may not create a space without being a member', assertFails(
+  setDoc(doc(db(MALLORY), 'spaces/space-nomember'), {
+    name: 'X', color: 0, members: [ALICE], createdBy: MALLORY, createdAt: 1 })));
+await check('user may not create a space with non-list members', assertFails(
+  setDoc(doc(db(ALICE), 'spaces/space-badmembers'), {
+    name: 'X', color: 0, members: 'everyone', createdBy: ALICE, createdAt: 1 })));
+
+console.log('  update / invite:');
+await resetSpace();
+await check('member may rename the space', assertSucceeds(
+  updateDoc(doc(db(ALICE), SPACE_PATH), { name: 'Renamed' })));
+// MALLORY is not in members ([ALICE, BOB]) — check this before the invite test
+// below adds them, otherwise it would no longer be testing a non-member.
+await check('non-member may not update the space', assertFails(
+  updateDoc(doc(db(MALLORY), SPACE_PATH), { name: 'hijacked' })));
+await check('member may not change createdBy (takeover)', assertFails(
+  updateDoc(doc(db(BOB), SPACE_PATH), { createdBy: BOB })));
+await check('member may not rewrite createdAt', assertFails(
+  updateDoc(doc(db(ALICE), SPACE_PATH), { createdAt: 1 })));
+await check('member may not set members to a non-list', assertFails(
+  updateDoc(doc(db(ALICE), SPACE_PATH), { members: 'everyone' })));
+// Mutates members, so keep it last in this section.
+await check('member may invite another member', assertSucceeds(
+  updateDoc(doc(db(BOB), SPACE_PATH), { members: [ALICE, BOB, MALLORY] })));
+
+console.log('  delete:');
+await resetSpace();
+await check('non-creator member may not delete the space', assertFails(
+  deleteDoc(doc(db(BOB), SPACE_PATH))));
+await check('non-member may not delete the space', assertFails(
+  deleteDoc(doc(db(MALLORY), SPACE_PATH))));
+await check('creator may delete the space', assertSucceeds(
+  deleteDoc(doc(db(ALICE), SPACE_PATH))));
+
 await testEnv.cleanup();
 
 if (failures > 0) {


### PR DESCRIPTION
Ersetzt #51 (wurde automatisch geschlossen, als beim Merge von #50 dessen Base-Branch gelöscht wurde). Inhalt unverändert — Spaces-Datenmodell, Rules & Tests (#40, Teil von #38). Base jetzt `main` (enthält bereits #39).

Verifikation unverändert: `tsc`/`lint`/`build` ✅, `npm run test:rules` ✅ (Firestore + Storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
