### PR TITLE
feat(spaces): space creation + member invite UI (#47)

### DIFF
--- a/src/components/shell/InvitePopover.tsx
+++ b/src/components/shell/InvitePopover.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import MemberManager from "./MemberManager";
+
+/**
+ * Desktop "+ einladen" popover (issue #47): toggles a panel with the member
+ * manager. Closes on outside click.
+ */
+export default function InvitePopover() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="rounded-full border border-dashed border-border px-3 py-1 text-sm text-text-dim hover:text-text"
+      >
+        + einladen
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-40 mt-2 w-64 rounded-xl border border-border bg-bg-pop p-2 shadow-soft">
+          <MemberManager />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/MemberManager.tsx
+++ b/src/components/shell/MemberManager.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { getContacts, type Contact } from "@/lib/firebase/firebaseUtils";
+import Avatar from "./Avatar";
+
+/**
+ * Member management for the active space (issue #47): lists the current user's
+ * contacts with a ✓ toggle for space membership. Shared by the desktop invite
+ * popover and the mobile members sheet. Touch targets are ≥44px.
+ */
+export default function MemberManager() {
+  const { user } = useAuth();
+  const { activeSpace, addMember, removeMember } = useSpaces();
+  const [contacts, setContacts] = useState<Contact[] | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const loaded = await getContacts(user.uid);
+        if (!cancelled) setContacts(loaded);
+      } catch {
+        if (!cancelled) setContacts([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  if (!activeSpace) return null;
+  const members = activeSpace.members;
+
+  const toggle = async (uid: string) => {
+    if (pending) return;
+    setPending(uid);
+    try {
+      if (members.includes(uid)) await removeMember(activeSpace.id, uid);
+      else await addMember(activeSpace.id, uid);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="px-1 pb-1 text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">
+        Mitglieder
+      </div>
+      {contacts === null ? (
+        <p className="px-1 py-2 text-sm text-text-dim">Lädt …</p>
+      ) : contacts.length === 0 ? (
+        <p className="px-1 py-2 text-sm text-text-dim">
+          Keine Kontakte zum Einladen. Füge zuerst Kontakte unter „Contacts“ hinzu.
+        </p>
+      ) : (
+        contacts.map((contact) => {
+          const isMember = members.includes(contact.uid);
+          return (
+            <button
+              key={contact.uid}
+              type="button"
+              onClick={() => toggle(contact.uid)}
+              disabled={pending === contact.uid}
+              className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-row-hover disabled:opacity-60"
+              style={{ minHeight: 44 }}
+            >
+              <Avatar uid={contact.uid} name={contact.displayName} size={26} />
+              <span className="flex-1 truncate text-sm font-semibold">
+                {contact.displayName ?? contact.email ?? "Unbekannt"}
+              </span>
+              <span
+                className="text-accent"
+                style={{ visibility: isMember ? "visible" : "hidden" }}
+                aria-hidden
+              >
+                ✓
+              </span>
+            </button>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/MobileHeader.tsx
+++ b/src/components/shell/MobileHeader.tsx
@@ -21,17 +21,20 @@ function Logo() {
 }
 
 interface MobileHeaderProps {
-  /** Opens the "+ Space" sheet (creation UI is the spaces-management issue #47). */
+  /** Opens the "+ Space" creation sheet. */
   onAddSpace: () => void;
+  /** Opens the members sheet for the active space (tapping the avatar stack). */
+  onManageMembers: () => void;
 }
 
 /**
  * Fixed mobile header (issue #43): brand + member avatars + theme toggle, with a
  * horizontally scrollable row of space pills underneath. Blurred nav background.
  */
-export default function MobileHeader({ onAddSpace }: MobileHeaderProps) {
+export default function MobileHeader({ onAddSpace, onManageMembers }: MobileHeaderProps) {
   const { spaces, activeSpaceId, activeSpace, openCounts, setActiveSpace } = useSpaces();
   const profiles = useMemberProfiles(activeSpace?.members ?? []);
+  const members = activeSpace?.members ?? [];
 
   return (
     <header
@@ -47,13 +50,20 @@ export default function MobileHeader({ onAddSpace }: MobileHeaderProps) {
         <Logo />
         <span className="text-[17px] font-black">aido</span>
         <div className="ml-auto flex items-center gap-2">
-          <div className="flex items-center">
-            {(activeSpace?.members ?? []).map((uid, i) => (
-              <div key={uid} style={{ marginLeft: i === 0 ? 0 : -8 }}>
-                <Avatar uid={uid} name={profiles[uid]?.displayName} size={26} ring />
-              </div>
-            ))}
-          </div>
+          {members.length > 0 && (
+            <button
+              type="button"
+              onClick={onManageMembers}
+              className="flex items-center"
+              aria-label="Mitglieder verwalten"
+            >
+              {members.map((uid, i) => (
+                <div key={uid} style={{ marginLeft: i === 0 ? 0 : -8 }}>
+                  <Avatar uid={uid} name={profiles[uid]?.displayName} size={26} ring />
+                </div>
+              ))}
+            </button>
+          )}
           <ThemeToggle width={42} height={24} />
         </div>
       </div>

--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -5,6 +5,7 @@ import { useSpaces } from "@/lib/contexts/SpacesContext";
 import MobileHeader from "./MobileHeader";
 import BottomTabs, { type MobileTab } from "./BottomTabs";
 import BottomSheet from "./BottomSheet";
+import MemberManager from "./MemberManager";
 
 /**
  * Per-tab content placeholders (issue #43). Interactive content is built in the
@@ -18,6 +19,48 @@ function MobileContent({ tab }: { tab: MobileTab }) {
     return <p className="pt-8 text-center text-sm text-text-dim">Board folgt.</p>;
   }
   return <p className="pt-8 text-center text-sm text-text-dim">Noch keine Todos.</p>;
+}
+
+/** "+ Space" creation form, shown inside the bottom sheet (issue #47). */
+function NewSpaceForm({ onDone }: { onDone: () => void }) {
+  const { createSpace } = useSpaces();
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async () => {
+    const value = name.trim();
+    if (!value) return;
+    setBusy(true);
+    await createSpace(value);
+    setBusy(false);
+    setName("");
+    onDone();
+  };
+
+  return (
+    <div className="flex flex-col gap-3 pb-2">
+      <input
+        autoFocus
+        value={name}
+        disabled={busy}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit();
+        }}
+        placeholder="Space-Name"
+        className="rounded-xl border border-border bg-bg-card px-4 py-3 text-base outline-none"
+      />
+      <button
+        type="button"
+        onClick={submit}
+        disabled={busy || !name.trim()}
+        className="rounded-full px-4 text-base font-extrabold text-white disabled:opacity-50"
+        style={{ background: "var(--accent)", minHeight: 48 }}
+      >
+        {busy ? "Anlegen …" : "Anlegen"}
+      </button>
+    </div>
+  );
 }
 
 /** Fixed Heute chat input bar (placeholder; the real composer lands in #44). */
@@ -50,10 +93,14 @@ export default function MobileShell() {
   const { activeSpace, loading } = useSpaces();
   const [tab, setTab] = useState<MobileTab>("todos");
   const [addSpaceOpen, setAddSpaceOpen] = useState(false);
+  const [membersOpen, setMembersOpen] = useState(false);
 
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-bg text-text md:hidden">
-      <MobileHeader onAddSpace={() => setAddSpaceOpen(true)} />
+      <MobileHeader
+        onAddSpace={() => setAddSpaceOpen(true)}
+        onManageMembers={() => setMembersOpen(true)}
+      />
 
       <div className="flex-1 overflow-y-auto px-4 py-3">
         {loading ? (
@@ -72,9 +119,12 @@ export default function MobileShell() {
 
       <BottomTabs tab={tab} onChange={setTab} />
 
-      {/* Space creation form lands in the spaces-management issue (#47). */}
       <BottomSheet open={addSpaceOpen} onClose={() => setAddSpaceOpen(false)} title="Neuer Space">
-        <p className="pb-4 text-sm text-text-dim">Space anlegen — bald verfügbar.</p>
+        <NewSpaceForm onDone={() => setAddSpaceOpen(false)} />
+      </BottomSheet>
+
+      <BottomSheet open={membersOpen} onClose={() => setMembersOpen(false)}>
+        <MemberManager />
       </BottomSheet>
     </div>
   );

--- a/src/components/shell/NewSpaceButton.tsx
+++ b/src/components/shell/NewSpaceButton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+
+/**
+ * Sidebar "+ Neuer Space" entry (issue #47): a dim button that turns into an
+ * inline input on click. Enter confirms, Escape/blur cancels.
+ */
+export default function NewSpaceButton() {
+  const { createSpace } = useSpaces();
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const cancel = () => {
+    setName("");
+    setEditing(false);
+  };
+
+  const submit = async () => {
+    const value = name.trim();
+    if (!value) {
+      cancel();
+      return;
+    }
+    setBusy(true);
+    await createSpace(value);
+    setBusy(false);
+    setName("");
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-text-dim hover:bg-row-hover hover:text-text"
+      >
+        + Neuer Space
+      </button>
+    );
+  }
+
+  return (
+    <input
+      autoFocus
+      value={name}
+      disabled={busy}
+      onChange={(e) => setName(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") submit();
+        else if (e.key === "Escape") cancel();
+      }}
+      onBlur={() => {
+        if (!busy) cancel();
+      }}
+      placeholder="Space-Name … ⏎"
+      className="rounded-xl border border-border bg-bg-card px-3 py-2.5 text-sm outline-none"
+    />
+  );
+}

--- a/src/components/shell/Sidebar.tsx
+++ b/src/components/shell/Sidebar.tsx
@@ -7,6 +7,7 @@ import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "./Avatar";
 import ThemeToggle from "./ThemeToggle";
+import NewSpaceButton from "./NewSpaceButton";
 
 /** aido logo: rounded accent square with two white "robot eyes". */
 function Logo() {
@@ -77,15 +78,7 @@ export default function Sidebar() {
           );
         })}
 
-        {/* "+ Neuer Space" — interactive creation lives in the spaces-management
-            issue (#47); here it is only the placeholder row. */}
-        <button
-          type="button"
-          disabled
-          className="flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm font-semibold text-text-dim"
-        >
-          + Neuer Space
-        </button>
+        <NewSpaceButton />
       </nav>
 
       {/* Footer: current user + settings */}

--- a/src/components/shell/SpaceHeader.tsx
+++ b/src/components/shell/SpaceHeader.tsx
@@ -6,6 +6,7 @@ import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
 import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "./Avatar";
 import SegmentedControl from "./SegmentedControl";
+import InvitePopover from "./InvitePopover";
 
 export default function SpaceHeader() {
   const { activeSpace } = useSpaces();
@@ -36,14 +37,7 @@ export default function SpaceHeader() {
         ))}
       </div>
 
-      {/* "+ einladen" — invite popover lives in the spaces-management issue (#47). */}
-      <button
-        type="button"
-        disabled
-        className="rounded-full border border-dashed border-border px-3 py-1 text-sm text-text-dim"
-      >
-        + einladen
-      </button>
+      <InvitePopover />
 
       <div className="ml-auto">
         <SegmentedControl />

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -9,7 +9,13 @@ import React, {
   ReactNode,
 } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
-import { getSpacesForUser, getOpenTodoCount } from "@/lib/firebase/firebaseUtils";
+import {
+  getSpacesForUser,
+  getOpenTodoCount,
+  createSpace as createSpaceDoc,
+  addSpaceMember,
+  removeSpaceMember,
+} from "@/lib/firebase/firebaseUtils";
 import type { Space } from "@/lib/types";
 
 export type SpaceView = "liste" | "board";
@@ -25,6 +31,10 @@ interface SpacesContextType {
   setActiveSpace: (id: string) => void;
   setView: (view: SpaceView) => void;
   refreshSpaces: () => Promise<void>;
+  /** Create a space (creator = first member, cyclic palette color) and select it. */
+  createSpace: (name: string) => Promise<string | null>;
+  addMember: (spaceId: string, uid: string) => Promise<void>;
+  removeMember: (spaceId: string, uid: string) => Promise<void>;
 }
 
 const SpacesContext = createContext<SpacesContextType | undefined>(undefined);
@@ -77,6 +87,33 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     refreshSpaces();
   }, [refreshSpaces]);
 
+  const createSpace = useCallback(
+    async (name: string): Promise<string | null> => {
+      if (!user || !name.trim()) return null;
+      const id = await createSpaceDoc(user.uid, name, spaces.length);
+      await refreshSpaces();
+      setActiveSpaceId(id);
+      return id;
+    },
+    [user, spaces.length, refreshSpaces]
+  );
+
+  const addMember = useCallback(
+    async (spaceId: string, uid: string) => {
+      await addSpaceMember(spaceId, uid);
+      await refreshSpaces();
+    },
+    [refreshSpaces]
+  );
+
+  const removeMember = useCallback(
+    async (spaceId: string, uid: string) => {
+      await removeSpaceMember(spaceId, uid);
+      await refreshSpaces();
+    },
+    [refreshSpaces]
+  );
+
   const activeSpace = spaces.find((s) => s.id === activeSpaceId) ?? null;
 
   const value: SpacesContextType = {
@@ -89,6 +126,9 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     setActiveSpace: setActiveSpaceId,
     setView,
     refreshSpaces,
+    createSpace,
+    addMember,
+    removeMember,
   };
 
   return <SpacesContext.Provider value={value}>{children}</SpacesContext.Provider>;


### PR DESCRIPTION
Setzt **#47** um — Spaces anlegen + Mitglieder einladen. **Vorgezogen** (vor #44–#46), damit das Redesign live mit echten Daten nutzbar ist. Base = `main` (kein Stacking, da #40/#42/#43 bereits gemergt sind). Teil von #38.

## Was
- **`SpacesContext`** — `createSpace(name)` (Ersteller = erstes Mitglied, zyklische Palette-Farbe, wählt den neuen Space direkt aktiv), `addMember`/`removeMember` (jeweils mit Refresh).
- **Desktop:**
  - `NewSpaceButton` — „+ Neuer Space" in der Sidebar wird beim Klick zum Inline-Input (Enter bestätigt, Esc/Blur bricht ab).
  - `InvitePopover` — „+ einladen" öffnet ein Popover (schließt bei Außenklick).
- **Mobile:**
  - „+ Space" öffnet ein Bottom-Sheet mit Anlege-Formular.
  - Mitglieder-Sheet öffnet sich per Tap auf den Avatar-Stack im Header.
- **`MemberManager`** (geteilt von Popover + Sheet) — listet die Kontakte des Users mit ✓-Toggle für die Space-Mitgliedschaft; Touch-Ziele ≥44px; Leerzustand-Hinweis.

Nutzt die Helper aus #40 (`createSpace`/`addSpaceMember`/`removeSpaceMember`) und `getContacts`.

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅.
- Nach Merge live testbar: einloggen → „+ Neuer Space" → der Space erscheint, die Shell füllt sich; „+ einladen" listet Kontakte zum Hinzufügen. (Firestore-Rules sind bereits deployed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
