### PR TITLE
feat(list): Liste view — composer, rows, details, waiting-on, tags (#45)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,3 +228,70 @@ body {
 
 /* Task List Styles */
 /* ... task list styles ... */
+
+/* === Redesigned todo body (issue #45) ===
+ * Scoped overrides for the rendered/edited todo body so it follows the design
+ * tokens instead of the legacy gray ProseMirror styles above. Higher specificity
+ * (.todo-body .ProseMirror …) + later source order win over the generic rules. */
+.todo-body .ProseMirror {
+  color: var(--text) !important;
+  font-size: 14px;
+  line-height: 1.55;
+}
+.todo-body .ProseMirror h1,
+.todo-body .ProseMirror h2,
+.todo-body .ProseMirror h3 {
+  text-transform: uppercase !important;
+  letter-spacing: 0.06em;
+  color: var(--text-dim) !important;
+  font-size: 0.78rem !important;
+  font-weight: 800 !important;
+  margin: 0.6em 0 0.3em !important;
+}
+.todo-body .ProseMirror p { margin: 0.25em 0; }
+.todo-body .ProseMirror ul:not([data-type="taskList"]) { list-style: disc; padding-left: 1.2rem; }
+.todo-body .ProseMirror .mention {
+  color: var(--mention) !important;
+  background: var(--mention-bg);
+  border-radius: 4px;
+  padding: 0 2px;
+  font-weight: 600;
+}
+.todo-body .ProseMirror .hashtag {
+  color: var(--tag) !important;
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+}
+.todo-body .ProseMirror a { color: var(--accent-text) !important; }
+
+/* Interactive checklist checkboxes (16x16, accent when done). */
+.todo-body .ProseMirror ul[data-type="taskList"] input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 2px solid var(--check-border);
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+  margin: 0;
+  flex-shrink: 0;
+}
+.todo-body .ProseMirror ul[data-type="taskList"] input[type="checkbox"]:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.todo-body .ProseMirror ul[data-type="taskList"] input[type="checkbox"]:checked::after {
+  content: "✓";
+  color: #fff;
+  font-size: 11px;
+  line-height: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.todo-body .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div {
+  opacity: 0.6;
+  text-decoration: line-through;
+}

--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { SpacesProvider } from "@/lib/contexts/SpacesContext";
+import { TodosProvider } from "@/lib/contexts/TodosContext";
 import { ToastProvider } from "@/lib/contexts/ToastContext";
 import DesktopShell from "./DesktopShell";
 import MobileShell from "./MobileShell";
@@ -15,8 +16,10 @@ export default function AppShell() {
   return (
     <ToastProvider>
       <SpacesProvider>
-        <DesktopShell />
-        <MobileShell />
+        <TodosProvider>
+          <DesktopShell />
+          <MobileShell />
+        </TodosProvider>
       </SpacesProvider>
     </ToastProvider>
   );

--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -6,6 +6,7 @@ import MobileHeader from "./MobileHeader";
 import BottomTabs, { type MobileTab } from "./BottomTabs";
 import BottomSheet from "./BottomSheet";
 import MemberManager from "./MemberManager";
+import MobileTodos from "./list/MobileTodos";
 
 /**
  * Per-tab content placeholders (issue #43). Interactive content is built in the
@@ -18,7 +19,7 @@ function MobileContent({ tab }: { tab: MobileTab }) {
   if (tab === "board") {
     return <p className="pt-8 text-center text-sm text-text-dim">Board folgt.</p>;
   }
-  return <p className="pt-8 text-center text-sm text-text-dim">Noch keine Todos.</p>;
+  return <MobileTodos />;
 }
 
 /** "+ Space" creation form, shown inside the bottom sheet (issue #47). */

--- a/src/components/shell/WorkspaceContent.tsx
+++ b/src/components/shell/WorkspaceContent.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import ListView from "./list/ListView";
 
 /**
  * Main-column content placeholders for the desktop shell (issue #42).
@@ -46,22 +47,20 @@ export default function WorkspaceContent() {
         <p className="text-sm text-text-dim">Noch nichts für heute.</p>
       </section>
 
-      {/* Todos / Board frame */}
-      <div className="flex flex-col gap-3">
-        <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">
-          {view === "board" ? "Board" : "Todos"}
+      {/* Liste (issue #45) or Board (placeholder until #46) */}
+      {view === "board" ? (
+        <div className="flex flex-col gap-3">
+          <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Board</div>
+          <div
+            className="flex items-center justify-center text-sm text-text-dim"
+            style={{ border: "1px dashed var(--border)", borderRadius: 16, minHeight: 240 }}
+          >
+            Board folgt.
+          </div>
         </div>
-        <div
-          className="flex items-center justify-center text-sm text-text-dim"
-          style={{
-            border: "1px dashed var(--border)",
-            borderRadius: 16,
-            minHeight: view === "board" ? 240 : 120,
-          }}
-        >
-          {view === "board" ? "Board folgt." : "Noch keine Todos."}
-        </div>
-      </div>
+      ) : (
+        <ListView />
+      )}
     </>
   );
 }

--- a/src/components/shell/list/ComposerToolbar.tsx
+++ b/src/components/shell/list/ComposerToolbar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import type { Editor } from "@tiptap/react";
+
+function Btn({
+  active,
+  onClick,
+  label,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      // Keep editor selection on click.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className="rounded px-2 py-1 text-sm"
+      style={active ? { background: "var(--row-hover)", color: "var(--text)" } : { color: "var(--text-dim)" }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Minimal TipTap format toolbar (issue #45): B / I / U / checklist / quote / code. */
+export default function ComposerToolbar({ editor }: { editor: Editor | null }) {
+  if (!editor) return null;
+  return (
+    <div className="flex items-center gap-1 border-b border-border pb-2">
+      <Btn label="Fett" active={editor.isActive("bold")} onClick={() => editor.chain().focus().toggleBold().run()}>
+        <b>B</b>
+      </Btn>
+      <Btn label="Kursiv" active={editor.isActive("italic")} onClick={() => editor.chain().focus().toggleItalic().run()}>
+        <i>I</i>
+      </Btn>
+      <Btn label="Unterstrichen" active={editor.isActive("underline")} onClick={() => editor.chain().focus().toggleUnderline().run()}>
+        <u>U</u>
+      </Btn>
+      <Btn label="Checkliste" active={editor.isActive("taskList")} onClick={() => editor.chain().focus().toggleTaskList().run()}>
+        ≔
+      </Btn>
+      <Btn label="Zitat" active={editor.isActive("blockquote")} onClick={() => editor.chain().focus().toggleBlockquote().run()}>
+        ❝
+      </Btn>
+      <Btn label="Code" active={editor.isActive("codeBlock")} onClick={() => editor.chain().focus().toggleCodeBlock().run()}>
+        {"</>"}
+      </Btn>
+    </div>
+  );
+}

--- a/src/components/shell/list/ListView.tsx
+++ b/src/components/shell/list/ListView.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import TagFilterBar from "./TagFilterBar";
+import TodoComposer from "./TodoComposer";
+import TodoRow from "./TodoRow";
+
+/**
+ * Desktop Liste view (issue #45): tag filter + composer + open todos + a
+ * collapsible "Erledigt" section.
+ */
+export default function ListView() {
+  const { filtered, loading } = useTodos();
+  const nameOf = useSpaceMemberNames();
+  const [showDone, setShowDone] = useState(false);
+
+  const open = filtered.filter((t) => !t.completed);
+  const done = filtered.filter((t) => t.completed);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Todos</div>
+      <TagFilterBar />
+      <TodoComposer />
+
+      {loading ? (
+        <p className="py-2 text-sm text-text-dim">Lädt …</p>
+      ) : (
+        <>
+          <div className="flex flex-col gap-1">
+            {open.map((t) => (
+              <TodoRow key={t.id} todo={t} nameOf={nameOf} />
+            ))}
+            {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
+          </div>
+
+          {done.length > 0 && (
+            <div className="flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={() => setShowDone((s) => !s)}
+                className="self-start text-sm font-semibold text-text-dim hover:text-text"
+              >
+                Erledigt ({done.length}) {showDone ? "▲" : "▼"}
+              </button>
+              {showDone &&
+                done.map((t) => (
+                  <div key={t.id} style={{ opacity: 0.55 }}>
+                    <TodoRow todo={t} nameOf={nameOf} />
+                  </div>
+                ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/list/MobileTodos.tsx
+++ b/src/components/shell/list/MobileTodos.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import TagFilterBar from "./TagFilterBar";
+import TodoComposer from "./TodoComposer";
+import TodoRow from "./TodoRow";
+import TodoActions from "./TodoActions";
+import TodoEditor from "./TodoEditor";
+import BottomSheet from "../BottomSheet";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Mobile Todos tab (issue #45): tag filter + composer + card rows; the "…" menu
+ * and edit form open as bottom sheets (the sheet covers the mobile shell root).
+ */
+export default function MobileTodos() {
+  const { filtered, loading, editContent } = useTodos();
+  const nameOf = useSpaceMemberNames();
+  const [showDone, setShowDone] = useState(false);
+  const [actionsFor, setActionsFor] = useState<Todo | null>(null);
+  const [editFor, setEditFor] = useState<Todo | null>(null);
+
+  const open = filtered.filter((t) => !t.completed);
+  const done = filtered.filter((t) => t.completed);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <TagFilterBar />
+      <TodoComposer />
+
+      {loading ? (
+        <p className="py-2 text-sm text-text-dim">Lädt …</p>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            {open.map((t) => (
+              <TodoRow key={t.id} todo={t} nameOf={nameOf} variant="mobile" onOpenActions={setActionsFor} />
+            ))}
+            {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
+          </div>
+
+          {done.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={() => setShowDone((s) => !s)}
+                className="self-start text-sm font-semibold text-text-dim"
+              >
+                Erledigt ({done.length}) {showDone ? "▲" : "▼"}
+              </button>
+              {showDone &&
+                done.map((t) => (
+                  <div key={t.id} style={{ opacity: 0.55 }}>
+                    <TodoRow todo={t} nameOf={nameOf} variant="mobile" onOpenActions={setActionsFor} />
+                  </div>
+                ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <BottomSheet open={!!actionsFor} onClose={() => setActionsFor(null)}>
+        {actionsFor && (
+          <TodoActions
+            todo={actionsFor}
+            nameOf={nameOf}
+            onEdit={() => setEditFor(actionsFor)}
+            onClose={() => setActionsFor(null)}
+          />
+        )}
+      </BottomSheet>
+
+      <BottomSheet open={!!editFor} onClose={() => setEditFor(null)}>
+        {editFor && (
+          <TodoEditor
+            initialTitle={editFor.title}
+            initialBody={editFor.body}
+            submitLabel="Speichern"
+            onCancel={() => setEditFor(null)}
+            onSave={async (title, body) => {
+              await editContent(editFor.id, title, body);
+              setEditFor(null);
+            }}
+          />
+        )}
+      </BottomSheet>
+    </div>
+  );
+}

--- a/src/components/shell/list/TagFilterBar.tsx
+++ b/src/components/shell/list/TagFilterBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+
+/**
+ * Tag chip bar (issue #45): all tags of the space; chips are combinable (AND).
+ * Active chip = accent/white. "✕ Filter" resets.
+ */
+export default function TagFilterBar() {
+  const { tags, tagFilters, toggleTag, clearTags } = useTodos();
+  if (tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {tags.map((tag) => {
+        const active = tagFilters.includes(tag);
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => toggleTag(tag)}
+            className="rounded-full px-3 py-1 font-mono text-xs"
+            style={
+              active
+                ? { background: "var(--accent)", color: "#fff" }
+                : { background: "var(--bg-card)", color: "var(--tag)" }
+            }
+          >
+            #{tag}
+          </button>
+        );
+      })}
+      {tagFilters.length > 0 && (
+        <button
+          type="button"
+          onClick={clearTags}
+          className="text-xs text-text-dim hover:text-text"
+        >
+          ✕ Filter
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoActions.tsx
+++ b/src/components/shell/list/TodoActions.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import type { Todo } from "@/lib/types";
+
+/**
+ * "…" menu actions for a todo (issue #45): Bearbeiten · Wartet auf … (members +
+ * Niemand) · Löschen. Used inside the desktop popover and the mobile sheet.
+ */
+export default function TodoActions({
+  todo,
+  nameOf,
+  onEdit,
+  onClose,
+}: {
+  todo: Todo;
+  nameOf: (uid: string) => string;
+  onEdit: () => void;
+  onClose: () => void;
+}) {
+  const { setWaitingOn, remove } = useTodos();
+  const { activeSpace } = useSpaces();
+  const [waitOpen, setWaitOpen] = useState(false);
+  const members = activeSpace?.members ?? [];
+
+  const item = "rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover";
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        className={item}
+        style={{ minHeight: 44 }}
+        onClick={() => {
+          onEdit();
+          onClose();
+        }}
+      >
+        Bearbeiten
+      </button>
+
+      <button
+        type="button"
+        className={`flex items-center justify-between ${item}`}
+        style={{ minHeight: 44 }}
+        onClick={() => setWaitOpen((o) => !o)}
+      >
+        Wartet auf … <span className="text-text-dim">{waitOpen ? "⌄" : "›"}</span>
+      </button>
+      {waitOpen && (
+        <div className="flex flex-col border-l border-border pl-2">
+          <button
+            type="button"
+            className={`flex items-center justify-between ${item}`}
+            style={{ minHeight: 44 }}
+            onClick={async () => {
+              await setWaitingOn(todo.id, null);
+              onClose();
+            }}
+          >
+            Niemand {todo.waitingOn === null && <span className="text-accent">✓</span>}
+          </button>
+          {members.map((uid) => (
+            <button
+              key={uid}
+              type="button"
+              className={`flex items-center justify-between ${item}`}
+              style={{ minHeight: 44 }}
+              onClick={async () => {
+                await setWaitingOn(todo.id, uid);
+                onClose();
+              }}
+            >
+              {nameOf(uid)} {todo.waitingOn === uid && <span className="text-accent">✓</span>}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="button"
+        className={item}
+        style={{ minHeight: 44, color: "var(--danger)" }}
+        onClick={async () => {
+          await remove(todo.id);
+          onClose();
+        }}
+      >
+        Löschen
+      </button>
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoBody.tsx
+++ b/src/components/shell/list/TodoBody.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import { useTiptapConfig } from "@/lib/hooks/useTiptapConfig";
+import type { TiptapContent } from "@/lib/types";
+
+/**
+ * Read-only renderer for a todo's rich body (issue #45). XSS-safe ProseMirror
+ * path (never dangerouslySetInnerHTML). Checklist checkboxes stay interactive
+ * via onReadOnlyChecked; toggling persists the new body through onChange.
+ */
+export default function TodoBody({
+  body,
+  onChange,
+}: {
+  body: TiptapContent | null;
+  onChange: (next: TiptapContent) => void;
+}) {
+  const { extensions, editorProps } = useTiptapConfig({
+    editable: false,
+    enableMentionSuggestion: false,
+    onReadOnlyChecked: () => true,
+  });
+
+  const editor = useEditor(
+    {
+      editable: false,
+      content: body || "",
+      extensions,
+      editorProps,
+      immediatelyRender: false,
+      onUpdate: ({ editor }) => onChange(editor.getJSON() as TiptapContent),
+    },
+    []
+  );
+
+  // Keep content in sync when the body prop changes externally (e.g. after save).
+  useEffect(() => {
+    if (editor && !editor.isDestroyed) {
+      const current = JSON.stringify(editor.getJSON());
+      const next = JSON.stringify(body || {});
+      if (current !== next) editor.commands.setContent(body || "", false);
+    }
+  }, [body, editor]);
+
+  useEffect(() => () => editor?.destroy(), [editor]);
+
+  return (
+    <div className="todo-body">
+      <EditorContent editor={editor} />
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoComposer.tsx
+++ b/src/components/shell/list/TodoComposer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import TodoEditor from "./TodoEditor";
+
+/**
+ * Todo composer (issue #45): collapsed quick-add row (border in the space color)
+ * that expands into the full TipTap editor via "⌵ Mehr".
+ */
+export default function TodoComposer() {
+  const { createTodo } = useTodos();
+  const { activeSpace } = useSpaces();
+  const [open, setOpen] = useState(false);
+  const [quick, setQuick] = useState("");
+  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
+
+  const quickAdd = async () => {
+    const value = quick.trim();
+    if (!value) return;
+    setQuick("");
+    await createTodo({ title: value });
+  };
+
+  if (open) {
+    return (
+      <TodoEditor
+        accentColor={accent}
+        submitLabel="Hinzufügen"
+        onCancel={() => setOpen(false)}
+        onSave={async (title, body) => {
+          await createTodo({ title, body });
+          setOpen(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded-2xl bg-bg-card px-3 py-2"
+      style={{ border: `1.5px solid ${accent}` }}
+    >
+      <span className="text-lg font-bold" style={{ color: accent }}>
+        +
+      </span>
+      <input
+        value={quick}
+        onChange={(e) => setQuick(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") quickAdd();
+        }}
+        placeholder="Strukturiertes Todo anlegen … @ Personen, # Tags"
+        className="flex-1 bg-transparent text-sm outline-none placeholder:text-text-dim"
+      />
+      <button type="button" onClick={() => setOpen(true)} className="shrink-0 text-sm text-text-dim">
+        ⌵ Mehr
+      </button>
+      <button
+        type="button"
+        onClick={quickAdd}
+        className="shrink-0 rounded-full px-4 py-1.5 text-sm font-extrabold text-white"
+        style={{ background: accent }}
+      >
+        Hinzufügen
+      </button>
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoEditor.tsx
+++ b/src/components/shell/list/TodoEditor.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useEditor, EditorContent } from "@tiptap/react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useTiptapConfig } from "@/lib/hooks/useTiptapConfig";
+import ComposerToolbar from "./ComposerToolbar";
+import type { TiptapContent } from "@/lib/types";
+
+interface TodoEditorProps {
+  initialTitle?: string;
+  initialBody?: TiptapContent | null;
+  submitLabel?: string;
+  accentColor?: string;
+  onSave: (title: string, body: TiptapContent | null) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Open composer / edit form (issue #45): title input (17/800) + TipTap body with
+ * the format toolbar and @/# autocomplete. Used for both creating and editing.
+ */
+export default function TodoEditor({
+  initialTitle = "",
+  initialBody = null,
+  submitLabel = "Hinzufügen",
+  accentColor,
+  onSave,
+  onCancel,
+}: TodoEditorProps) {
+  const { user } = useAuth();
+  const [title, setTitle] = useState(initialTitle);
+
+  const { extensions, editorProps } = useTiptapConfig({
+    editable: true,
+    enableMentionSuggestion: true,
+    currentUserId: user?.uid,
+    placeholder: "Beschreibung, Checklisten, @Personen, #Tags …",
+  });
+
+  const editor = useEditor(
+    {
+      editable: true,
+      content: initialBody || "",
+      extensions,
+      editorProps,
+      immediatelyRender: false,
+    },
+    []
+  );
+
+  useEffect(() => () => editor?.destroy(), [editor]);
+
+  const save = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    const isEmpty = editor ? editor.getText().trim().length === 0 : true;
+    const body = !isEmpty && editor ? (editor.getJSON() as TiptapContent) : null;
+    onSave(trimmed, body);
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-2xl bg-bg-card p-3"
+      style={{ border: `1.5px solid ${accentColor ?? "var(--border)"}` }}
+    >
+      <input
+        autoFocus
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            save();
+          }
+        }}
+        placeholder="Titel"
+        className="bg-transparent text-[17px] font-extrabold outline-none placeholder:text-text-dim"
+      />
+      <ComposerToolbar editor={editor} />
+      <div className="todo-body">
+        <EditorContent editor={editor} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <button type="button" onClick={onCancel} className="rounded-full px-3 py-1.5 text-sm text-text-dim">
+          Abbrechen
+        </button>
+        <button
+          type="button"
+          onClick={save}
+          disabled={!title.trim()}
+          className="rounded-full px-4 py-1.5 text-sm font-extrabold text-white disabled:opacity-50"
+          style={{ background: accentColor ?? "var(--accent)" }}
+        >
+          {submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import TodoTitle from "./TodoTitle";
+import TodoBody from "./TodoBody";
+import TodoEditor from "./TodoEditor";
+import TodoActions from "./TodoActions";
+import type { Todo } from "@/lib/types";
+
+/** Counts task-list checkboxes in a Tiptap body → { done, total }. */
+function checklistProgress(body: unknown): { done: number; total: number } {
+  let done = 0;
+  let total = 0;
+  const walk = (n: any) => {
+    if (!n) return;
+    if (n.type === "taskItem") {
+      total++;
+      if (n.attrs?.checked) done++;
+    }
+    if (Array.isArray(n.content)) n.content.forEach(walk);
+  };
+  walk(body);
+  return { done, total };
+}
+
+interface TodoRowProps {
+  todo: Todo;
+  nameOf: (uid: string) => string;
+  variant?: "desktop" | "mobile";
+  /** Mobile: open the actions sheet for this todo (desktop uses an inline popover). */
+  onOpenActions?: (todo: Todo) => void;
+}
+
+export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActions }: TodoRowProps) {
+  const { setCompleted, editContent } = useTodos();
+  const { activeSpace } = useSpaces();
+  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
+
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const hasBody = !!todo.body && Array.isArray((todo.body as any).content) && (todo.body as any).content.length > 0;
+  const progress = hasBody ? checklistProgress(todo.body) : { done: 0, total: 0 };
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [menuOpen]);
+
+  if (editing) {
+    return (
+      <TodoEditor
+        accentColor={accent}
+        submitLabel="Speichern"
+        initialTitle={todo.title}
+        initialBody={todo.body}
+        onCancel={() => setEditing(false)}
+        onSave={async (title, body) => {
+          await editContent(todo.id, title, body);
+          setEditing(false);
+        }}
+      />
+    );
+  }
+
+  const container =
+    variant === "mobile"
+      ? "rounded-2xl bg-bg-card px-3 py-3"
+      : "rounded-xl px-2 py-2 hover:bg-row-hover";
+
+  return (
+    <div
+      className={`relative flex flex-col gap-2 ${container}`}
+      style={variant === "mobile" ? { border: "1px solid var(--border)" } : undefined}
+    >
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          aria-label={todo.completed ? "Wieder öffnen" : "Erledigen"}
+          onClick={() => setCompleted(todo.id, !todo.completed)}
+          className="mt-0.5 flex shrink-0 items-center justify-center rounded-full"
+          style={{
+            width: 22,
+            height: 22,
+            border: `2px solid ${todo.completed ? accent : "var(--check-border)"}`,
+            background: todo.completed ? accent : "transparent",
+          }}
+        >
+          {todo.completed && <span className="text-white" style={{ fontSize: 12 }}>✓</span>}
+        </button>
+
+        <div
+          className={`min-w-0 flex-1 ${hasBody ? "cursor-pointer" : ""}`}
+          onClick={() => hasBody && setExpanded((e) => !e)}
+        >
+          <TodoTitle title={todo.title} completed={todo.completed} />
+          {(todo.waitingOn || progress.total > 0) && (
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              {todo.waitingOn && (
+                <span
+                  className="rounded-md px-2 py-0.5 text-xs font-semibold"
+                  style={{ background: "var(--wait-bg)", color: "var(--wait-text)" }}
+                >
+                  wartet auf {nameOf(todo.waitingOn)}
+                </span>
+              )}
+              {progress.total > 0 && (
+                <span className="font-mono text-xs text-text-dim">
+                  {progress.done}/{progress.total}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {hasBody && (
+          <button
+            type="button"
+            aria-label="Details"
+            onClick={() => setExpanded((e) => !e)}
+            className="shrink-0 text-text-dim"
+          >
+            <span
+              style={{
+                display: "inline-block",
+                transform: expanded ? "rotate(180deg)" : "none",
+                transition: "transform 0.15s",
+              }}
+            >
+              ⌄
+            </span>
+          </button>
+        )}
+
+        {variant === "mobile" ? (
+          <button
+            type="button"
+            aria-label="Aktionen"
+            onClick={() => onOpenActions?.(todo)}
+            className="shrink-0 text-text-dim"
+          >
+            …
+          </button>
+        ) : (
+          <div className="relative shrink-0" ref={menuRef}>
+            <button
+              type="button"
+              aria-label="Aktionen"
+              onClick={() => setMenuOpen((o) => !o)}
+              className="text-text-dim"
+            >
+              …
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 top-full z-40 mt-1 w-52 rounded-xl border border-border bg-bg-pop p-1 shadow-soft">
+                <TodoActions
+                  todo={todo}
+                  nameOf={nameOf}
+                  onEdit={() => setEditing(true)}
+                  onClose={() => setMenuOpen(false)}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {expanded && hasBody && (
+        <div className="pl-[34px]">
+          <TodoBody body={todo.body} onChange={(next) => editContent(todo.id, todo.title, next)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/list/TodoTitle.tsx
+++ b/src/components/shell/list/TodoTitle.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+
+// Splits on @mentions and #tags while keeping the delimiters.
+const TOKEN = /(@[\w]+|#[\w]+)/g;
+
+/**
+ * Renders a todo title with @mention and #tag highlighting (issue #45).
+ * #tags are clickable and activate the tag filter.
+ */
+export default function TodoTitle({ title, completed }: { title: string; completed?: boolean }) {
+  const { toggleTag } = useTodos();
+  const parts = title.split(TOKEN);
+
+  return (
+    <span className={`text-[15px] font-bold ${completed ? "line-through opacity-60" : ""}`}>
+      {parts.map((part, i) => {
+        if (part.startsWith("@")) {
+          return (
+            <span
+              key={i}
+              className="rounded px-1"
+              style={{ color: "var(--mention)", background: "var(--mention-bg)" }}
+            >
+              {part}
+            </span>
+          );
+        }
+        if (part.startsWith("#")) {
+          const tag = part.slice(1);
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleTag(tag);
+              }}
+              className="font-mono"
+              style={{ color: "var(--tag)" }}
+            >
+              {part}
+            </button>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </span>
+  );
+}

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -35,6 +35,8 @@ interface SpacesContextType {
   createSpace: (name: string) => Promise<string | null>;
   addMember: (spaceId: string, uid: string) => Promise<void>;
   removeMember: (spaceId: string, uid: string) => Promise<void>;
+  /** Update one space's open-todo badge locally (e.g. after add/complete). */
+  setOpenCount: (spaceId: string, count: number) => void;
 }
 
 const SpacesContext = createContext<SpacesContextType | undefined>(undefined);
@@ -114,6 +116,10 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     [refreshSpaces]
   );
 
+  const setOpenCount = useCallback((spaceId: string, count: number) => {
+    setOpenCounts((prev) => ({ ...prev, [spaceId]: count }));
+  }, []);
+
   const activeSpace = spaces.find((s) => s.id === activeSpaceId) ?? null;
 
   const value: SpacesContextType = {
@@ -129,6 +135,7 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     createSpace,
     addMember,
     removeMember,
+    setOpenCount,
   };
 
   return <SpacesContext.Provider value={value}>{children}</SpacesContext.Provider>;

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import {
+  getTodosForSpace,
+  createTodo as createTodoDoc,
+  editTodoContent,
+  setTodoCompleted,
+  setTodoWaitingOn,
+  deleteTodo,
+} from "@/lib/firebase/firebaseUtils";
+import type { Todo, TiptapContent } from "@/lib/types";
+
+interface CreateTodoInput {
+  title: string;
+  body?: TiptapContent | null;
+}
+
+interface TodosContextType {
+  todos: Todo[];
+  loading: boolean;
+  /** Unique tags across the active space's todos. */
+  tags: string[];
+  tagFilters: string[];
+  toggleTag: (tag: string) => void;
+  clearTags: () => void;
+  /** Todos matching the active tag filter (AND), still split open/done by callers. */
+  filtered: Todo[];
+  refresh: () => Promise<void>;
+  createTodo: (input: CreateTodoInput) => Promise<void>;
+  editContent: (id: string, title: string, body: TiptapContent | null) => Promise<void>;
+  setCompleted: (id: string, completed: boolean) => Promise<void>;
+  setWaitingOn: (id: string, waitingOn: string | null) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+const TodosContext = createContext<TodosContextType | undefined>(undefined);
+
+/**
+ * Loads and mutates the active space's todos (issue #45). Shared by the Liste
+ * and Board views (#46). Tag filters reset when the active space changes.
+ */
+export const TodosProvider = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
+  const { activeSpaceId, setOpenCount } = useSpaces();
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tagFilters, setTagFilters] = useState<string[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!activeSpaceId) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const loaded = await getTodosForSpace(activeSpaceId);
+    setTodos(loaded);
+    setLoading(false);
+    setOpenCount(activeSpaceId, loaded.filter((t) => !t.completed).length);
+  }, [activeSpaceId, setOpenCount]);
+
+  // Reload + reset filters whenever the active space changes.
+  useEffect(() => {
+    setTagFilters([]);
+    refresh();
+  }, [refresh]);
+
+  const tags = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of todos) for (const tag of t.tags) set.add(tag);
+    return [...set].sort();
+  }, [todos]);
+
+  const toggleTag = useCallback((tag: string) => {
+    setTagFilters((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  }, []);
+
+  const clearTags = useCallback(() => setTagFilters([]), []);
+
+  const filtered = useMemo(() => {
+    if (tagFilters.length === 0) return todos;
+    // AND filter: a todo must carry every active tag.
+    return todos.filter((t) => tagFilters.every((tag) => t.tags.includes(tag)));
+  }, [todos, tagFilters]);
+
+  const createTodo = useCallback(
+    async (input: CreateTodoInput) => {
+      if (!activeSpaceId || !user) return;
+      const maxOrder = todos.reduce((m, t) => Math.max(m, t.order), 0);
+      await createTodoDoc(activeSpaceId, user.uid, {
+        title: input.title,
+        body: input.body ?? null,
+        order: maxOrder + 1,
+      });
+      await refresh();
+    },
+    [activeSpaceId, user, todos, refresh]
+  );
+
+  const editContent = useCallback(
+    async (id: string, title: string, body: TiptapContent | null) => {
+      if (!activeSpaceId) return;
+      await editTodoContent(activeSpaceId, id, title, body);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const setCompleted = useCallback(
+    async (id: string, completed: boolean) => {
+      if (!activeSpaceId) return;
+      await setTodoCompleted(activeSpaceId, id, completed);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const setWaitingOn = useCallback(
+    async (id: string, waitingOn: string | null) => {
+      if (!activeSpaceId) return;
+      await setTodoWaitingOn(activeSpaceId, id, waitingOn);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      if (!activeSpaceId) return;
+      await deleteTodo(activeSpaceId, id);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const value: TodosContextType = {
+    todos,
+    loading,
+    tags,
+    tagFilters,
+    toggleTag,
+    clearTags,
+    filtered,
+    refresh,
+    createTodo,
+    editContent,
+    setCompleted,
+    setWaitingOn,
+    remove,
+  };
+
+  return <TodosContext.Provider value={value}>{children}</TodosContext.Provider>;
+};
+
+export const useTodos = (): TodosContextType => {
+  const context = useContext(TodosContext);
+  if (context === undefined) {
+    throw new Error("useTodos must be used within a TodosProvider");
+  }
+  return context;
+};

--- a/src/lib/hooks/useMemberProfiles.ts
+++ b/src/lib/hooks/useMemberProfiles.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getPublicProfile, type PublicProfile } from "@/lib/firebase/firebaseUtils";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
 
 /**
  * Loads public profiles for a list of member uids (for avatar initials / names).
@@ -38,4 +39,14 @@ export function useMemberProfiles(memberUids: string[]): Record<string, PublicPr
   }, [key]);
 
   return profiles;
+}
+
+/**
+ * Returns a `nameOf(uid)` resolver for the active space's members (issue #45):
+ * member display name, or "jemand" as a fallback.
+ */
+export function useSpaceMemberNames(): (uid: string) => string {
+  const { activeSpace } = useSpaces();
+  const profiles = useMemberProfiles(activeSpace?.members ?? []);
+  return (uid: string) => profiles[uid]?.displayName ?? "jemand";
 }

--- a/src/lib/hooks/useTiptapConfig.ts
+++ b/src/lib/hooks/useTiptapConfig.ts
@@ -58,6 +58,10 @@ interface UseTiptapConfigOptions {
   placeholder?: string;
   enableMentionSuggestion: boolean;
   currentUserId?: string; // Added currentUserId
+  // When set, task-list checkboxes stay interactive even in a non-editable
+  // editor (issue #45: toggling a checklist item in the rendered todo body).
+  // Return true to allow the toggle (TipTap then mutates the doc and fires onUpdate).
+  onReadOnlyChecked?: (node: unknown, checked: boolean) => boolean;
 }
 
 // This hook RETURNS configuration objects, it does NOT call useEditor itself.
@@ -66,6 +70,7 @@ export function useTiptapConfig({
   placeholder,
   enableMentionSuggestion,
   currentUserId, // Destructure currentUserId
+  onReadOnlyChecked,
 }: UseTiptapConfigOptions): {
   extensions: EditorOptions['extensions'];
   editorProps: EditorOptions['editorProps'];
@@ -141,7 +146,10 @@ export function useTiptapConfig({
     ListItem,
     CustomCodeBlock,
     TaskList,
-    TaskItem.configure({ nested: true }),
+    TaskItem.configure({
+      nested: true,
+      ...(onReadOnlyChecked ? { onReadOnlyChecked } : {}),
+    }),
     Underline,
     Link.configure({
       autolink: true,


### PR DESCRIPTION
Setzt **#45** um — die **Liste**-Sicht (strukturierte Todos, der neu gestaltete TipTap-Anwendungsfall) für Desktop & Mobile. Teil von #38.

> ⚠️ **Gestapelt auf #47** (PR #56). Base = `feature/47-spaces-management`. **Merge-Reihenfolge: #56 → dieser PR.** (Beim Abzweigen war der #47-Branch aktiv; #45 nutzt zwar #47 nicht direkt, enthält dessen Commit aber in der Historie.)

## Was
- **`TodosContext`** — lädt die Todos des aktiven Space, UND-Tag-Filter, CRUD-Wrapper (`create`/`editContent`/`setCompleted`/`setWaitingOn`/`remove`), hält den Offen-Zähler live (`SpacesContext.setOpenCount`). Wird auch von Board (#46) genutzt; Filter werden beim Space-Wechsel zurückgesetzt.
- **`TagFilterBar`** — kombinierbare `#tag`-Chips (UND), „✕ Filter".
- **`TodoComposer`** — eingeklappter Quick-Add (Border in Space-Farbe) → klappt zu `TodoEditor` auf.
- **`TodoEditor`** — Titel-Input + `ComposerToolbar` (B/I/U/≔/❝/</>) + TipTap-Body mit @/#-Autocomplete; für Anlegen **und** Bearbeiten.
- **`TodoRow`** — 22px-Abhak-Kreis, Titel mit @Mention/#Tag-Hervorhebung, „wartet auf X" + Checklisten-Fortschritt, Chevron (bei Body) zum Aufklappen, „…"-Menü (Desktop-Popover / Mobile-Sheet). **`TodoBody`** rendert den Body read-only über ProseMirror (XSS-sicher) mit **interaktiven Checklisten-Checkboxen** (`onReadOnlyChecked`), die den Body zurückschreiben.
- **`TodoActions`** — Bearbeiten · Wartet auf … (Mitglieder + Niemand) · Löschen (danger).
- **`ListView`** (Desktop, inkl. einklappbarer „Erledigt"-Sektion) + **`MobileTodos`** (Mobile, Karten-Zeilen, Aktions-/Edit-Sheets).
- `useTiptapConfig` um `onReadOnlyChecked` erweitert; `SpacesContext.setOpenCount`; `useSpaceMemberNames`; gescopte `.todo-body`-Styles in `globals.css`.

Eingehängt in `WorkspaceContent` (Liste-View) und `MobileShell` (Todos-Tab). Alte `TodoList`/`Todo` bleiben bis zum Cleanup (#49).

## Bewusste Vereinfachung
Der **eingeklappte Quick-Add** ist ein einfaches Eingabefeld (Titel; #Tags werden aus dem Text abgeleitet). Echtes @/#-Popover-Autocomplete steckt im **aufgeklappten** TipTap-Editor (voll funktional). Das Inline-Autocomplete-über-Plain-Input für den Quick-Add ist bewusst weggelassen.

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅ (`/todos` prerendert).
- **Interaktive Abnahme** (Todo anlegen/bearbeiten, Checkboxen, Tag-Filter, Wartet-auf, Erledigt) erfordert eine eingeloggte Session mit einem Space + Todos → am besten live testen, sobald #56 und dieser PR gemergt sind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
