### PR TITLE
feat(heute): chat-style daily quick-capture per space (#44)

### DIFF
--- a/src/components/shell/AppShell.tsx
+++ b/src/components/shell/AppShell.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { SpacesProvider } from "@/lib/contexts/SpacesContext";
 import { TodosProvider } from "@/lib/contexts/TodosContext";
+import { DailyProvider } from "@/lib/contexts/DailyContext";
 import { ToastProvider } from "@/lib/contexts/ToastContext";
 import DesktopShell from "./DesktopShell";
 import MobileShell from "./MobileShell";
@@ -17,8 +18,10 @@ export default function AppShell() {
     <ToastProvider>
       <SpacesProvider>
         <TodosProvider>
-          <DesktopShell />
-          <MobileShell />
+          <DailyProvider>
+            <DesktopShell />
+            <MobileShell />
+          </DailyProvider>
         </TodosProvider>
       </SpacesProvider>
     </ToastProvider>

--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -7,14 +7,16 @@ import BottomTabs, { type MobileTab } from "./BottomTabs";
 import BottomSheet from "./BottomSheet";
 import MemberManager from "./MemberManager";
 import MobileTodos from "./list/MobileTodos";
+import MobileHeute from "./heute/MobileHeute";
+import HeuteInput from "./heute/HeuteInput";
 
 /**
- * Per-tab content placeholders (issue #43). Interactive content is built in the
- * feature issues: Heute → #44, Todos → #45, Board → #46.
+ * Per-tab content (issue #43). Heute → #44, Todos → #45; Board (#46) is still a
+ * placeholder.
  */
 function MobileContent({ tab }: { tab: MobileTab }) {
   if (tab === "heute") {
-    return <p className="pt-8 text-center text-sm text-text-dim">Noch nichts für heute.</p>;
+    return <MobileHeute />;
   }
   if (tab === "board") {
     return <p className="pt-8 text-center text-sm text-text-dim">Board folgt.</p>;
@@ -64,27 +66,6 @@ function NewSpaceForm({ onDone }: { onDone: () => void }) {
   );
 }
 
-/** Fixed Heute chat input bar (placeholder; the real composer lands in #44). */
-function HeuteInputBar() {
-  return (
-    <div className="shrink-0 px-4 pb-3 pt-1">
-      <div
-        className="flex items-center gap-2 rounded-full bg-bg-card"
-        style={{ padding: "8px 8px 8px 18px" }}
-      >
-        <span className="flex-1 text-sm text-text-dim">Sag&apos;s aido kurz …</span>
-        <span
-          className="flex items-center justify-center rounded-full text-white"
-          style={{ width: 30, height: 30, background: "var(--accent)" }}
-          aria-hidden
-        >
-          ↑
-        </span>
-      </div>
-    </div>
-  );
-}
-
 /**
  * Mobile shell (issue #43): single column — fixed header, scrolling content,
  * contextual Heute input, fixed bottom tabs; bottom sheets overlay the root.
@@ -116,7 +97,11 @@ export default function MobileShell() {
         )}
       </div>
 
-      {activeSpace && tab === "heute" && <HeuteInputBar />}
+      {activeSpace && tab === "heute" && (
+        <div className="shrink-0 px-4 pb-3 pt-1">
+          <HeuteInput />
+        </div>
+      )}
 
       <BottomTabs tab={tab} onChange={setTab} />
 

--- a/src/components/shell/WorkspaceContent.tsx
+++ b/src/components/shell/WorkspaceContent.tsx
@@ -3,49 +3,18 @@
 import React from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import ListView from "./list/ListView";
+import Heute from "./heute/Heute";
 
 /**
- * Main-column content placeholders for the desktop shell (issue #42).
- *
- * The shell renders the Heute container chrome and the Liste/Board frame; the
- * interactive content is built in the feature issues:
- *   - Heute  → #44
- *   - Liste  → #45
- *   - Board  → #46
- * These placeholders keep the layout faithful (spacing/containers) while those
- * land, and are meant to be replaced by the feature components.
+ * Main-column content for the desktop shell: Heute (#44) above the active view.
+ * Board (#46) is still a placeholder.
  */
 export default function WorkspaceContent() {
   const { view } = useSpaces();
 
   return (
     <>
-      {/* Heute container (chrome only; chat content → #44) */}
-      <section
-        className="flex flex-col gap-2"
-        style={{
-          background: "var(--accent-soft)",
-          borderRadius: 18,
-          padding: "16px 18px 14px",
-        }}
-      >
-        <div className="flex items-center gap-2">
-          <div
-            className="flex items-center justify-center gap-[3px]"
-            style={{ width: 24, height: 24, borderRadius: 8, backgroundColor: "var(--accent)" }}
-            aria-hidden
-          >
-            <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
-            <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
-          </div>
-          <span className="text-[15px] font-black">Heute</span>
-          <span className="text-sm text-text-dim">
-            Kurzes für zwischendurch — landet nicht in der Liste
-          </span>
-          <span className="ml-auto text-sm text-accent-text">0 offen</span>
-        </div>
-        <p className="text-sm text-text-dim">Noch nichts für heute.</p>
-      </section>
+      <Heute />
 
       {/* Liste (issue #45) or Board (placeholder until #46) */}
       {view === "board" ? (

--- a/src/components/shell/heute/Heute.tsx
+++ b/src/components/shell/heute/Heute.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+import { useDaily } from "@/lib/contexts/DailyContext";
+import HeuteList from "./HeuteList";
+import HeuteInput from "./HeuteInput";
+
+/** Logo icon with two robot eyes (24px), matching the sidebar logo. */
+function HeuteIcon() {
+  return (
+    <div
+      className="flex items-center justify-center gap-[3px]"
+      style={{ width: 24, height: 24, borderRadius: 8, backgroundColor: "var(--accent)" }}
+      aria-hidden
+    >
+      <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
+      <span className="block rounded-full bg-white" style={{ width: 4, height: 4 }} />
+    </div>
+  );
+}
+
+/**
+ * Desktop Heute (issue #44): accent-soft container with the header, the
+ * liegengeblieben/bubble list, and the chat input pill.
+ */
+export default function Heute() {
+  const { today } = useDaily();
+
+  return (
+    <section
+      className="flex flex-col gap-3"
+      style={{ background: "var(--accent-soft)", borderRadius: 18, padding: "16px 18px 14px" }}
+    >
+      <div className="flex items-center gap-2">
+        <HeuteIcon />
+        <span className="text-[15px] font-black">Heute</span>
+        <span className="text-sm text-text-dim">
+          Kurzes für zwischendurch — landet nicht in der Liste
+        </span>
+        {today.length > 0 && (
+          <span className="ml-auto text-sm text-accent-text">{today.length} offen</span>
+        )}
+      </div>
+      <HeuteList />
+      <HeuteInput />
+    </section>
+  );
+}

--- a/src/components/shell/heute/HeuteInput.tsx
+++ b/src/components/shell/heute/HeuteInput.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React, { useState } from "react";
+import { useDaily } from "@/lib/contexts/DailyContext";
+import { useMemberResolver } from "./useMemberResolver";
+
+/**
+ * Heute chat input (issue #44): pill with a round send button. A trailing
+ * @token opens a member-autocomplete popover above the field; Enter picks the
+ * first suggestion when open, otherwise sends. Creates a Daily for today.
+ */
+export default function HeuteInput() {
+  const { add } = useDaily();
+  const resolver = useMemberResolver();
+  const [value, setValue] = useState("");
+
+  const tokenMatch = value.match(/@(\w*)$/);
+  const query = tokenMatch ? tokenMatch[1].toLowerCase() : null;
+  const suggestions =
+    query !== null
+      ? resolver.members.filter((uid) => resolver.nameOf(uid).toLowerCase().includes(query)).slice(0, 5)
+      : [];
+  const showSuggestions = query !== null && suggestions.length > 0;
+
+  const pick = (uid: string) => {
+    setValue(value.replace(/@(\w*)$/, `@${resolver.firstName(uid)} `));
+  };
+
+  const send = () => {
+    const text = value.trim();
+    if (!text) return;
+    setValue("");
+    add(text);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      if (showSuggestions) {
+        e.preventDefault();
+        pick(suggestions[0]);
+        return;
+      }
+      send();
+    }
+  };
+
+  return (
+    <div className="relative">
+      {showSuggestions && (
+        <div className="absolute bottom-full left-0 mb-2 w-56 rounded-xl border border-border bg-bg-pop p-1 shadow-soft">
+          {suggestions.map((uid) => (
+            <button
+              key={uid}
+              type="button"
+              // Keep focus in the input on click.
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => pick(uid)}
+              className="block w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover"
+              style={{ minHeight: 44 }}
+            >
+              @{resolver.firstName(uid)}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-2 rounded-full bg-bg-card" style={{ padding: "8px 8px 8px 18px" }}>
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Sag's aido kurz … „Pakete annehmen @Michi“"
+          className="flex-1 bg-transparent text-sm outline-none placeholder:text-text-dim"
+        />
+        <button
+          type="button"
+          onClick={send}
+          aria-label="Senden"
+          className="flex shrink-0 items-center justify-center rounded-full text-white"
+          style={{ width: 30, height: 30, background: "var(--accent)" }}
+        >
+          ↑
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shell/heute/HeuteList.tsx
+++ b/src/components/shell/heute/HeuteList.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import React from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useDaily } from "@/lib/contexts/DailyContext";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useToast } from "@/lib/contexts/ToastContext";
+import Avatar from "../Avatar";
+import { useMemberResolver, type MemberResolver } from "./useMemberResolver";
+import type { Daily } from "@/lib/types";
+
+/** Direction meta-label: "du → Michi" / "Michi → dich" / "von Michi". */
+function directionLabel(daily: Daily, currentUid: string | undefined, r: MemberResolver): string {
+  const mentioned = r.matchMention(daily.text);
+  if (daily.author === currentUid) {
+    return mentioned ? `du → ${r.firstName(mentioned)}` : "du";
+  }
+  if (mentioned && mentioned === currentUid) return `${r.firstName(daily.author)} → dich`;
+  return `von ${r.firstName(daily.author)}`;
+}
+
+function StaleItem({ daily, onPromote, onDismiss }: {
+  daily: Daily;
+  onPromote: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="rounded-md px-2 py-0.5 text-xs font-semibold"
+        style={{ background: "var(--wait-bg)", color: "var(--wait-text)" }}
+      >
+        liegengeblieben
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm">{daily.text}</span>
+      <button type="button" onClick={onPromote} className="shrink-0 text-xs text-accent-text hover:underline">
+        → in die Liste
+      </button>
+      <button type="button" onClick={onDismiss} aria-label="Verwerfen" className="shrink-0 text-text-dim">
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function Bubble({ daily, currentUid, resolver, onToggle, onDelete }: {
+  daily: Daily;
+  currentUid: string | undefined;
+  resolver: MemberResolver;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const own = daily.author === currentUid;
+  const label = directionLabel(daily, currentUid, resolver);
+
+  return (
+    <div className={`flex flex-col ${own ? "items-end" : "items-start"}`}>
+      <span className="px-1 pb-0.5 text-[10px] font-extrabold uppercase tracking-wide text-text-dim">
+        {label}
+      </span>
+      <div className={`flex max-w-[85%] items-start gap-2 ${own ? "flex-row-reverse" : ""}`}>
+        {!own && <Avatar uid={daily.author} name={resolver.nameOf(daily.author)} size={26} />}
+        <div
+          className="flex items-start gap-2 bg-bg-card px-3 py-2"
+          style={{
+            borderRadius: own ? "14px 14px 4px 14px" : "4px 14px 14px 14px",
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Erledigt"
+            onClick={onToggle}
+            className="mt-0.5 shrink-0 rounded-full"
+            style={{ width: 19, height: 19, border: "2px solid var(--check-border)" }}
+          />
+          <span className="text-sm font-bold">{daily.text}</span>
+          <button type="button" aria-label="Löschen" onClick={onDelete} className="shrink-0 text-text-dim">
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Liegengebliebene + today's chat bubbles (issue #44). Shared by desktop/mobile. */
+export default function HeuteList() {
+  const { user } = useAuth();
+  const { today, stale, setCompleted, remove } = useDaily();
+  const { createTodo } = useTodos();
+  const { showToast } = useToast();
+  const resolver = useMemberResolver();
+
+  const promote = async (d: Daily) => {
+    await createTodo({ title: d.text });
+    await remove(d.id);
+    showToast("In die Liste übernommen.");
+  };
+
+  if (today.length === 0 && stale.length === 0) {
+    return <p className="text-sm text-text-dim">Noch nichts für heute.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {stale.map((d) => (
+        <StaleItem key={d.id} daily={d} onPromote={() => promote(d)} onDismiss={() => remove(d.id)} />
+      ))}
+      {today.map((d) => (
+        <Bubble
+          key={d.id}
+          daily={d}
+          currentUid={user?.uid}
+          resolver={resolver}
+          onToggle={() => setCompleted(d.id, true)}
+          onDelete={() => remove(d.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/shell/heute/MobileHeute.tsx
+++ b/src/components/shell/heute/MobileHeute.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import HeuteList from "./HeuteList";
+
+/**
+ * Mobile Heute tab content (issue #44): a light header + the bubble/stale list.
+ * The chat input is rendered as a fixed bar by MobileShell (HeuteInput).
+ */
+export default function MobileHeute() {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-lg font-black">Heute</span>
+        <span className="text-sm text-text-dim">landet nicht in der Liste</span>
+      </div>
+      <HeuteList />
+    </div>
+  );
+}

--- a/src/components/shell/heute/useMemberResolver.ts
+++ b/src/components/shell/heute/useMemberResolver.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
+
+export interface MemberResolver {
+  members: string[];
+  nameOf: (uid: string) => string;
+  firstName: (uid: string) => string;
+  /** First @mention in the text resolved to a member uid, or null. */
+  matchMention: (text: string) => string | null;
+}
+
+/**
+ * Resolves space members for the Heute view (issue #44): display names and the
+ * first @mention in a daily text → member uid (drives the direction label and
+ * the input autocomplete).
+ */
+export function useMemberResolver(): MemberResolver {
+  const { activeSpace } = useSpaces();
+  const members = activeSpace?.members ?? [];
+  const profiles = useMemberProfiles(members);
+
+  const nameOf = (uid: string) => profiles[uid]?.displayName ?? "jemand";
+  const firstName = (uid: string) => nameOf(uid).split(/\s+/)[0];
+
+  const matchMention = (text: string): string | null => {
+    const match = text.match(/@(\w+)/);
+    if (!match) return null;
+    const word = match[1].toLowerCase();
+    return (
+      members.find((uid) =>
+        (profiles[uid]?.displayName ?? "")
+          .toLowerCase()
+          .split(/\s+/)
+          .some((part) => part.startsWith(word))
+      ) ?? null
+    );
+  };
+
+  return { members, nameOf, firstName, matchMention };
+}

--- a/src/lib/contexts/DailyContext.tsx
+++ b/src/lib/contexts/DailyContext.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import {
+  getOpenDailyForSpace,
+  createDaily,
+  setDailyCompleted,
+  deleteDaily,
+  isStaleDaily,
+  todayString,
+} from "@/lib/firebase/firebaseUtils";
+import type { Daily } from "@/lib/types";
+
+interface DailyContextType {
+  /** Today's open daily items (chat bubbles). */
+  today: Daily[];
+  /** Open daily items from before today ("liegengeblieben"). */
+  stale: Daily[];
+  loading: boolean;
+  add: (text: string) => Promise<void>;
+  setCompleted: (id: string, completed: boolean) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const DailyContext = createContext<DailyContextType | undefined>(undefined);
+
+/**
+ * Loads and mutates the active space's "Heute" items (issue #44). Daily items
+ * are short-lived and deliberately separate from todos. Resets on space switch.
+ */
+export const DailyProvider = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuth();
+  const { activeSpaceId } = useSpaces();
+  const [items, setItems] = useState<Daily[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (!activeSpaceId) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const loaded = await getOpenDailyForSpace(activeSpaceId);
+    setItems(loaded);
+    setLoading(false);
+  }, [activeSpaceId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const todayStr = todayString();
+  const today = useMemo(() => items.filter((d) => d.date === todayStr), [items, todayStr]);
+  const stale = useMemo(() => items.filter((d) => isStaleDaily(d, todayStr)), [items, todayStr]);
+
+  const add = useCallback(
+    async (text: string) => {
+      if (!activeSpaceId || !user || !text.trim()) return;
+      await createDaily(activeSpaceId, user.uid, text);
+      await refresh();
+    },
+    [activeSpaceId, user, refresh]
+  );
+
+  const setCompleted = useCallback(
+    async (id: string, completed: boolean) => {
+      if (!activeSpaceId) return;
+      await setDailyCompleted(activeSpaceId, id, completed);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      if (!activeSpaceId) return;
+      await deleteDaily(activeSpaceId, id);
+      await refresh();
+    },
+    [activeSpaceId, refresh]
+  );
+
+  const value: DailyContextType = { today, stale, loading, add, setCompleted, remove, refresh };
+
+  return <DailyContext.Provider value={value}>{children}</DailyContext.Provider>;
+};
+
+export const useDaily = (): DailyContextType => {
+  const context = useContext(DailyContext);
+  if (context === undefined) {
+    throw new Error("useDaily must be used within a DailyProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
Setzt **#44** um — die **Heute**-Sicht (chat-artige Schnellerfassung kurzlebiger Tages-Todos) für Desktop & Mobile. Base = `main` (kein Stacking). Teil von #38.

## Was
- **`DailyContext`** — lädt offene Daily-Items des aktiven Space, splittet **heute** vs. **liegengeblieben** (`date < today`), `add`/`setCompleted`/`remove`. Reset bei Space-Wechsel. Nutzt die Helper aus #41.
- **`HeuteList`** —
  - **Liegengebliebene:** Badge „liegengeblieben" + Text + „→ in die Liste" (wandelt ein Daily über `TodosContext.createTodo` in ein Todo um + Toast) + „✕".
  - **Bubbles (heute):** eigene Nachrichten rechts, fremde links mit Avatar; Richtungs-Label darüber („du → Michi" / „Michi → dich" / „von Michi"), abgeleitet aus Autor + erstem @Mention.
- **`HeuteInput`** — Pille + runder Senden-Button (↑); ein abschließender `@`-Token öffnet ein Mitglieder-Autocomplete **über** dem Feld (Enter wählt ersten Vorschlag, sonst senden). Legt ein Daily für heute an.
- **`Heute`** (Desktop, `accent-soft`-Container: Header + Liste + Input) und **`MobileHeute`** (Heute-Tab); auf Mobile ist `HeuteInput` die fixe kontextuelle Eingabeleiste.
- `useMemberResolver` (Namen + @Mention→Mitglied). Eingehängt in `WorkspaceContent` (über Liste/Board) und `MobileShell` (Heute-Tab); `DailyProvider` in `AppShell`.

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅ (`/todos` prerendert).
- Keine `firestore.rules`-Änderung → **kein** Rules-Deploy nötig (Daily-Rules sind aus #41 bereits live).
- **Interaktive Abnahme** (Daily senden, @Mention-Autocomplete, Richtungs-Labels, „→ in die Liste", Erledigen/Löschen) → am besten live nach Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
