### PR TITLE
feat(board): Kanban board — group by person/status, DnD + move sheet (#46)

### DIFF
--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -9,17 +9,15 @@ import MemberManager from "./MemberManager";
 import MobileTodos from "./list/MobileTodos";
 import MobileHeute from "./heute/MobileHeute";
 import HeuteInput from "./heute/HeuteInput";
+import MobileBoard from "./board/MobileBoard";
 
-/**
- * Per-tab content (issue #43). Heute → #44, Todos → #45; Board (#46) is still a
- * placeholder.
- */
+/** Per-tab content (issue #43): Heute → #44, Todos → #45, Board → #46. */
 function MobileContent({ tab }: { tab: MobileTab }) {
   if (tab === "heute") {
     return <MobileHeute />;
   }
   if (tab === "board") {
-    return <p className="pt-8 text-center text-sm text-text-dim">Board folgt.</p>;
+    return <MobileBoard />;
   }
   return <MobileTodos />;
 }

--- a/src/components/shell/WorkspaceContent.tsx
+++ b/src/components/shell/WorkspaceContent.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import ListView from "./list/ListView";
 import Heute from "./heute/Heute";
+import BoardView from "./board/BoardView";
 
 /**
  * Main-column content for the desktop shell: Heute (#44) above the active view.
@@ -16,20 +17,7 @@ export default function WorkspaceContent() {
     <>
       <Heute />
 
-      {/* Liste (issue #45) or Board (placeholder until #46) */}
-      {view === "board" ? (
-        <div className="flex flex-col gap-3">
-          <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Board</div>
-          <div
-            className="flex items-center justify-center text-sm text-text-dim"
-            style={{ border: "1px dashed var(--border)", borderRadius: 16, minHeight: 240 }}
-          >
-            Board folgt.
-          </div>
-        </div>
-      ) : (
-        <ListView />
-      )}
+      {view === "board" ? <BoardView /> : <ListView />}
     </>
   );
 }

--- a/src/components/shell/board/BoardGroupToggle.tsx
+++ b/src/components/shell/board/BoardGroupToggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import React from "react";
+import type { GroupBy } from "./columns";
+
+const OPTIONS: { id: GroupBy; label: string }[] = [
+  { id: "person", label: "Nach Person" },
+  { id: "status", label: "Nach Status" },
+];
+
+/** "Nach Person" / "Nach Status" grouping toggle (issue #46). */
+export default function BoardGroupToggle({
+  value,
+  onChange,
+}: {
+  value: GroupBy;
+  onChange: (next: GroupBy) => void;
+}) {
+  return (
+    <div className="flex gap-2">
+      {OPTIONS.map((o) => {
+        const active = value === o.id;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(o.id)}
+            className="rounded-full px-4 py-1.5 text-sm font-bold"
+            style={
+              active
+                ? { background: "var(--accent)", color: "#fff" }
+                : { background: "var(--bg-card)", color: "var(--text-dim)" }
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import Avatar from "../Avatar";
+import BoardGroupToggle from "./BoardGroupToggle";
+import TodoCard from "./TodoCard";
+import { buildColumns, type BoardColumn, type GroupBy } from "./columns";
+
+/** Desktop Board view (issue #46): horizontal columns with HTML5 drag & drop. */
+export default function BoardView() {
+  const { todos, loading, setWaitingOn, setCompleted } = useTodos();
+  const { activeSpace } = useSpaces();
+  const { user } = useAuth();
+  const nameOf = useSpaceMemberNames();
+  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
+
+  const [groupBy, setGroupBy] = useState<GroupBy>("person");
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        groupBy,
+        todos,
+        members: activeSpace?.members ?? [],
+        currentUid: user?.uid,
+        nameOf,
+        setWaitingOn,
+        setCompleted,
+      }),
+    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setCompleted]
+  );
+
+  const onDrop = async (col: BoardColumn) => {
+    const id = dragId;
+    setDragId(null);
+    setDragOver(null);
+    if (id && col.apply) await col.apply(id);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <span className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Gruppieren</span>
+        <BoardGroupToggle value={groupBy} onChange={setGroupBy} />
+        <span className="ml-auto text-xs text-text-dim">Karten ziehen, um sie zu verschieben</span>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-text-dim">Lädt …</p>
+      ) : (
+        <div
+          className="grid gap-3 overflow-x-auto pb-2"
+          style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(190px, 1fr))` }}
+        >
+          {columns.map((col) => (
+            <div
+              key={col.id}
+              onDragOver={(e) => {
+                if (col.apply) {
+                  e.preventDefault();
+                  setDragOver(col.id);
+                }
+              }}
+              onDragLeave={() => setDragOver((o) => (o === col.id ? null : o))}
+              onDrop={() => onDrop(col)}
+              className="flex flex-col gap-2 p-2"
+              style={{
+                border: `1.5px dashed ${dragOver === col.id ? accent : "var(--border)"}`,
+                borderRadius: 16,
+                minHeight: 240,
+                background: dragOver === col.id ? "var(--row-hover)" : "transparent",
+                transition: "background 0.15s, border-color 0.15s",
+              }}
+            >
+              <div className="flex items-center gap-2 px-1 pb-1">
+                {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
+                <span className="text-xs font-extrabold uppercase tracking-wide text-text-dim">{col.label}</span>
+                {col.todos.length > 0 && <span className="ml-auto text-xs text-text-dim">{col.todos.length}</span>}
+              </div>
+              {col.todos.map((t) => (
+                <TodoCard
+                  key={t.id}
+                  todo={t}
+                  accent={accent}
+                  nameOf={nameOf}
+                  draggable
+                  onDragStart={() => setDragId(t.id)}
+                />
+              ))}
+              {col.todos.length === 0 && col.apply && (
+                <p className="px-1 py-4 text-center text-xs text-text-dim">Karten hierher ziehen</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/board/MobileBoard.tsx
+++ b/src/components/shell/board/MobileBoard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import Avatar from "../Avatar";
+import BottomSheet from "../BottomSheet";
+import BoardGroupToggle from "./BoardGroupToggle";
+import TodoCard from "./TodoCard";
+import { buildColumns, type GroupBy } from "./columns";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Mobile Board (issue #46): columns stacked vertically; instead of drag & drop,
+ * each card has a "Verschieben" sheet listing the other columns as targets.
+ */
+export default function MobileBoard() {
+  const { todos, loading, setWaitingOn, setCompleted } = useTodos();
+  const { activeSpace } = useSpaces();
+  const { user } = useAuth();
+  const nameOf = useSpaceMemberNames();
+  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
+
+  const [groupBy, setGroupBy] = useState<GroupBy>("person");
+  const [moveCard, setMoveCard] = useState<Todo | null>(null);
+
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        groupBy,
+        todos,
+        members: activeSpace?.members ?? [],
+        currentUid: user?.uid,
+        nameOf,
+        setWaitingOn,
+        setCompleted,
+      }),
+    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setCompleted]
+  );
+
+  const targets = columns.filter((c) => c.apply);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <BoardGroupToggle value={groupBy} onChange={setGroupBy} />
+
+      {loading ? (
+        <p className="text-sm text-text-dim">Lädt …</p>
+      ) : (
+        columns.map((col) => (
+          <section key={col.id} className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
+              <span className="text-xs font-extrabold uppercase tracking-wide text-text-dim">{col.label}</span>
+              {col.todos.length > 0 && <span className="ml-auto text-xs text-text-dim">{col.todos.length}</span>}
+            </div>
+            {col.todos.map((t) => (
+              <TodoCard key={t.id} todo={t} accent={accent} nameOf={nameOf} onMove={() => setMoveCard(t)} />
+            ))}
+            {col.todos.length === 0 && <p className="text-xs text-text-dim">—</p>}
+          </section>
+        ))
+      )}
+
+      <BottomSheet open={!!moveCard} onClose={() => setMoveCard(null)} title="Verschieben">
+        <div className="flex flex-col">
+          {targets.map((col) => (
+            <button
+              key={col.id}
+              type="button"
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover"
+              style={{ minHeight: 44 }}
+              onClick={async () => {
+                if (moveCard && col.apply) await col.apply(moveCard.id);
+                setMoveCard(null);
+              }}
+            >
+              {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
+              {col.label}
+            </button>
+          ))}
+        </div>
+      </BottomSheet>
+    </div>
+  );
+}

--- a/src/components/shell/board/TodoCard.tsx
+++ b/src/components/shell/board/TodoCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { checklistProgress } from "@/lib/utils/checklist";
+import Avatar from "../Avatar";
+import type { Todo } from "@/lib/types";
+
+const TOKEN = /(@[\w]+|#[\w]+)/g;
+
+/** Non-interactive @mention/#tag highlight for board card titles. */
+function highlight(title: string) {
+  return title.split(TOKEN).map((part, i) => {
+    if (part.startsWith("@")) {
+      return (
+        <span key={i} className="rounded px-1" style={{ color: "var(--mention)", background: "var(--mention-bg)" }}>
+          {part}
+        </span>
+      );
+    }
+    if (part.startsWith("#")) {
+      return (
+        <span key={i} className="font-mono" style={{ color: "var(--tag)" }}>
+          {part}
+        </span>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+interface TodoCardProps {
+  todo: Todo;
+  accent: string;
+  nameOf: (uid: string) => string;
+  draggable?: boolean;
+  onDragStart?: () => void;
+  /** Mobile: open the "Verschieben" sheet for this card. */
+  onMove?: () => void;
+}
+
+/** Board card (issue #46): title + progress + "bei X" chip + check circle. */
+export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove }: TodoCardProps) {
+  const { setCompleted } = useTodos();
+  const progress = checklistProgress(todo.body);
+
+  return (
+    <div
+      draggable={draggable}
+      onDragStart={onDragStart}
+      className="flex flex-col gap-2 bg-bg-card p-3 shadow-soft"
+      style={{ borderRadius: 12, cursor: draggable ? "grab" : undefined }}
+    >
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          aria-label={todo.completed ? "Wieder öffnen" : "Erledigen"}
+          onClick={() => setCompleted(todo.id, !todo.completed)}
+          className="mt-0.5 flex shrink-0 items-center justify-center rounded-full"
+          style={{
+            width: 20,
+            height: 20,
+            border: `2px solid ${todo.completed ? accent : "var(--check-border)"}`,
+            background: todo.completed ? accent : "transparent",
+          }}
+        >
+          {todo.completed && <span className="text-white" style={{ fontSize: 11 }}>✓</span>}
+        </button>
+        <span className={`flex-1 text-sm font-bold ${todo.completed ? "line-through opacity-60" : ""}`}>
+          {highlight(todo.title)}
+        </span>
+      </div>
+
+      {(progress.total > 0 || todo.waitingOn) && (
+        <div className="flex flex-wrap items-center gap-2 pl-7">
+          {todo.waitingOn && (
+            <span className="flex items-center gap-1 text-xs text-text-dim">
+              <Avatar uid={todo.waitingOn} name={nameOf(todo.waitingOn)} size={18} /> bei {nameOf(todo.waitingOn)}
+            </span>
+          )}
+          {progress.total > 0 && (
+            <span className="font-mono text-xs text-text-dim">
+              {progress.done}/{progress.total}
+            </span>
+          )}
+        </div>
+      )}
+
+      {onMove && (
+        <button
+          type="button"
+          onClick={onMove}
+          className="self-end rounded-full border border-border px-3 py-1 text-xs font-semibold"
+          style={{ minHeight: 32 }}
+        >
+          Verschieben
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/board/columns.ts
+++ b/src/components/shell/board/columns.ts
@@ -1,0 +1,86 @@
+import type { Todo } from "@/lib/types";
+
+export type GroupBy = "person" | "status";
+
+export interface BoardColumn {
+  id: string;
+  label: string;
+  /** Member uid for the "bei X" avatar (person view). */
+  badgeUid?: string;
+  todos: Todo[];
+  /** Drop / move action for this column; undefined → not a drop target. */
+  apply?: (todoId: string) => Promise<void>;
+}
+
+interface BuildArgs {
+  groupBy: GroupBy;
+  todos: Todo[];
+  members: string[];
+  currentUid: string | undefined;
+  nameOf: (uid: string) => string;
+  setWaitingOn: (id: string, waitingOn: string | null) => Promise<void>;
+  setCompleted: (id: string, completed: boolean) => Promise<void>;
+}
+
+/**
+ * Builds the board columns for the active grouping (issue #46).
+ * - Person: OFFEN (no waitingOn) + one "bei X" column per member; dropping sets waitingOn.
+ * - Status: Offen / Wartet / Erledigt; dropping sets completed/waitingOn (Wartet
+ *   needs a person, so it is display-only — move via the person view).
+ */
+export function buildColumns({
+  groupBy,
+  todos,
+  members,
+  currentUid,
+  nameOf,
+  setWaitingOn,
+  setCompleted,
+}: BuildArgs): BoardColumn[] {
+  if (groupBy === "person") {
+    const open = todos.filter((t) => !t.completed);
+    const columns: BoardColumn[] = [
+      {
+        id: "open",
+        label: "Offen",
+        todos: open.filter((t) => !t.waitingOn),
+        apply: (id) => setWaitingOn(id, null),
+      },
+    ];
+    for (const uid of members) {
+      columns.push({
+        id: `member:${uid}`,
+        label: uid === currentUid ? "bei dir" : `bei ${nameOf(uid)}`,
+        badgeUid: uid,
+        todos: open.filter((t) => t.waitingOn === uid),
+        apply: (id) => setWaitingOn(id, uid),
+      });
+    }
+    return columns;
+  }
+
+  // Status grouping
+  return [
+    {
+      id: "offen",
+      label: "Offen",
+      todos: todos.filter((t) => !t.completed && !t.waitingOn),
+      apply: async (id) => {
+        await setWaitingOn(id, null);
+        await setCompleted(id, false);
+      },
+    },
+    {
+      id: "wartet",
+      label: "Wartet",
+      todos: todos.filter((t) => !t.completed && !!t.waitingOn),
+      // No apply: "Wartet" needs a specific person — use the person view to assign.
+    },
+    {
+      id: "erledigt",
+      label: "Erledigt",
+      todos: todos.filter((t) => t.completed),
+      apply: (id) => setCompleted(id, true),
+    },
+  ];
+}

--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -8,23 +8,8 @@ import TodoTitle from "./TodoTitle";
 import TodoBody from "./TodoBody";
 import TodoEditor from "./TodoEditor";
 import TodoActions from "./TodoActions";
+import { checklistProgress } from "@/lib/utils/checklist";
 import type { Todo } from "@/lib/types";
-
-/** Counts task-list checkboxes in a Tiptap body → { done, total }. */
-function checklistProgress(body: unknown): { done: number; total: number } {
-  let done = 0;
-  let total = 0;
-  const walk = (n: any) => {
-    if (!n) return;
-    if (n.type === "taskItem") {
-      total++;
-      if (n.attrs?.checked) done++;
-    }
-    if (Array.isArray(n.content)) n.content.forEach(walk);
-  };
-  walk(body);
-  return { done, total };
-}
 
 interface TodoRowProps {
   todo: Todo;

--- a/src/lib/utils/checklist.ts
+++ b/src/lib/utils/checklist.ts
@@ -1,0 +1,15 @@
+/** Counts task-list checkboxes in a Tiptap body → { done, total } (issues #45/#46). */
+export function checklistProgress(body: unknown): { done: number; total: number } {
+  let done = 0;
+  let total = 0;
+  const walk = (n: any) => {
+    if (!n) return;
+    if (n.type === "taskItem") {
+      total++;
+      if (n.attrs?.checked) done++;
+    }
+    if (Array.isArray(n.content)) n.content.forEach(walk);
+  };
+  walk(body);
+  return { done, total };
+}


### PR DESCRIPTION
Setzt **#46** um — die **Board**-Sicht (Kanban) für Desktop & Mobile; teilt `TodosContext` mit der Liste. Teil von #38.

> ⚠️ **Gestapelt auf #44** (PR #58), da beide `WorkspaceContent` + `MobileShell` anfassen. Base = `feature/44-heute`. **Merge-Reihenfolge: #58 → dieser PR.**

## Was
- **`buildColumns`** — **Nach Person:** „Offen" + je Mitglied eine „bei X"-Spalte (Ablegen setzt `waitingOn`). **Nach Status:** „Offen" / „Wartet" / „Erledigt" (Ablegen setzt `completed`/`waitingOn`; „Wartet" ist nur Anzeige, da es eine Person braucht → über die Personen-Ansicht zuweisen).
- **`BoardGroupToggle`** (Nach Person / Nach Status), **`TodoCard`** (Titel mit @/#-Hervorhebung, Fortschritt + „bei X"-Chip, Abhak-Kreis).
- **`BoardView`** (Desktop) — horizontale Spalten (`repeat(N, minmax(190px,1fr))`, dashed Border, min-height 240) mit **HTML5-Drag&Drop**; Ablegen setzt `waitingOn`/`completed`, mit Drag-Over-Highlight + Hinweis „Karten ziehen …".
- **`MobileBoard`** — Spalten **vertikal gestapelt**; statt DnD pro Karte ein **„Verschieben"-Sheet** mit den übrigen Spalten als Zielen.
- `checklistProgress` nach `lib/utils/checklist.ts` extrahiert (von `TodoRow` + Karten genutzt).

Eingehängt in `WorkspaceContent` (Board-View) und `MobileShell` (Board-Tab). Board und Liste lesen/schreiben denselben `TodosContext` → `waitingOn`/`completed`-Änderungen spiegeln sich in beiden.

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅ (`/todos` prerendert).
- Keine `firestore.rules`-Änderung → kein Deploy nötig.
- **Interaktive Abnahme** (Gruppieren, DnD desktop / Verschieben mobil) → live nach Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
