### PR TITLE
feat(migration): lazy migrate legacy todos into the spaces model (#48)

### DIFF
--- a/src/lib/contexts/AuthContext.tsx
+++ b/src/lib/contexts/AuthContext.tsx
@@ -6,7 +6,7 @@ import { User } from "firebase/auth";
 import { auth, db } from "../firebase/firebase";
 import { doc, setDoc, getDoc, onSnapshot, Unsubscribe } from 'firebase/firestore';
 import { useRouter } from 'next/navigation';
-import { upsertPublicProfile } from '../firebase/firebaseUtils';
+import { upsertPublicProfile, migrateLegacyTodos } from '../firebase/firebaseUtils';
 import { useTheme } from './ThemeContext';
 import type { Theme as ThemeValue } from './ThemeContext';
 
@@ -58,8 +58,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               const firestoreTheme = data.theme || 'system';
               debugLog("Setting theme from Firestore snapshot:", firestoreTheme);
               setTheme(firestoreTheme as ThemeValue);
-              
+
               setUser(authUser);
+
+              // One-time lazy migration of legacy users/{uid}/todos into the
+              // spaces model (issue #48). Guarded by a persisted flag + an
+              // in-flight lock inside migrateLegacyTodos; safe to skip-call.
+              if (!data.todosMigratedToSpacesAt) {
+                migrateLegacyTodos(authUser.uid).catch((error) => {
+                  console.error("Error migrating legacy todos:", error);
+                });
+              }
             } else {
               debugLog("User document does not exist, creating...");
               setDoc(userDocRef, {

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -738,4 +738,141 @@ export const cancelOutgoingRequest = async (
   }
 };
 
+// --- Legacy todo migration (issue #48) ---
+// Lazily migrates a user's old users/{uid}/todos into the new spaces model on
+// login (see AuthContext). Strategy:
+//  - own (non-shared) todos → a default "Privat" space (marker: migratedDefault).
+//  - shared todos (sharedWith) → a "Geteilt" space per distinct member set
+//    (owner + sharees; marker: migratedShareKey), so former sharees regain
+//    access via space membership. Trade-off: a sharee now sees ALL todos the
+//    owner shared with that exact same group (per-space, not per-todo, sharing).
+// Non-destructive: legacy docs are kept and tagged `migratedTo`. Idempotent via
+// the per-user flag, per-todo marker, and per-space markers — safe to re-run
+// (e.g. after a partial failure). Rollback: delete the created spaces and clear
+// the user flag / `migratedTo` markers; the original todos are untouched. Export
+// Firestore before relying on the result.
+
+const TODOS_MIGRATION_FLAG = "todosMigratedToSpacesAt";
+// Guards against concurrent runs within a session (the user-doc snapshot can
+// fire repeatedly before the persisted flag is set).
+const migrationInFlight = new Set<string>();
+
+const firstLine = (text: string): string =>
+  (text || "")
+    .split("\n")
+    .map((s) => s.trim())
+    .find(Boolean) ?? "";
+
+const memberSetKey = (members: string[]): string =>
+  [...new Set(members)].sort().join(",");
+
+export const migrateLegacyTodos = async (uid: string): Promise<void> => {
+  if (!uid || migrationInFlight.has(uid)) return;
+  migrationInFlight.add(uid);
+  try {
+    const userRef = doc(db, "users", uid);
+    const userSnap = await getDoc(userRef);
+    if (userSnap.exists() && userSnap.data()?.[TODOS_MIGRATION_FLAG]) return;
+
+    const legacySnap = await getDocs(collection(db, "users", uid, "todos"));
+    if (legacySnap.empty) {
+      await setDoc(userRef, { [TODOS_MIGRATION_FLAG]: serverTimestamp() }, { merge: true });
+      return;
+    }
+
+    // Reuse migration-marked spaces from a previous (partial) run.
+    const spacesSnap = await getDocs(
+      query(collection(db, SPACES_COLLECTION), where("members", "array-contains", uid))
+    );
+    const ownSpaces = spacesSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Array<
+      DocumentData & { id: string }
+    >;
+
+    let privatId =
+      ownSpaces.find((s) => s.migratedDefault === true && s.createdBy === uid)?.id ?? null;
+    if (!privatId) {
+      const ref = await addDoc(collection(db, SPACES_COLLECTION), {
+        name: "Privat",
+        color: getSpaceColor(0).hue,
+        members: [uid],
+        createdBy: uid,
+        createdAt: serverTimestamp(),
+        migratedDefault: true,
+      });
+      privatId = ref.id;
+    }
+
+    const sharedByKey = new Map<string, string>();
+    for (const s of ownSpaces) {
+      if (s.migratedShareKey && s.createdBy === uid) sharedByKey.set(s.migratedShareKey, s.id);
+    }
+
+    let migrated = 0;
+    let order = 0;
+    for (const d of legacySnap.docs) {
+      const data = d.data();
+      if (data.migratedTo) continue; // already migrated this todo
+
+      const sharedWith: string[] = Array.isArray(data.sharedWith)
+        ? data.sharedWith.filter((x: unknown) => typeof x === "string" && x && x !== uid)
+        : [];
+
+      let targetSpaceId: string;
+      if (sharedWith.length === 0) {
+        targetSpaceId = privatId;
+      } else {
+        const members = [uid, ...sharedWith];
+        const key = memberSetKey(members);
+        let sid = sharedByKey.get(key);
+        if (!sid) {
+          const ref = await addDoc(collection(db, SPACES_COLLECTION), {
+            name: "Geteilt",
+            color: getSpaceColor(1).hue,
+            members,
+            createdBy: uid,
+            createdAt: serverTimestamp(),
+            migratedShareKey: key,
+          });
+          sid = ref.id;
+          sharedByKey.set(key, sid);
+        }
+        targetSpaceId = sid;
+      }
+
+      const plain = typeof data.text === "string" ? data.text : "";
+      const body =
+        data.content && typeof data.content === "object" ? (data.content as TiptapContent) : null;
+      const title = firstLine(plain) || "(ohne Titel)";
+      const tags =
+        Array.isArray(data.tags) && data.tags.length ? data.tags : deriveTags(title, body);
+      const mentions = Array.isArray(data.mentionedUsers)
+        ? data.mentionedUsers
+        : deriveMentions(body);
+
+      const newTodoRef = await addDoc(collection(db, SPACES_COLLECTION, targetSpaceId, "todos"), {
+        spaceId: targetSpaceId,
+        title,
+        body,
+        completed: data.completed === true,
+        waitingOn: null,
+        tags,
+        mentions,
+        createdBy: uid,
+        createdAt: serverTimestamp(),
+        order: order++,
+      });
+
+      await updateDoc(doc(db, "users", uid, "todos", d.id), {
+        migratedTo: `${SPACES_COLLECTION}/${targetSpaceId}/todos/${newTodoRef.id}`,
+      });
+      migrated++;
+    }
+
+    await setDoc(userRef, { [TODOS_MIGRATION_FLAG]: serverTimestamp() }, { merge: true });
+    console.log(`[migration] Migrated ${migrated} legacy todo(s) into spaces for user ${uid}.`);
+  } finally {
+    migrationInFlight.delete(uid);
+  }
+};
+
 // --- Add other potential functions like getIncomingContactRequests, getContacts etc. later ---

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -329,6 +329,26 @@ await check('non-member may not delete a daily item', assertFails(
 await check('member may delete a daily item', assertSucceeds(
   deleteDoc(doc(db(ALICE), DAILY_PATH))));
 
+console.log('Legacy todo migration writes (issue #48):');
+await check('owner may create a space with migration marker fields', assertSucceeds(
+  setDoc(doc(db(ALICE), 'spaces/space-mig'), {
+    name: 'Privat', color: 40, members: [ALICE], createdBy: ALICE, createdAt: 1,
+    migratedDefault: true })));
+await check('owner may create a shared migration space (owner + sharee)', assertSucceeds(
+  setDoc(doc(db(ALICE), 'spaces/space-mig-shared'), {
+    name: 'Geteilt', color: 200, members: [ALICE, BOB], createdBy: ALICE, createdAt: 1,
+    migratedShareKey: `${ALICE},${BOB}` })));
+await testEnv.withSecurityRulesDisabled(async (ctx) => {
+  await setDoc(doc(ctx.firestore(), `users/${ALICE}/todos/legacy-1`), {
+    text: 'old todo', content: { type: 'doc', content: [] }, completed: false,
+    sharedWith: [BOB], mentionedUsers: [], tags: [] });
+});
+await check('owner may tag a legacy todo with migratedTo', assertSucceeds(
+  updateDoc(doc(db(ALICE), `users/${ALICE}/todos/legacy-1`), {
+    migratedTo: 'spaces/space-mig/todos/new-1' })));
+await check('owner may set the migration flag on their user doc', assertSucceeds(
+  setDoc(doc(db(ALICE), `users/${ALICE}`), { todosMigratedToSpacesAt: 1 }, { merge: true })));
+
 await testEnv.cleanup();
 
 if (failures > 0) {


### PR DESCRIPTION
Setzt **#48** um — Migration der Altdaten (`users/{uid}/todos`) ins Spaces-Modell. Base = `main`. Teil von #38.

## Entscheidung: Lazy-Migration beim Login (begründet)
Umgesetzt in `AuthContext` (analog zur bestehenden `publicProfiles`-Upsert), **nicht** als Admin-Skript. Gründe:
- Kein Service-Account / kein manueller Skriptlauf — läuft automatisch beim ersten Login.
- Bleibt **innerhalb der Firestore-Rules**: der **Owner** migriert seine eigenen Todos; geteilte Todos landen in einem Space, dessen Mitglieder die früheren Sharees enthalten → Sharees bekommen passiv über Mitgliedschaft Zugriff.

## Strategie
- **Eigene (nicht geteilte) Todos** → Default-Space **„Privat"** (Marker `migratedDefault`).
- **Geteilte Todos** → ein **„Geteilt"**-Space pro distinkter Mitglieder-Menge (Owner + Sharees; Marker `migratedShareKey`).
- Feld-Mapping: `text`→`title` (erste Zeile), `content`→`body`; `completed`/`tags`/`mentions` übernommen, `waitingOn: null`, `order` fortlaufend.

**Trade-off (dokumentiert):** Aus per-Todo-Sharing wird per-Space-Sharing — ein Sharee sieht künftig **alle** Todos, die der Owner mit *genau dieser* Gruppe geteilt hat.

## Sicherheit
- **Non-destruktiv:** Alt-Todos bleiben erhalten und werden nur mit `migratedTo` markiert.
- **Idempotent:** User-Flag `todosMigratedToSpacesAt` + per-Todo-Marker + per-Space-Marker + In-Flight-Lock → mehrfaches Ausführen (auch nach Teilabbruch) schadet nicht.
- **Rollback:** erzeugte Spaces löschen + Flag/`migratedTo`-Marker entfernen; Originale unangetastet. **Vor Verlass auf das Ergebnis: Firestore exportieren.**

## Verifikation
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende Warnungen) · `npm run build` ✅.
- `npm run test:rules` ✅ — neue Assertions bestätigen, dass die Migrations-Schreibvorgänge regelkonform sind (Space mit Marker-Feldern, `migratedTo` am Alt-Todo, User-Flag). **Keine `firestore.rules`-Änderung** → kein Deploy nötig.
- Hinweis: Die eigentliche Lazy-Migration läuft client-seitig beim Login; an echten Altdaten am besten nach Merge einmal einloggen und prüfen (Privat-Space erscheint mit den Alt-Todos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
