### PR TITLE
fix(spaces): clear waitingOn when removing a space member (#63)

### DIFF
--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -100,8 +100,21 @@ export const renameSpace = (spaceId: string, name: string) =>
 export const addSpaceMember = (spaceId: string, uid: string) =>
   updateDoc(doc(db, SPACES_COLLECTION, spaceId), { members: arrayUnion(uid) });
 
-export const removeSpaceMember = (spaceId: string, uid: string) =>
-  updateDoc(doc(db, SPACES_COLLECTION, spaceId), { members: arrayRemove(uid) });
+// Removing a member also clears any todos in the space that were waiting on
+// them. Otherwise such a todo keeps a `waitingOn` pointing at a non-member, and
+// firestore.rules' hasValidWaitingOn() then rejects EVERY subsequent update —
+// the todo can no longer be completed or edited, only deleted (issue #63). Done
+// as one atomic batch so there is never a window where the member is gone but
+// the dangling references remain.
+export const removeSpaceMember = async (spaceId: string, uid: string) => {
+  const stranded = await getDocs(
+    query(todosCol(spaceId), where("waitingOn", "==", uid))
+  );
+  const batch = writeBatch(db);
+  batch.update(doc(db, SPACES_COLLECTION, spaceId), { members: arrayRemove(uid) });
+  stranded.forEach((d) => batch.update(d.ref, { waitingOn: null }));
+  await batch.commit();
+};
 
 // Only the creator may delete (enforced by firestore.rules).
 export const deleteSpace = (spaceId: string) =>


### PR DESCRIPTION
## Problem
`hasValidWaitingOn()` in `firestore.rules` runs on **every** todo update. On a partial `updateDoc`, `request.resource.data` is the merged doc (incl. the old `waitingOn`). `removeSpaceMember` did **not** clean up open `waitingOn` references — so once a member was removed, every `setTodoCompleted`/`editTodoContent` on a todo that was waiting on that person failed with **permission-denied**. The todo became uneditable/uncompletable (only deletable). **CONFIRMED** in the code review.

## Fix
`removeSpaceMember` now runs an **atomic `writeBatch`** that:
1. removes the member from `spaces/{id}.members`, and
2. sets `waitingOn = null` on every todo in the space where `waitingOn == removedUid`.

Because both happen in one batch, there is no window where the member is gone but the dangling references remain. No `firestore.rules` change is needed — clearing the references is sufficient and keeps the rule strict.

## Notes
- Single-field equality query (`where("waitingOn", "==", uid)`) needs no composite index.
- `removeSpaceMember` is now `async` returning `Promise<void>`; the only caller (`SpacesContext.removeMember`) already `await`s it.

## Test plan
- [x] `npx tsc --noEmit` clean (only stale `.next/types`)
- [x] `npm run lint` clean (only pre-existing `<img>` warnings in unrelated files)
- Manual: set a todo waiting on member B, remove B → todo's `waitingOn` clears, todo stays completable/editable.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)