### PR TITLE
fix(spaces): prevent removing the space creator (#64)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,8 +43,10 @@ service cloud.firestore {
     // with me". Membership grants full access to everything in the space.
     // Rights model: any member may read and update (rename, recolor, add/remove
     // members — this is how "+ einladen" works); createdBy/createdAt are
-    // immutable so a member cannot take over or rewrite history; only the
-    // creator may delete the space. Finer-grained roles can be layered on later.
+    // immutable so a member cannot take over or rewrite history; the creator
+    // must stay in members so the space can never be orphaned (only the creator
+    // may delete it); only the creator may delete the space. Finer-grained roles
+    // can be layered on later.
     match /spaces/{spaceId} {
       function isExistingMember() {
         return isAuthenticated() && request.auth.uid in resource.data.members;
@@ -79,7 +81,11 @@ service cloud.firestore {
       allow update: if isExistingMember()
         && isValidSpace()
         && request.resource.data.createdBy == resource.data.createdBy
-        && request.resource.data.createdAt == resource.data.createdAt;
+        && request.resource.data.createdAt == resource.data.createdAt
+        // The creator can never be removed from members — otherwise they lose
+        // read access and, since only the creator may delete, the space (with
+        // all its todos/dailies) becomes orphaned and undeletable (issue #64).
+        && request.resource.data.createdBy in request.resource.data.members;
 
       allow delete: if isAuthenticated()
         && resource.data.createdBy == request.auth.uid;

--- a/src/components/shell/MemberManager.tsx
+++ b/src/components/shell/MemberManager.tsx
@@ -38,6 +38,9 @@ export default function MemberManager() {
 
   const toggle = async (uid: string) => {
     if (pending) return;
+    // The creator must stay a member: removing them orphans the space (only the
+    // creator may delete it). firestore.rules enforces this too (issue #64).
+    if (uid === activeSpace.createdBy) return;
     setPending(uid);
     try {
       if (members.includes(uid)) await removeMember(activeSpace.id, uid);
@@ -61,19 +64,28 @@ export default function MemberManager() {
       ) : (
         contacts.map((contact) => {
           const isMember = members.includes(contact.uid);
+          const isCreator = contact.uid === activeSpace.createdBy;
           return (
             <button
               key={contact.uid}
               type="button"
               onClick={() => toggle(contact.uid)}
-              disabled={pending === contact.uid}
-              className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-left hover:bg-row-hover disabled:opacity-60"
+              disabled={pending === contact.uid || isCreator}
+              title={isCreator ? "Ersteller kann nicht entfernt werden" : undefined}
+              className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-left ${
+                isCreator ? "cursor-default" : "hover:bg-row-hover"
+              } ${pending === contact.uid ? "opacity-60" : ""}`}
               style={{ minHeight: 44 }}
             >
               <Avatar uid={contact.uid} name={contact.displayName} size={26} />
               <span className="flex-1 truncate text-sm font-semibold">
                 {contact.displayName ?? contact.email ?? "Unbekannt"}
               </span>
+              {isCreator && (
+                <span className="text-[10px] font-bold uppercase tracking-wide text-text-dim">
+                  Ersteller
+                </span>
+              )}
               <span
                 className="text-accent"
                 style={{ visibility: isMember ? "visible" : "hidden" }}

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -232,6 +232,16 @@ await check('member may not set members to a non-list', assertFails(
 await check('member may invite another member', assertSucceeds(
   updateDoc(doc(db(BOB), SPACE_PATH), { members: [ALICE, BOB, MALLORY] })));
 
+// Creator may never be removed from members (issue #64) — otherwise the space
+// is orphaned and undeletable. These run after a reset to a clean [ALICE, BOB].
+await resetSpace();
+await check('member may not remove the creator (orphan)', assertFails(
+  updateDoc(doc(db(BOB), SPACE_PATH), { members: [BOB] })));
+await check('creator may not remove themselves', assertFails(
+  updateDoc(doc(db(ALICE), SPACE_PATH), { members: [BOB] })));
+await check('member may remove a non-creator member', assertSucceeds(
+  updateDoc(doc(db(ALICE), SPACE_PATH), { members: [ALICE] })));
+
 console.log('  delete:');
 await resetSpace();
 await check('non-creator member may not delete the space', assertFails(


### PR DESCRIPTION
## Problem
The rules let **any member** rewrite `members`, and `MemberManager` rendered every contact-member with a remove toggle — **including the creator**. If a member removed the creator, the creator lost read access and, since **only the creator may delete** a space, the space plus all its todos/dailies became **orphaned and undeletable**.

## Fix
- **`firestore.rules`** — the space `update` rule now also requires `createdBy in members`. Combined with the existing immutability of `createdBy`, the creator can never be removed from the member list (and the space can therefore never be orphaned). This also covers the "last member" case: the creator is always present.
- **`MemberManager.tsx`** — the creator's row is no longer a toggle: the button is `disabled`, labelled **„Ersteller"**, shows no hover affordance, and `toggle()` early-returns for the creator UID as a belt-and-braces guard.
- **tests** — added: a member may not remove the creator; the creator may not remove themselves; a non-creator member can still be removed.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] Firestore + Storage rules suites pass in the emulator (firebase-tools@13, Java 11) — incl. the 3 new creator-protection cases

## Deploy note
Needs `firebase deploy --only firestore:rules`. Order-independent here: the tightened rule only blocks an action the new UI no longer offers, so deploying before/after the app is both safe.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)