### PR TITLE
fix(migration): make legacy-todo migration safe under concurrent login (#65)

### DIFF
--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -17,6 +17,7 @@ import {
   where,
   serverTimestamp,
   writeBatch,
+  runTransaction,
   limit,
   orderBy,
   arrayUnion,
@@ -733,6 +734,14 @@ export const cancelOutgoingRequest = async (
 // (e.g. after a partial failure). Rollback: delete the created spaces and clear
 // the user flag / `migratedTo` markers; the original todos are untouched. Export
 // Firestore before relying on the result.
+//
+// Concurrency (issue #65): two tabs/devices logging in at the same time both
+// pass the flag check, so the run must be safe to execute twice in parallel.
+// Two guarantees make it so: (1) migration spaces use DETERMINISTIC ids and are
+// created via an ensure-if-absent transaction, so concurrent runs converge on
+// the same space instead of each forging its own; (2) each legacy todo is
+// migrated inside its OWN transaction that re-reads the `migratedTo` marker
+// before writing, so the loser of a race skips instead of creating a duplicate.
 
 const TODOS_MIGRATION_FLAG = "todosMigratedToSpacesAt";
 // Guards against concurrent runs within a session (the user-doc snapshot can
@@ -748,6 +757,13 @@ const firstLine = (text: string): string =>
 const memberSetKey = (members: string[]): string =>
   [...new Set(members)].sort().join(",");
 
+// Deterministic id for a migration space, so concurrent runs target the SAME
+// doc. `key` is null for the default "Privat" space and the member-set key for a
+// "Geteilt" space; non-alphanumerics are collapsed since uids may be joined by
+// commas and doc ids must not contain "/".
+const migrationSpaceId = (uid: string, key: string | null): string =>
+  `mig_${uid}_${(key ?? "privat").replace(/[^A-Za-z0-9]+/g, "_")}`;
+
 export const migrateLegacyTodos = async (uid: string): Promise<void> => {
   if (!uid || migrationInFlight.has(uid)) return;
   migrationInFlight.add(uid);
@@ -762,32 +778,45 @@ export const migrateLegacyTodos = async (uid: string): Promise<void> => {
       return;
     }
 
-    // Reuse migration-marked spaces from a previous (partial) run.
+    // Prefer a space already created by a previous (possibly old-style, random-
+    // id) migration run; otherwise fall back to the deterministic id.
     const spacesSnap = await getDocs(
       query(collection(db, SPACES_COLLECTION), where("members", "array-contains", uid))
     );
     const ownSpaces = spacesSnap.docs.map((d) => ({ id: d.id, ...d.data() })) as Array<
       DocumentData & { id: string }
     >;
-
-    let privatId =
-      ownSpaces.find((s) => s.migratedDefault === true && s.createdBy === uid)?.id ?? null;
-    if (!privatId) {
-      const ref = await addDoc(collection(db, SPACES_COLLECTION), {
-        name: "Privat",
-        color: getSpaceColor(0).hue,
-        members: [uid],
-        createdBy: uid,
-        createdAt: serverTimestamp(),
-        migratedDefault: true,
-      });
-      privatId = ref.id;
-    }
-
-    const sharedByKey = new Map<string, string>();
+    const existingDefault = ownSpaces.find(
+      (s) => s.migratedDefault === true && s.createdBy === uid
+    )?.id;
+    const existingShared = new Map<string, string>();
     for (const s of ownSpaces) {
-      if (s.migratedShareKey && s.createdBy === uid) sharedByKey.set(s.migratedShareKey, s.id);
+      if (s.migratedShareKey && s.createdBy === uid) existingShared.set(s.migratedShareKey, s.id);
     }
+
+    // Create a migration space only if it doesn't exist yet, atomically: two
+    // concurrent runs both run this transaction on the same deterministic id, so
+    // exactly one wins the create and the other becomes a no-op (issue #65).
+    const ensuredSpaces = new Set<string>();
+    const ensureSpace = async (
+      spaceId: string,
+      space: { name: string; color: number; members: string[]; marker: Record<string, unknown> }
+    ): Promise<void> => {
+      if (ensuredSpaces.has(spaceId)) return;
+      await runTransaction(db, async (tx) => {
+        const ref = doc(db, SPACES_COLLECTION, spaceId);
+        if ((await tx.get(ref)).exists()) return;
+        tx.set(ref, {
+          name: space.name,
+          color: space.color,
+          members: space.members,
+          createdBy: uid,
+          createdAt: serverTimestamp(),
+          ...space.marker,
+        });
+      });
+      ensuredSpaces.add(spaceId);
+    };
 
     let migrated = 0;
     let order = 0;
@@ -801,24 +830,23 @@ export const migrateLegacyTodos = async (uid: string): Promise<void> => {
 
       let targetSpaceId: string;
       if (sharedWith.length === 0) {
-        targetSpaceId = privatId;
+        targetSpaceId = existingDefault ?? migrationSpaceId(uid, null);
+        await ensureSpace(targetSpaceId, {
+          name: "Privat",
+          color: getSpaceColor(0).hue,
+          members: [uid],
+          marker: { migratedDefault: true },
+        });
       } else {
         const members = [uid, ...sharedWith];
         const key = memberSetKey(members);
-        let sid = sharedByKey.get(key);
-        if (!sid) {
-          const ref = await addDoc(collection(db, SPACES_COLLECTION), {
-            name: "Geteilt",
-            color: getSpaceColor(1).hue,
-            members,
-            createdBy: uid,
-            createdAt: serverTimestamp(),
-            migratedShareKey: key,
-          });
-          sid = ref.id;
-          sharedByKey.set(key, sid);
-        }
-        targetSpaceId = sid;
+        targetSpaceId = existingShared.get(key) ?? migrationSpaceId(uid, key);
+        await ensureSpace(targetSpaceId, {
+          name: "Geteilt",
+          color: getSpaceColor(1).hue,
+          members,
+          marker: { migratedShareKey: key },
+        });
       }
 
       const plain = typeof data.text === "string" ? data.text : "";
@@ -831,23 +859,38 @@ export const migrateLegacyTodos = async (uid: string): Promise<void> => {
         ? data.mentionedUsers
         : deriveMentions(body);
 
-      const newTodoRef = await addDoc(collection(db, SPACES_COLLECTION, targetSpaceId, "todos"), {
-        spaceId: targetSpaceId,
-        title,
-        body,
-        completed: data.completed === true,
-        waitingOn: null,
-        tags,
-        mentions,
-        createdBy: uid,
-        createdAt: serverTimestamp(),
-        order: order++,
+      // One transaction per legacy todo: re-read the marker and, only if still
+      // unmigrated, create the new todo and tag the legacy doc in the same
+      // atomic step. A concurrent run racing on the same todo loses the
+      // transaction, re-reads `migratedTo`, and skips — so no duplicate todo is
+      // ever created (issue #65). The new todo's id is generated client-side so
+      // it can be referenced inside the transaction.
+      const newTodoRef = doc(collection(db, SPACES_COLLECTION, targetSpaceId, "todos"));
+      const created = await runTransaction(db, async (tx) => {
+        const legacyRef = doc(db, "users", uid, "todos", d.id);
+        const fresh = await tx.get(legacyRef);
+        if (!fresh.exists() || fresh.data()?.migratedTo) return false;
+        tx.set(newTodoRef, {
+          spaceId: targetSpaceId,
+          title,
+          body,
+          completed: data.completed === true,
+          waitingOn: null,
+          tags,
+          mentions,
+          createdBy: uid,
+          createdAt: serverTimestamp(),
+          order,
+        });
+        tx.update(legacyRef, {
+          migratedTo: `${SPACES_COLLECTION}/${targetSpaceId}/todos/${newTodoRef.id}`,
+        });
+        return true;
       });
-
-      await updateDoc(doc(db, "users", uid, "todos", d.id), {
-        migratedTo: `${SPACES_COLLECTION}/${targetSpaceId}/todos/${newTodoRef.id}`,
-      });
-      migrated++;
+      if (created) {
+        order++;
+        migrated++;
+      }
     }
 
     await setDoc(userRef, { [TODOS_MIGRATION_FLAG]: serverTimestamp() }, { merge: true });


### PR DESCRIPTION
## Problem
`migrateLegacyTodos` was guarded only by a **module/tab-local** `migrationInFlight` set plus the per-user flag, and the flag check and `migratedTo` markers were **not atomic**. Two tabs/devices logging in at the same time after the deploy both passed the flag check, read the same unmarked legacy todos, and created **duplicate** todos/spaces.

## Fix
Two atomic guarantees make the run safe to execute in parallel:

1. **Deterministic, ensure-if-absent spaces.** Migration spaces now use deterministic ids (`mig_<uid>_privat` / `mig_<uid>_<memberKey>`) and are created in a transaction that only writes if the doc is absent. Concurrent runs converge on the *same* space doc instead of each forging its own. Spaces created by a previous (incl. old random-id) run are still reused via the `migratedDefault`/`migratedShareKey` markers, so already-migrated users are unaffected.
2. **Per-todo transaction.** Each legacy todo is migrated inside its own transaction that re-reads the `migratedTo` marker before writing. The loser of a race re-reads the marker and **skips** — no duplicate todo is ever created. The new todo's id is generated client-side (`doc(collection(...))`) so it can be referenced inside the transaction.

Re-runnability after a partial failure is preserved (per-todo/per-space markers + per-user flag set only at the end).

## No rules change
The migration performs the same rule-permitted writes as before (create space with `createdBy == uid` & `uid in members`; create space todo; tag legacy todo with `migratedTo`). `firestore.rules` is untouched, so the existing migration rules tests still apply.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- Concurrency is client-side logic (no rules/unit-test harness covers it); correctness argued above. Manual: open two tabs on first post-deploy login → single set of todos/spaces, no duplicates.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)