### PR TITLE
fix(board): keep todos with a non-member waitingOn visible in person view (#67)

### DIFF
--- a/src/components/shell/board/columns.ts
+++ b/src/components/shell/board/columns.ts
@@ -24,7 +24,9 @@ interface BuildArgs {
 
 /**
  * Builds the board columns for the active grouping (issue #46).
- * - Person: OFFEN (no waitingOn) + one "bei X" column per member; dropping sets waitingOn.
+ * - Person: OFFEN (no waitingOn, or waitingOn pointing at a non-member) + one
+ *   "bei X" column per member; dropping sets waitingOn. Folding unknown
+ *   waitingOn into OFFEN keeps such todos visible/assignable (issue #67).
  * - Status: Offen / Wartet / Erledigt; dropping sets completed/waitingOn (Wartet
  *   needs a person, so it is display-only — move via the person view).
  */
@@ -39,11 +41,15 @@ export function buildColumns({
 }: BuildArgs): BoardColumn[] {
   if (groupBy === "person") {
     const open = todos.filter((t) => !t.completed);
+    const memberSet = new Set(members);
     const columns: BoardColumn[] = [
       {
         id: "open",
         label: "Offen",
-        todos: open.filter((t) => !t.waitingOn),
+        // No waitingOn, OR waitingOn pointing at someone who is no longer a
+        // member: such todos have no "bei X" column, so they must surface here
+        // rather than vanishing from the board (issue #67).
+        todos: open.filter((t) => !t.waitingOn || !memberSet.has(t.waitingOn)),
         apply: (id) => setWaitingOn(id, null),
       },
     ];


### PR DESCRIPTION
## Problem
In the Board **person** grouping, the "Offen" column filtered `!waitingOn` and each member column filtered `waitingOn === uid`. A todo whose `waitingOn` pointed at a **removed or foreign uid** matched **no** column and disappeared from the board entirely (and, before #63, couldn't even be reassigned).

## Fix
The "Offen" column now also catches open todos whose `waitingOn` is **not a current member** (`!waitingOn || !members.has(waitingOn)`). Such todos stay visible and can be dropped back to unassigned (`setWaitingOn(null)`). No extra column added — unknown assignees fold into "Offen", as suggested in the issue.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- Manual: a todo with `waitingOn` = ex-member shows under "Offen" in person view instead of vanishing.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)