### PR TITLE
fix(shell): handle errors + give feedback on redesign mutations (#68)

### DIFF
--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -33,10 +33,16 @@ function NewSpaceForm({ onDone }: { onDone: () => void }) {
     const value = name.trim();
     if (!value) return;
     setBusy(true);
-    await createSpace(value);
-    setBusy(false);
-    setName("");
-    onDone();
+    try {
+      const id = await createSpace(value);
+      // Only clear/close on success; keep the input on failure (toast shown) (#68).
+      if (id) {
+        setName("");
+        onDone();
+      }
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (

--- a/src/components/shell/NewSpaceButton.tsx
+++ b/src/components/shell/NewSpaceButton.tsx
@@ -25,10 +25,17 @@ export default function NewSpaceButton() {
       return;
     }
     setBusy(true);
-    await createSpace(value);
-    setBusy(false);
-    setName("");
-    setEditing(false);
+    try {
+      const id = await createSpace(value);
+      // Keep the input open with the typed name on failure so it can be retried
+      // (createSpace shows an error toast); only clear/close on success (#68).
+      if (id) {
+        setName("");
+        setEditing(false);
+      }
+    } finally {
+      setBusy(false);
+    }
   };
 
   if (!editing) {

--- a/src/components/shell/heute/HeuteInput.tsx
+++ b/src/components/shell/heute/HeuteInput.tsx
@@ -26,11 +26,11 @@ export default function HeuteInput() {
     setValue(value.replace(/@(\w*)$/, `@${resolver.firstName(uid)} `));
   };
 
-  const send = () => {
+  const send = async () => {
     const text = value.trim();
     if (!text) return;
-    setValue("");
-    add(text);
+    // Clear only after a successful write so the text isn't lost on failure (#68).
+    if (await add(text)) setValue("");
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {

--- a/src/components/shell/heute/HeuteList.tsx
+++ b/src/components/shell/heute/HeuteList.tsx
@@ -92,7 +92,10 @@ export default function HeuteList() {
   const resolver = useMemberResolver();
 
   const promote = async (d: Daily) => {
-    await createTodo({ title: d.text });
+    // Only remove the daily once the todo actually exists — otherwise a failed
+    // createTodo would still delete the daily and lose it (#68). createTodo
+    // shows its own error toast on failure.
+    if (!(await createTodo({ title: d.text }))) return;
     await remove(d.id);
     showToast("In die Liste übernommen.");
   };

--- a/src/components/shell/list/MobileTodos.tsx
+++ b/src/components/shell/list/MobileTodos.tsx
@@ -80,8 +80,8 @@ export default function MobileTodos() {
             submitLabel="Speichern"
             onCancel={() => setEditFor(null)}
             onSave={async (title, body) => {
-              await editContent(editFor.id, title, body);
-              setEditFor(null);
+              // Keep the editor open (edit intact) if the save fails (#68).
+              if (await editContent(editFor.id, title, body)) setEditFor(null);
             }}
           />
         )}

--- a/src/components/shell/list/TodoComposer.tsx
+++ b/src/components/shell/list/TodoComposer.tsx
@@ -20,8 +20,8 @@ export default function TodoComposer() {
   const quickAdd = async () => {
     const value = quick.trim();
     if (!value) return;
-    setQuick("");
-    await createTodo({ title: value });
+    // Clear only after a successful write so the text isn't lost on failure (#68).
+    if (await createTodo({ title: value })) setQuick("");
   };
 
   if (open) {
@@ -31,8 +31,8 @@ export default function TodoComposer() {
         submitLabel="Hinzufügen"
         onCancel={() => setOpen(false)}
         onSave={async (title, body) => {
-          await createTodo({ title, body });
-          setOpen(false);
+          // Keep the editor open (draft intact) if the write fails (#68).
+          if (await createTodo({ title, body })) setOpen(false);
         }}
       />
     );

--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -50,8 +50,8 @@ export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActio
         initialBody={todo.body}
         onCancel={() => setEditing(false)}
         onSave={async (title, body) => {
-          await editContent(todo.id, title, body);
-          setEditing(false);
+          // Keep the editor open (edit intact) if the save fails (#68).
+          if (await editContent(todo.id, title, body)) setEditing(false);
         }}
       />
     );

--- a/src/lib/contexts/DailyContext.tsx
+++ b/src/lib/contexts/DailyContext.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getOpenDailyForSpace,
   createDaily,
@@ -27,7 +28,8 @@ interface DailyContextType {
   /** Open daily items from before today ("liegengeblieben"). */
   stale: Daily[];
   loading: boolean;
-  add: (text: string) => Promise<void>;
+  /** Returns true on success; on failure shows an error toast and returns false. */
+  add: (text: string) => Promise<boolean>;
   setCompleted: (id: string, completed: boolean) => Promise<void>;
   remove: (id: string) => Promise<void>;
   refresh: () => Promise<void>;
@@ -42,6 +44,7 @@ const DailyContext = createContext<DailyContextType | undefined>(undefined);
 export const DailyProvider = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
   const { activeSpaceId } = useSpaces();
+  const { showError } = useToast();
   const [items, setItems] = useState<Daily[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -66,30 +69,47 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
   const stale = useMemo(() => items.filter((d) => isStaleDaily(d, todayStr)), [items, todayStr]);
 
   const add = useCallback(
-    async (text: string) => {
-      if (!activeSpaceId || !user || !text.trim()) return;
-      await createDaily(activeSpaceId, user.uid, text);
-      await refresh();
+    async (text: string): Promise<boolean> => {
+      if (!activeSpaceId || !user || !text.trim()) return false;
+      try {
+        await createDaily(activeSpaceId, user.uid, text);
+        await refresh();
+        return true;
+      } catch (e) {
+        console.error("daily add failed", e);
+        showError("Konnte nicht gesendet werden.");
+        return false;
+      }
     },
-    [activeSpaceId, user, refresh]
+    [activeSpaceId, user, refresh, showError]
   );
 
   const setCompleted = useCallback(
     async (id: string, completed: boolean) => {
       if (!activeSpaceId) return;
-      await setDailyCompleted(activeSpaceId, id, completed);
-      await refresh();
+      try {
+        await setDailyCompleted(activeSpaceId, id, completed);
+        await refresh();
+      } catch (e) {
+        console.error("daily setCompleted failed", e);
+        showError("Status konnte nicht geändert werden.");
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const remove = useCallback(
     async (id: string) => {
       if (!activeSpaceId) return;
-      await deleteDaily(activeSpaceId, id);
-      await refresh();
+      try {
+        await deleteDaily(activeSpaceId, id);
+        await refresh();
+      } catch (e) {
+        console.error("daily remove failed", e);
+        showError("Konnte nicht gelöscht werden.");
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const value: DailyContextType = { today, stale, loading, add, setCompleted, remove, refresh };

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -9,6 +9,7 @@ import React, {
   ReactNode,
 } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getSpacesForUser,
   getOpenTodoCount,
@@ -48,6 +49,7 @@ const SpacesContext = createContext<SpacesContextType | undefined>(undefined);
  */
 export const SpacesProvider = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
+  const { showError } = useToast();
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
@@ -92,28 +94,44 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
   const createSpace = useCallback(
     async (name: string): Promise<string | null> => {
       if (!user || !name.trim()) return null;
-      const id = await createSpaceDoc(user.uid, name, spaces.length);
-      await refreshSpaces();
-      setActiveSpaceId(id);
-      return id;
+      try {
+        const id = await createSpaceDoc(user.uid, name, spaces.length);
+        await refreshSpaces();
+        setActiveSpaceId(id);
+        return id;
+      } catch (e) {
+        console.error("createSpace failed", e);
+        showError("Space konnte nicht erstellt werden.");
+        return null;
+      }
     },
-    [user, spaces.length, refreshSpaces]
+    [user, spaces.length, refreshSpaces, showError]
   );
 
   const addMember = useCallback(
     async (spaceId: string, uid: string) => {
-      await addSpaceMember(spaceId, uid);
-      await refreshSpaces();
+      try {
+        await addSpaceMember(spaceId, uid);
+        await refreshSpaces();
+      } catch (e) {
+        console.error("addMember failed", e);
+        showError("Mitglied konnte nicht hinzugefügt werden.");
+      }
     },
-    [refreshSpaces]
+    [refreshSpaces, showError]
   );
 
   const removeMember = useCallback(
     async (spaceId: string, uid: string) => {
-      await removeSpaceMember(spaceId, uid);
-      await refreshSpaces();
+      try {
+        await removeSpaceMember(spaceId, uid);
+        await refreshSpaces();
+      } catch (e) {
+        console.error("removeMember failed", e);
+        showError("Mitglied konnte nicht entfernt werden.");
+      }
     },
-    [refreshSpaces]
+    [refreshSpaces, showError]
   );
 
   const setOpenCount = useCallback((spaceId: string, count: number) => {

--- a/src/lib/contexts/ToastContext.tsx
+++ b/src/lib/contexts/ToastContext.tsx
@@ -9,40 +9,53 @@ import React, {
   ReactNode,
 } from "react";
 
+type ToastVariant = "info" | "error";
+
 interface ToastContextType {
-  /** Show a transient confirmation toast (auto-hides after 2600ms). */
+  /** Show a transient confirmation toast (auto-hides). */
   showToast: (message: string) => void;
+  /** Show a transient error toast (danger style, hides a bit slower). */
+  showError: (message: string) => void;
 }
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
-const AUTO_HIDE_MS = 2600;
+const AUTO_HIDE_MS: Record<ToastVariant, number> = { info: 2600, error: 4500 };
 
 /**
  * App-wide toast primitive (issue #43). Features call `showToast(...)` for
- * short confirmations (e.g. "In die Liste übernommen."). Rendered fixed at the
- * bottom center, above the mobile tab bar.
+ * short confirmations (e.g. "In die Liste übernommen.") and `showError(...)`
+ * for failed mutations (issue #68 — write failures must never be silent).
+ * Rendered fixed at the bottom center, above the mobile tab bar.
  */
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [message, setMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ message: string; variant: ToastVariant } | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const showToast = useCallback((msg: string) => {
-    setMessage(msg);
+  const show = useCallback((message: string, variant: ToastVariant) => {
+    setToast({ message, variant });
     if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => setMessage(null), AUTO_HIDE_MS);
+    timer.current = setTimeout(() => setToast(null), AUTO_HIDE_MS[variant]);
   }, []);
 
+  const showToast = useCallback((msg: string) => show(msg, "info"), [show]);
+  const showError = useCallback((msg: string) => show(msg, "error"), [show]);
+
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={{ showToast, showError }}>
       {children}
-      {message && (
+      {toast && (
         <div
-          className="fixed left-1/2 z-[60] -translate-x-1/2 rounded-full bg-bg-pop px-4 py-2 text-sm font-semibold shadow-soft"
-          style={{ bottom: "calc(env(safe-area-inset-bottom, 0px) + 86px)" }}
-          role="status"
+          className={`fixed left-1/2 z-[60] -translate-x-1/2 rounded-full px-4 py-2 text-sm font-semibold shadow-soft ${
+            toast.variant === "error" ? "text-white" : "bg-bg-pop"
+          }`}
+          style={{
+            bottom: "calc(env(safe-area-inset-bottom, 0px) + 86px)",
+            ...(toast.variant === "error" ? { background: "var(--danger)" } : {}),
+          }}
+          role={toast.variant === "error" ? "alert" : "status"}
         >
-          {message}
+          {toast.message}
         </div>
       )}
     </ToastContext.Provider>

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getTodosForSpace,
   createTodo as createTodoDoc,
@@ -37,8 +38,10 @@ interface TodosContextType {
   /** Todos matching the active tag filter (AND), still split open/done by callers. */
   filtered: Todo[];
   refresh: () => Promise<void>;
-  createTodo: (input: CreateTodoInput) => Promise<void>;
-  editContent: (id: string, title: string, body: TiptapContent | null) => Promise<void>;
+  /** Returns true on success; on failure shows an error toast and returns false. */
+  createTodo: (input: CreateTodoInput) => Promise<boolean>;
+  /** Returns true on success; on failure shows an error toast and returns false. */
+  editContent: (id: string, title: string, body: TiptapContent | null) => Promise<boolean>;
   setCompleted: (id: string, completed: boolean) => Promise<void>;
   setWaitingOn: (id: string, waitingOn: string | null) => Promise<void>;
   remove: (id: string) => Promise<void>;
@@ -53,6 +56,7 @@ const TodosContext = createContext<TodosContextType | undefined>(undefined);
 export const TodosProvider = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
   const { activeSpaceId, setOpenCount } = useSpaces();
+  const { showError } = useToast();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(true);
   const [tagFilters, setTagFilters] = useState<string[]>([]);
@@ -97,53 +101,82 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
   }, [todos, tagFilters]);
 
   const createTodo = useCallback(
-    async (input: CreateTodoInput) => {
-      if (!activeSpaceId || !user) return;
-      const maxOrder = todos.reduce((m, t) => Math.max(m, t.order), 0);
-      await createTodoDoc(activeSpaceId, user.uid, {
-        title: input.title,
-        body: input.body ?? null,
-        order: maxOrder + 1,
-      });
-      await refresh();
+    async (input: CreateTodoInput): Promise<boolean> => {
+      if (!activeSpaceId || !user) return false;
+      try {
+        const maxOrder = todos.reduce((m, t) => Math.max(m, t.order), 0);
+        await createTodoDoc(activeSpaceId, user.uid, {
+          title: input.title,
+          body: input.body ?? null,
+          order: maxOrder + 1,
+        });
+        await refresh();
+        return true;
+      } catch (e) {
+        console.error("createTodo failed", e);
+        showError("Todo konnte nicht erstellt werden.");
+        return false;
+      }
     },
-    [activeSpaceId, user, todos, refresh]
+    [activeSpaceId, user, todos, refresh, showError]
   );
 
   const editContent = useCallback(
-    async (id: string, title: string, body: TiptapContent | null) => {
-      if (!activeSpaceId) return;
-      await editTodoContent(activeSpaceId, id, title, body);
-      await refresh();
+    async (id: string, title: string, body: TiptapContent | null): Promise<boolean> => {
+      if (!activeSpaceId) return false;
+      try {
+        await editTodoContent(activeSpaceId, id, title, body);
+        await refresh();
+        return true;
+      } catch (e) {
+        console.error("editContent failed", e);
+        showError("Änderung konnte nicht gespeichert werden.");
+        return false;
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const setCompleted = useCallback(
     async (id: string, completed: boolean) => {
       if (!activeSpaceId) return;
-      await setTodoCompleted(activeSpaceId, id, completed);
-      await refresh();
+      try {
+        await setTodoCompleted(activeSpaceId, id, completed);
+        await refresh();
+      } catch (e) {
+        console.error("setCompleted failed", e);
+        showError("Status konnte nicht geändert werden.");
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const setWaitingOn = useCallback(
     async (id: string, waitingOn: string | null) => {
       if (!activeSpaceId) return;
-      await setTodoWaitingOn(activeSpaceId, id, waitingOn);
-      await refresh();
+      try {
+        await setTodoWaitingOn(activeSpaceId, id, waitingOn);
+        await refresh();
+      } catch (e) {
+        console.error("setWaitingOn failed", e);
+        showError("Zuweisung konnte nicht gespeichert werden.");
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const remove = useCallback(
     async (id: string) => {
       if (!activeSpaceId) return;
-      await deleteTodo(activeSpaceId, id);
-      await refresh();
+      try {
+        await deleteTodo(activeSpaceId, id);
+        await refresh();
+      } catch (e) {
+        console.error("remove failed", e);
+        showError("Todo konnte nicht gelöscht werden.");
+      }
     },
-    [activeSpaceId, refresh]
+    [activeSpaceId, refresh, showError]
   );
 
   const value: TodosContextType = {


### PR DESCRIPTION
## Problem
Every redesign write ran **without try/catch and without user feedback**. The old `ErrorContext`/`reportError` path was removed with the legacy Todo/ShareTodo components and never replaced; `ToastContext` was success-only. So failures vanished silently, and `NewSpaceButton.submit` left its input **permanently disabled** because `setBusy(false)` was never reached after a throw.

## Fix
**Feedback** — `ToastContext` gains an error variant: `showError(msg)` renders a danger-styled toast (`--danger`, white text, `role="alert"`, slightly longer auto-hide) next to the existing `showToast`.

**Centralised error handling** — every mutation in `TodosContext`, `DailyContext` and `SpacesContext` is now wrapped in try/catch and reports failures via `showError` + `console.error`:
- `createTodo`, `editContent`, daily `add` return `Promise<boolean>` (and `createSpace` keeps `string | null`) so callers can branch on success.
- The fire-and-forget mutations (`setCompleted`/`setWaitingOn`/`remove`, daily `setCompleted`/`remove`, `addMember`/`removeMember`) swallow after toasting — so `onClick` handlers never produce unhandled promise rejections, and `columns.ts`/board types stay unchanged.

**Callers commit UI only on success + reset busy in `finally`:**
- `NewSpaceButton` & mobile `NewSpaceForm`: keep the typed name on failure, reset `busy` in `finally`.
- `TodoComposer` quick-add/editor & Heute input: keep the draft on failure.
- `TodoRow` / `MobileTodos` editors: stay open on a failed save.
- `HeuteList.promote`: no longer deletes the daily when the todo couldn't be created (was data loss).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only pre-existing `<img>` warnings)
- Manual: with writes forced to fail (e.g. offline), each action shows an error toast, inputs keep their text, the New-Space input is no longer stuck disabled, and promoting a daily doesn't delete it on failure.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)