### PR TITLE
fix(migration): derive title from rich-text body for editor-only todos (#69)

### DIFF
--- a/scripts/migrate-legacy-todos-admin.mjs
+++ b/scripts/migrate-legacy-todos-admin.mjs
@@ -96,6 +96,18 @@ function firstLine(text) {
     .find(Boolean) ?? "";
 }
 
+// First non-empty block's text of a Tiptap body — title fallback for legacy
+// todos created purely via the editor (empty `text`) (issue #69).
+function firstBodyLine(body) {
+  const blocks = body?.content;
+  if (!Array.isArray(blocks)) return "";
+  for (const block of blocks) {
+    const text = extractPlainText(block).trim();
+    if (text) return text;
+  }
+  return "";
+}
+
 function memberSetKey(members) {
   return [...new Set(members)].sort().join(",");
 }
@@ -190,7 +202,7 @@ export async function migrateOwner(db, uid, { dryRun = false } = {}) {
 
     const plain = typeof data.text === "string" ? data.text : "";
     const body = data.content && typeof data.content === "object" ? data.content : null;
-    const title = firstLine(plain) || "(ohne Titel)";
+    const title = firstLine(plain) || firstBodyLine(body) || "(ohne Titel)";
     const tags = Array.isArray(data.tags) && data.tags.length ? data.tags : deriveTags(title, body);
     const mentions = Array.isArray(data.mentionedUsers) ? data.mentionedUsers : deriveMentions(body);
 

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -27,7 +27,7 @@ import {
   type DocumentData,
 } from "firebase/firestore";
 import { getSpaceColor } from "../theme/colors";
-import { deriveTags, deriveMentions } from "../utils/textUtils";
+import { deriveTags, deriveMentions, extractPlainText } from "../utils/textUtils";
 import type { Space, Todo, Daily, TiptapContent } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
@@ -767,6 +767,19 @@ const firstLine = (text: string): string =>
     .map((s) => s.trim())
     .find(Boolean) ?? "";
 
+// First non-empty block's text of a Tiptap body — used as a title fallback for
+// legacy todos created purely via the editor (empty `text`), so they don't all
+// collapse to "(ohne Titel)" (issue #69).
+const firstBodyLine = (body: TiptapContent | null): string => {
+  const blocks = (body as { content?: unknown[] } | null)?.content;
+  if (!Array.isArray(blocks)) return "";
+  for (const block of blocks) {
+    const text = extractPlainText(block).trim();
+    if (text) return text;
+  }
+  return "";
+};
+
 const memberSetKey = (members: string[]): string =>
   [...new Set(members)].sort().join(",");
 
@@ -865,7 +878,7 @@ export const migrateLegacyTodos = async (uid: string): Promise<void> => {
       const plain = typeof data.text === "string" ? data.text : "";
       const body =
         data.content && typeof data.content === "object" ? (data.content as TiptapContent) : null;
-      const title = firstLine(plain) || "(ohne Titel)";
+      const title = firstLine(plain) || firstBodyLine(body) || "(ohne Titel)";
       const tags =
         Array.isArray(data.tags) && data.tags.length ? data.tags : deriveTags(title, body);
       const mentions = Array.isArray(data.mentionedUsers)

--- a/tests/migration-admin.test.mjs
+++ b/tests/migration-admin.test.mjs
@@ -51,13 +51,22 @@ async function seed() {
     mentionedUsers: [],
     tags: [],
   });
+  // Rich-text-only todo: empty `text`, title must come from the body (#69).
+  await db.collection("users").doc(ALICE).collection("todos").doc("t-richtext").set({
+    text: "",
+    content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Aus dem Editor" }] }] },
+    completed: false,
+    sharedWith: [],
+    mentionedUsers: [],
+    tags: [],
+  });
 }
 
 console.log("Admin migration (issue #66):");
 await seed();
 
 const first = await migrateAllUsers(db, {});
-check("reports 2 migrated todos", first.migratedTodos === 2);
+check("reports 3 migrated todos", first.migratedTodos === 3);
 check("reports 2 spaces created (Privat + Geteilt)", first.spacesCreated === 2);
 
 const privatId = migrationSpaceId(ALICE, null);
@@ -75,9 +84,11 @@ check(
 );
 
 const privTodos = await db.collection("spaces").doc(privatId).collection("todos").get();
-check("Privat space has 1 todo", privTodos.size === 1);
-check("private todo title derived from first line", privTodos.docs[0].data().title === "Privat A");
-check("private todo keeps legacy tag", JSON.stringify(privTodos.docs[0].data().tags) === JSON.stringify(["home"]));
+const privByTitle = Object.fromEntries(privTodos.docs.map((d) => [d.data().title, d.data()]));
+check("Privat space has 2 todos", privTodos.size === 2);
+check("private todo title derived from first line", !!privByTitle["Privat A"]);
+check("private todo keeps legacy tag", JSON.stringify(privByTitle["Privat A"]?.tags) === JSON.stringify(["home"]));
+check("rich-text-only todo gets title from body (#69)", !!privByTitle["Aus dem Editor"]);
 
 const sharedTodos = await db.collection("spaces").doc(sharedId).collection("todos").get();
 check("Geteilt space has 1 todo", sharedTodos.size === 1);
@@ -97,7 +108,7 @@ check("second run migrates nothing (flag set)", second.migratedTodos === 0 && se
 const forced = await migrateAllUsers(db, { force: true });
 check("forced re-run creates no duplicate todos", forced.migratedTodos === 0);
 const privTodos2 = await db.collection("spaces").doc(privatId).collection("todos").get();
-check("Privat space still has exactly 1 todo after re-runs", privTodos2.size === 1);
+check("Privat space still has exactly 2 todos after re-runs", privTodos2.size === 2);
 
 if (failures) {
   console.error(`\n${failures} migration test(s) failed`);


### PR DESCRIPTION
## Problem
Legacy todos created purely via the editor have an empty `text` and carry their content only in `content` (the Tiptap body). The migration set `title = firstLine(text) || "(ohne Titel)"`, so **all** such todos collapsed to the indistinguishable placeholder **"(ohne Titel)"** — identifying text remained only in the collapsed body.

## Fix
Add a `firstBodyLine()` fallback that returns the **first non-empty block's** plain text from the Tiptap body, used before falling back to "(ohne Titel)":

```
title = firstLine(text) || firstBodyLine(body) || "(ohne Titel)"
```

Mirrored in both `firebaseUtils.ts` (client lazy migration) and `scripts/migrate-legacy-todos-admin.mjs` (admin migration) so the two stay in agreement.

## Test
`tests/migration-admin.test.mjs` now seeds a rich-text-only todo (empty `text`, body "Aus dem Editor") and asserts the migrated title is derived from the body.

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:migration` — all assertions pass incl. the new #69 case

## Note
Already-migrated todos are **not** retroactively retitled (their `migratedTo` marker makes re-runs a no-op). This fixes not-yet-migrated users and any future/admin re-run.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)