### PR TITLE
fix(heute): make completing a bubble reversible via an undo toast (#70)

### DIFF
--- a/src/components/shell/heute/HeuteList.tsx
+++ b/src/components/shell/heute/HeuteList.tsx
@@ -100,6 +100,14 @@ export default function HeuteList() {
     showToast("In die Liste übernommen.");
   };
 
+  // Completing a bubble only loads open dailies, so a finished one disappears.
+  // Offer an immediate undo so an accidental tap isn't unrecoverable (#70).
+  const complete = async (d: Daily) => {
+    if (await setCompleted(d.id, true)) {
+      showToast("Erledigt.", { label: "Rückgängig", onAction: () => setCompleted(d.id, false) });
+    }
+  };
+
   if (today.length === 0 && stale.length === 0) {
     return <p className="text-sm text-text-dim">Noch nichts für heute.</p>;
   }
@@ -115,7 +123,7 @@ export default function HeuteList() {
           daily={d}
           currentUid={user?.uid}
           resolver={resolver}
-          onToggle={() => setCompleted(d.id, true)}
+          onToggle={() => complete(d)}
           onDelete={() => remove(d.id)}
         />
       ))}

--- a/src/lib/contexts/DailyContext.tsx
+++ b/src/lib/contexts/DailyContext.tsx
@@ -30,7 +30,8 @@ interface DailyContextType {
   loading: boolean;
   /** Returns true on success; on failure shows an error toast and returns false. */
   add: (text: string) => Promise<boolean>;
-  setCompleted: (id: string, completed: boolean) => Promise<void>;
+  /** Returns true on success; on failure shows an error toast and returns false. */
+  setCompleted: (id: string, completed: boolean) => Promise<boolean>;
   remove: (id: string) => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -85,14 +86,16 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
   );
 
   const setCompleted = useCallback(
-    async (id: string, completed: boolean) => {
-      if (!activeSpaceId) return;
+    async (id: string, completed: boolean): Promise<boolean> => {
+      if (!activeSpaceId) return false;
       try {
         await setDailyCompleted(activeSpaceId, id, completed);
         await refresh();
+        return true;
       } catch (e) {
         console.error("daily setCompleted failed", e);
         showError("Status konnte nicht geändert werden.");
+        return false;
       }
     },
     [activeSpaceId, refresh, showError]

--- a/src/lib/contexts/ToastContext.tsx
+++ b/src/lib/contexts/ToastContext.tsx
@@ -11,9 +11,23 @@ import React, {
 
 type ToastVariant = "info" | "error";
 
+interface ToastAction {
+  label: string;
+  onAction: () => void;
+}
+
+interface ToastState {
+  message: string;
+  variant: ToastVariant;
+  action?: ToastAction;
+}
+
 interface ToastContextType {
-  /** Show a transient confirmation toast (auto-hides). */
-  showToast: (message: string) => void;
+  /**
+   * Show a transient confirmation toast (auto-hides). Pass `action` to render
+   * an inline button (e.g. "Rückgängig" for an undo, issue #70).
+   */
+  showToast: (message: string, action?: ToastAction) => void;
   /** Show a transient error toast (danger style, hides a bit slower). */
   showError: (message: string) => void;
 }
@@ -21,24 +35,36 @@ interface ToastContextType {
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
 const AUTO_HIDE_MS: Record<ToastVariant, number> = { info: 2600, error: 4500 };
+// An actionable toast stays a bit longer so the action is reachable.
+const ACTION_HIDE_MS = 5500;
 
 /**
  * App-wide toast primitive (issue #43). Features call `showToast(...)` for
- * short confirmations (e.g. "In die Liste übernommen.") and `showError(...)`
- * for failed mutations (issue #68 — write failures must never be silent).
- * Rendered fixed at the bottom center, above the mobile tab bar.
+ * short confirmations (e.g. "In die Liste übernommen."), optionally with an
+ * undo action (issue #70), and `showError(...)` for failed mutations (issue
+ * #68 — write failures must never be silent). Rendered fixed at the bottom
+ * center, above the mobile tab bar.
  */
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toast, setToast] = useState<{ message: string; variant: ToastVariant } | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const show = useCallback((message: string, variant: ToastVariant) => {
-    setToast({ message, variant });
+  const dismiss = useCallback(() => {
     if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => setToast(null), AUTO_HIDE_MS[variant]);
+    setToast(null);
   }, []);
 
-  const showToast = useCallback((msg: string) => show(msg, "info"), [show]);
+  const show = useCallback((message: string, variant: ToastVariant, action?: ToastAction) => {
+    setToast({ message, variant, action });
+    if (timer.current) clearTimeout(timer.current);
+    const ms = action ? ACTION_HIDE_MS : AUTO_HIDE_MS[variant];
+    timer.current = setTimeout(() => setToast(null), ms);
+  }, []);
+
+  const showToast = useCallback(
+    (msg: string, action?: ToastAction) => show(msg, "info", action),
+    [show]
+  );
   const showError = useCallback((msg: string) => show(msg, "error"), [show]);
 
   return (
@@ -46,7 +72,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       {children}
       {toast && (
         <div
-          className={`fixed left-1/2 z-[60] -translate-x-1/2 rounded-full px-4 py-2 text-sm font-semibold shadow-soft ${
+          className={`fixed left-1/2 z-[60] flex -translate-x-1/2 items-center gap-3 rounded-full px-4 py-2 text-sm font-semibold shadow-soft ${
             toast.variant === "error" ? "text-white" : "bg-bg-pop"
           }`}
           style={{
@@ -56,6 +82,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
           role={toast.variant === "error" ? "alert" : "status"}
         >
           {toast.message}
+          {toast.action && (
+            <button
+              type="button"
+              onClick={() => {
+                toast.action?.onAction();
+                dismiss();
+              }}
+              className="-mr-1 shrink-0 rounded-full px-2 py-0.5 font-extrabold text-accent-text underline"
+            >
+              {toast.action.label}
+            </button>
+          )}
         </div>
       )}
     </ToastContext.Provider>


### PR DESCRIPTION
## Problem
Completing a Heute bubble called `setCompleted(d.id, true)` one-way, and `getOpenDailyForSpace` only loads `completed == false`. So an accidental tap hid the daily **permanently** — no "done" view, no undo, no confirmation.

## Fix
- **`ToastContext`** — `showToast(message, action?)` now accepts an optional `{ label, onAction }` rendered as an inline button; actionable toasts stay a little longer (`5.5s`) so the action is reachable, and clicking it runs the action and dismisses the toast.
- **`DailyContext`** — `setCompleted` returns a `boolean` (success), mirroring `add`.
- **`HeuteList`** — completing a bubble shows **"Erledigt. · Rückgängig"**; the undo re-opens the daily via `setCompleted(d.id, false)`. The toast appears only on a successful write (otherwise the error toast from the context is shown instead).

## Scope note
The empty/future-`date` edge case mentioned in the issue ("unsichtbar-aber-offen") is deliberately left to the **rules validation in #71**, as the issue itself prescribes.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- Manual: tap a bubble → it disappears and an "Erledigt. · Rückgängig" toast appears; clicking Rückgängig brings it back.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)