### PR TITLE
feat(contexts): live updates via onSnapshot for spaces/todos/daily (#72)

### DIFF
--- a/src/lib/contexts/DailyContext.tsx
+++ b/src/lib/contexts/DailyContext.tsx
@@ -14,6 +14,7 @@ import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getOpenDailyForSpace,
+  subscribeOpenDailyForSpace,
   createDaily,
   setDailyCompleted,
   deleteDaily,
@@ -49,21 +50,41 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
   const [items, setItems] = useState<Daily[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // Manual one-shot reload, kept as a fallback. Live updates flow through the
+  // onSnapshot subscription below (issue #72), so mutations no longer call this.
   const refresh = useCallback(async () => {
     if (!activeSpaceId) {
       setItems([]);
       setLoading(false);
       return;
     }
-    setLoading(true);
     const loaded = await getOpenDailyForSpace(activeSpaceId);
     setItems(loaded);
     setLoading(false);
   }, [activeSpaceId]);
 
+  // Live subscription to the active space's open daily items (issue #72).
   useEffect(() => {
-    refresh();
-  }, [refresh]);
+    if (!activeSpaceId) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const unsubscribe = subscribeOpenDailyForSpace(
+      activeSpaceId,
+      (loaded) => {
+        setItems(loaded);
+        setLoading(false);
+      },
+      (e) => {
+        console.error("daily subscription failed", e);
+        showError("Heute-Einträge konnten nicht geladen werden.");
+        setLoading(false);
+      }
+    );
+    return unsubscribe;
+  }, [activeSpaceId, showError]);
 
   const todayStr = todayString();
   const today = useMemo(() => items.filter((d) => d.date === todayStr), [items, todayStr]);
@@ -74,7 +95,6 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId || !user || !text.trim()) return false;
       try {
         await createDaily(activeSpaceId, user.uid, text);
-        await refresh();
         return true;
       } catch (e) {
         console.error("daily add failed", e);
@@ -82,7 +102,7 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, user, refresh, showError]
+    [activeSpaceId, user, showError]
   );
 
   const setCompleted = useCallback(
@@ -90,7 +110,6 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return false;
       try {
         await setDailyCompleted(activeSpaceId, id, completed);
-        await refresh();
         return true;
       } catch (e) {
         console.error("daily setCompleted failed", e);
@@ -98,7 +117,7 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const remove = useCallback(
@@ -106,13 +125,12 @@ export const DailyProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return;
       try {
         await deleteDaily(activeSpaceId, id);
-        await refresh();
       } catch (e) {
         console.error("daily remove failed", e);
         showError("Konnte nicht gelöscht werden.");
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const value: DailyContextType = { today, stale, loading, add, setCompleted, remove, refresh };

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -12,6 +12,7 @@ import { useAuth } from "@/lib/hooks/useAuth";
 import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getSpacesForUser,
+  subscribeSpacesForUser,
   getOpenTodoCount,
   createSpace as createSpaceDoc,
   addSpaceMember,
@@ -56,6 +57,17 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
   const [openCounts, setOpenCounts] = useState<Record<string, number>>({});
   const [view, setView] = useState<SpaceView>("liste");
 
+  const applyLoaded = useCallback((loaded: Space[]) => {
+    setSpaces(loaded);
+    // Keep the current selection if it still exists, else default to the first.
+    setActiveSpaceId((prev) =>
+      prev && loaded.some((s) => s.id === prev) ? prev : loaded[0]?.id ?? null
+    );
+    setLoading(false);
+  }, []);
+
+  // Manual one-shot reload, kept as a fallback. Live updates flow through the
+  // onSnapshot subscription below (issue #72), so mutations no longer call this.
   const refreshSpaces = useCallback(async () => {
     if (!user) {
       setSpaces([]);
@@ -64,39 +76,60 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
       setLoading(false);
       return;
     }
-    setLoading(true);
-    const loaded = await getSpacesForUser(user.uid);
-    setSpaces(loaded);
-    // Keep the current selection if it still exists, else default to the first.
-    setActiveSpaceId((prev) =>
-      prev && loaded.some((s) => s.id === prev) ? prev : loaded[0]?.id ?? null
-    );
-    setLoading(false);
+    applyLoaded(await getSpacesForUser(user.uid));
+  }, [user, applyLoaded]);
 
-    // Open-todo counts are best-effort: a failure must not break the shell.
-    const counts: Record<string, number> = {};
-    await Promise.all(
-      loaded.map(async (s) => {
-        try {
-          counts[s.id] = await getOpenTodoCount(s.id);
-        } catch {
-          /* ignore per-space count errors */
-        }
-      })
-    );
-    setOpenCounts(counts);
-  }, [user]);
-
+  // Live subscription to the user's spaces (issue #72): a space created, renamed
+  // or shared by a collaborator now appears without a manual reload.
   useEffect(() => {
-    refreshSpaces();
-  }, [refreshSpaces]);
+    if (!user) {
+      setSpaces([]);
+      setActiveSpaceId(null);
+      setOpenCounts({});
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const unsubscribe = subscribeSpacesForUser(user.uid, applyLoaded, (e) => {
+      console.error("spaces subscription failed", e);
+      showError("Spaces konnten nicht geladen werden.");
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, [user, applyLoaded, showError]);
+
+  // Open-todo counts per space (sidebar badges). Best-effort, recomputed when
+  // the set of spaces changes; the active space's count is also kept live by
+  // TodosContext via setOpenCount. A failure must not break the shell.
+  const spaceIdsKey = spaces.map((s) => s.id).join(",");
+  useEffect(() => {
+    if (!spaceIdsKey) return;
+    let cancelled = false;
+    (async () => {
+      const ids = spaceIdsKey.split(",");
+      const counts: Record<string, number> = {};
+      await Promise.all(
+        ids.map(async (id) => {
+          try {
+            counts[id] = await getOpenTodoCount(id);
+          } catch {
+            /* ignore per-space count errors */
+          }
+        })
+      );
+      if (!cancelled) setOpenCounts((prev) => ({ ...prev, ...counts }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [spaceIdsKey]);
 
   const createSpace = useCallback(
     async (name: string): Promise<string | null> => {
       if (!user || !name.trim()) return null;
       try {
         const id = await createSpaceDoc(user.uid, name, spaces.length);
-        await refreshSpaces();
+        // The new space arrives via the live subscription; select it now.
         setActiveSpaceId(id);
         return id;
       } catch (e) {
@@ -105,33 +138,31 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
         return null;
       }
     },
-    [user, spaces.length, refreshSpaces, showError]
+    [user, spaces.length, showError]
   );
 
   const addMember = useCallback(
     async (spaceId: string, uid: string) => {
       try {
         await addSpaceMember(spaceId, uid);
-        await refreshSpaces();
       } catch (e) {
         console.error("addMember failed", e);
         showError("Mitglied konnte nicht hinzugefügt werden.");
       }
     },
-    [refreshSpaces, showError]
+    [showError]
   );
 
   const removeMember = useCallback(
     async (spaceId: string, uid: string) => {
       try {
         await removeSpaceMember(spaceId, uid);
-        await refreshSpaces();
       } catch (e) {
         console.error("removeMember failed", e);
         showError("Mitglied konnte nicht entfernt werden.");
       }
     },
-    [refreshSpaces, showError]
+    [showError]
   );
 
   const setOpenCount = useCallback((spaceId: string, count: number) => {

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -14,6 +14,7 @@ import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useToast } from "@/lib/contexts/ToastContext";
 import {
   getTodosForSpace,
+  subscribeTodosForSpace,
   createTodo as createTodoDoc,
   editTodoContent,
   setTodoCompleted,
@@ -61,24 +62,46 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
   const [loading, setLoading] = useState(true);
   const [tagFilters, setTagFilters] = useState<string[]>([]);
 
+  // Manual one-shot reload, kept as a fallback. Live updates flow through the
+  // onSnapshot subscription below (issue #72), so mutations no longer call this.
   const refresh = useCallback(async () => {
     if (!activeSpaceId) {
       setTodos([]);
       setLoading(false);
       return;
     }
-    setLoading(true);
     const loaded = await getTodosForSpace(activeSpaceId);
     setTodos(loaded);
     setLoading(false);
     setOpenCount(activeSpaceId, loaded.filter((t) => !t.completed).length);
   }, [activeSpaceId, setOpenCount]);
 
-  // Reload + reset filters whenever the active space changes.
+  // Live subscription to the active space's todos (issue #72): collaborators'
+  // edits now appear in real time instead of needing a manual reload. Reset the
+  // tag filter on space switch.
   useEffect(() => {
     setTagFilters([]);
-    refresh();
-  }, [refresh]);
+    if (!activeSpaceId) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const unsubscribe = subscribeTodosForSpace(
+      activeSpaceId,
+      (loaded) => {
+        setTodos(loaded);
+        setLoading(false);
+        setOpenCount(activeSpaceId, loaded.filter((t) => !t.completed).length);
+      },
+      (e) => {
+        console.error("todos subscription failed", e);
+        showError("Todos konnten nicht geladen werden.");
+        setLoading(false);
+      }
+    );
+    return unsubscribe;
+  }, [activeSpaceId, setOpenCount, showError]);
 
   const tags = useMemo(() => {
     const set = new Set<string>();
@@ -110,7 +133,6 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
           body: input.body ?? null,
           order: maxOrder + 1,
         });
-        await refresh();
         return true;
       } catch (e) {
         console.error("createTodo failed", e);
@@ -118,7 +140,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, user, todos, refresh, showError]
+    [activeSpaceId, user, todos, showError]
   );
 
   const editContent = useCallback(
@@ -126,7 +148,6 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return false;
       try {
         await editTodoContent(activeSpaceId, id, title, body);
-        await refresh();
         return true;
       } catch (e) {
         console.error("editContent failed", e);
@@ -134,7 +155,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const setCompleted = useCallback(
@@ -142,13 +163,12 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return;
       try {
         await setTodoCompleted(activeSpaceId, id, completed);
-        await refresh();
       } catch (e) {
         console.error("setCompleted failed", e);
         showError("Status konnte nicht geändert werden.");
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const setWaitingOn = useCallback(
@@ -156,13 +176,12 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return;
       try {
         await setTodoWaitingOn(activeSpaceId, id, waitingOn);
-        await refresh();
       } catch (e) {
         console.error("setWaitingOn failed", e);
         showError("Zuweisung konnte nicht gespeichert werden.");
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const remove = useCallback(
@@ -170,13 +189,12 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
       if (!activeSpaceId) return;
       try {
         await deleteTodo(activeSpaceId, id);
-        await refresh();
       } catch (e) {
         console.error("remove failed", e);
         showError("Todo konnte nicht gelöscht werden.");
       }
     },
-    [activeSpaceId, refresh, showError]
+    [activeSpaceId, showError]
   );
 
   const value: TodosContextType = {

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -23,6 +23,8 @@ import {
   arrayUnion,
   arrayRemove,
   getCountFromServer,
+  onSnapshot,
+  type Unsubscribe,
   type QueryDocumentSnapshot,
   type DocumentData,
 } from "firebase/firestore";
@@ -70,30 +72,44 @@ export const createSpace = async (
   return ref.id;
 };
 
+const mapSpace = (d: QueryDocumentSnapshot<DocumentData>): Space => {
+  const data = d.data();
+  return {
+    id: d.id,
+    name: typeof data.name === "string" ? data.name : "",
+    color: typeof data.color === "number" ? data.color : getSpaceColor(0).hue,
+    members: Array.isArray(data.members) ? data.members : [],
+    createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
+    createdAt: data.createdAt ?? null,
+  } as Space;
+};
+
+// array-contains + orderBy would require a composite index, so sort client-side.
+const sortSpaces = (spaces: Space[]): Space[] =>
+  spaces.sort((a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0));
+
+const spacesForUserQuery = (uid: string) =>
+  query(collection(db, SPACES_COLLECTION), where("members", "array-contains", uid));
+
 // Load every space the user is a member of (oldest first, for stable ordering).
 export const getSpacesForUser = async (uid: string): Promise<Space[]> => {
   if (!uid) return [];
-  const q = query(
-    collection(db, SPACES_COLLECTION),
-    where("members", "array-contains", uid)
-  );
-  const snapshot = await getDocs(q);
-  const spaces = snapshot.docs.map((d) => {
-    const data = d.data();
-    return {
-      id: d.id,
-      name: typeof data.name === "string" ? data.name : "",
-      color: typeof data.color === "number" ? data.color : getSpaceColor(0).hue,
-      members: Array.isArray(data.members) ? data.members : [],
-      createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
-      createdAt: data.createdAt ?? null,
-    } as Space;
-  });
-  // array-contains + orderBy would require a composite index, so sort client-side.
-  return spaces.sort(
-    (a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0)
-  );
+  const snapshot = await getDocs(spacesForUserQuery(uid));
+  return sortSpaces(snapshot.docs.map(mapSpace));
 };
+
+// Live subscription to the user's spaces (issue #72): returns an unsubscribe
+// function. Fires immediately with the current set, then on every change.
+export const subscribeSpacesForUser = (
+  uid: string,
+  onChange: (spaces: Space[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe =>
+  onSnapshot(
+    spacesForUserQuery(uid),
+    (snap) => onChange(sortSpaces(snap.docs.map(mapSpace))),
+    onError
+  );
 
 export const renameSpace = (spaceId: string, name: string) =>
   updateDoc(doc(db, SPACES_COLLECTION, spaceId), { name: name.trim() });
@@ -180,6 +196,19 @@ export const getTodosForSpace = async (spaceId: string): Promise<Todo[]> => {
   const snapshot = await getDocs(query(todosCol(spaceId), orderBy("order", "asc")));
   return snapshot.docs.map(mapTodo);
 };
+
+// Live subscription to a space's todos (issue #72): returns an unsubscribe
+// function and fires on every change so collaborators see edits in real time.
+export const subscribeTodosForSpace = (
+  spaceId: string,
+  onChange: (todos: Todo[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe =>
+  onSnapshot(
+    query(todosCol(spaceId), orderBy("order", "asc")),
+    (snap) => onChange(snap.docs.map(mapTodo)),
+    onError
+  );
 
 // Server-side count of open (not completed) todos — drives the sidebar/pill
 // "open" badge per space without fetching every todo.
@@ -269,15 +298,29 @@ export const createDaily = async (
 
 // Open (not completed) daily items. Single-field filter → no composite index;
 // callers split into today's vs. "liegengeblieben" (date < today) client-side.
+const sortDaily = (items: Daily[]): Daily[] =>
+  items.sort((a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0));
+
 export const getOpenDailyForSpace = async (spaceId: string): Promise<Daily[]> => {
   if (!spaceId) return [];
   const snapshot = await getDocs(
     query(dailyCol(spaceId), where("completed", "==", false))
   );
-  return snapshot.docs
-    .map(mapDaily)
-    .sort((a, b) => (a.createdAt?.toMillis() ?? 0) - (b.createdAt?.toMillis() ?? 0));
+  return sortDaily(snapshot.docs.map(mapDaily));
 };
+
+// Live subscription to a space's open daily items (issue #72): returns an
+// unsubscribe function and fires on every change.
+export const subscribeOpenDailyForSpace = (
+  spaceId: string,
+  onChange: (items: Daily[]) => void,
+  onError?: (error: Error) => void
+): Unsubscribe =>
+  onSnapshot(
+    query(dailyCol(spaceId), where("completed", "==", false)),
+    (snap) => onChange(sortDaily(snap.docs.map(mapDaily))),
+    onError
+  );
 
 // "Liegengeblieben": an open daily item from before today.
 export const isStaleDaily = (d: Daily, today: string = todayString()): boolean =>


### PR DESCRIPTION
## Problem
The data model was rebuilt for multi-person collaboration, but every context read **once** via `getDocs` + manual `refresh()` — **no `onSnapshot`**. Two members in the same space never saw each other's changes until a manual reload, so the redesign's core promise didn't hold live.

## Fix
- **`firebaseUtils`** — add live subscriptions returning an `Unsubscribe`: `subscribeSpacesForUser`, `subscribeTodosForSpace`, `subscribeOpenDailyForSpace` (all `onSnapshot`). Factored out `mapSpace`/`sortSpaces`/`sortDaily` shared with the existing one-shot getters so the live and one-shot paths stay identical.
- **`SpacesContext` / `TodosContext` / `DailyContext`** — subscribe on mount / active-space switch and unsubscribe on cleanup; subscription errors go through `showError`. The manual `refresh()`/`refreshSpaces()` remain as fallbacks but are no longer wired to the effect, and mutations drop their trailing `await refresh()` because the listener now reflects writes automatically (incl. Firestore's optimistic local echo, so the UI still updates instantly).
- **Open-todo counts** moved to a dedicated effect keyed on the space-id set; the active space's badge stays live via `TodosContext.setOpenCount`.

## Notes / trade-offs
- Non-active spaces' badges refresh when the space set changes (not on every remote todo write) — unchanged best-effort behaviour; the broader count optimisation is tracked in #77.
- No `firestore.rules` change; reads were already permitted for members.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (no new warnings; only pre-existing `<img>` ones)
- Manual: two browsers on the same space — creating/completing/editing a todo or sending a Heute item in one reflects in the other without reload.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)