### PR TITLE
fix(list): stop read-only checklist toggle race from reverting edits (#73)

### DIFF
--- a/src/components/shell/list/TodoBody.tsx
+++ b/src/components/shell/list/TodoBody.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import { useTiptapConfig } from "@/lib/hooks/useTiptapConfig";
 import type { TiptapContent } from "@/lib/types";
@@ -23,6 +23,12 @@ export default function TodoBody({
     onReadOnlyChecked: () => true,
   });
 
+  // Serialised states this component itself produced (checkbox toggles). The
+  // sync effect uses it to ignore the delayed echo of our own write, which
+  // would otherwise revert a second toggle made before the first write landed
+  // (issue #73). Bounded — a single body only churns through a few states.
+  const authoredRef = useRef<Set<string>>(new Set());
+
   const editor = useEditor(
     {
       editable: false,
@@ -30,18 +36,28 @@ export default function TodoBody({
       extensions,
       editorProps,
       immediatelyRender: false,
-      onUpdate: ({ editor }) => onChange(editor.getJSON() as TiptapContent),
+      onUpdate: ({ editor }) => {
+        const json = editor.getJSON() as TiptapContent;
+        authoredRef.current.add(JSON.stringify(json));
+        if (authoredRef.current.size > 50) authoredRef.current.clear();
+        onChange(json);
+      },
     },
     []
   );
 
-  // Keep content in sync when the body prop changes externally (e.g. after save).
+  // Keep content in sync when the body prop changes externally (e.g. a
+  // collaborator's edit). Skip echoes of our own toggles so a slower write
+  // round-trip can't clobber a newer local edit (issue #73).
   useEffect(() => {
-    if (editor && !editor.isDestroyed) {
-      const current = JSON.stringify(editor.getJSON());
-      const next = JSON.stringify(body || {});
-      if (current !== next) editor.commands.setContent(body || "", false);
+    if (!editor || editor.isDestroyed) return;
+    const next = JSON.stringify(body || {});
+    if (authoredRef.current.has(next)) {
+      authoredRef.current.delete(next); // consume this echo
+      return;
     }
+    const current = JSON.stringify(editor.getJSON());
+    if (current !== next) editor.commands.setContent(body || "", false);
   }, [body, editor]);
 
   useEffect(() => () => editor?.destroy(), [editor]);


### PR DESCRIPTION
## Problem
Toggling a checkbox in the read-only `TodoBody` fires `onUpdate → onChange → editContent`, which (via the live snapshot, #72, or the old refresh) feeds a new `body` prop back into the sync effect's `setContent`. If a **second** box was toggled before the first write's echo arrived, that delayed `setContent` re-applied the older state and **reverted the second toggle** — a lost edit.

## Fix
`TodoBody` now records the serialised states it authored (`authoredRef`). The sync effect ignores — and consumes — the echo of our own writes, applying `setContent` only for genuinely **external** `body` changes (e.g. a collaborator's edit). The authored set is cleared past 50 entries to stay bounded.

This keeps the interactive checklist responsive to rapid toggles while still syncing in real edits from other members.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- Manual: rapidly toggle two checklist boxes in a todo body → both stick (previously the second reverted); an edit from another browser still syncs in.

Refs #62, #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)