### PR TITLE
fix(rules): scope legacy collection-group todos read rule to the legacy path (#80)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -230,11 +230,26 @@ service cloud.firestore {
       }
     }
 
-    // Single authoritative read rule for todos: covers collection group
-    // queries AND direct reads of users/{uid}/todos/{todoId} (path[1] is the
-    // owner's uid). Owner, sharees and mentioned users may read.
+    // Read rule for LEGACY todos only (users/{uid}/todos/{todoId}; path[1] is the
+    // owner's uid). Owner, sharees and mentioned users may read — via a direct
+    // read or a query scoped to one user's subcollection (e.g. the migration).
+    //
+    // Scoped to path[0] == 'users' (issue #80): the recursive wildcard otherwise
+    // also matches the new spaces/{spaceId}/todos — which have their own
+    // membership-based read rule above. Today space todos carry no sharedWith/
+    // mentionedUsers, so the wildcard grants them nothing; but were such a field
+    // ever added, the legacy `uid in sharedWith` predicate would leak access
+    // beyond space membership. The path scope closes that latent bypass.
+    //
+    // Trade-off: path[0] cannot be guaranteed across a cross-collection
+    // collectionGroup('todos') query, so such queries are no longer permitted.
+    // That is intended — the redesign replaced "shared with me" enumeration with
+    // space membership, and no current client runs a legacy collection-group
+    // query (sharees reach migrated todos through their space).
     match /{path=**}/todos/{todoId} {
-       allow read: if isAuthenticated() && (
+       allow read: if isAuthenticated()
+                    && path[0] == 'users'
+                    && (
                        request.auth.uid == path[1] ||
                        (resource.data.sharedWith != null && request.auth.uid in resource.data.sharedWith) ||
                        (resource.data.mentionedUsers != null && request.auth.uid in resource.data.mentionedUsers)

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -165,10 +165,18 @@ await check('owner may read own todo directly', assertSucceeds(
   getDoc(doc(db(ALICE), TODO_PATH))));
 await check('mentioned user may read the todo directly', assertSucceeds(
   getDoc(doc(db(VICTIM), `users/${ALICE}/todos/todo-mention`))));
-await check('mentioned user may run collection group query', assertSucceeds(
+await check('sharee may read the shared todo directly', assertSucceeds(
+  getDoc(doc(db(BOB), TODO_PATH))));
+await check('owner may run a scoped query over own legacy todos', assertSucceeds(
+  getDocs(collection(db(ALICE), `users/${ALICE}/todos`))));
+// Issue #80: the legacy read rule is scoped to path[0] == 'users', which a
+// cross-collection collectionGroup('todos') query cannot guarantee — so such
+// queries are now denied. This is the deliberate retirement of "shared with me"
+// enumeration; sharees reach migrated todos through their space instead.
+await check('mentioned user may NOT run a collection group query (retired)', assertFails(
   getDocs(query(collectionGroup(db(VICTIM), 'todos'),
     where('mentionedUsers', 'array-contains', VICTIM)))));
-await check('sharee may run collection group query', assertSucceeds(
+await check('sharee may NOT run a collection group query (retired)', assertFails(
   getDocs(query(collectionGroup(db(BOB), 'todos'),
     where('sharedWith', 'array-contains', BOB)))));
 await check('unauthenticated user may not read', assertFails(
@@ -277,6 +285,18 @@ await check('member may list space todos', assertSucceeds(
   getDocs(collection(db(BOB), `spaces/${TS}/todos`))));
 await check('non-member may not list space todos', assertFails(
   getDocs(collection(db(MALLORY), `spaces/${TS}/todos`))));
+// The legacy collection-group read rule is scoped to path[0] == 'users' (issue
+// #80). A space todo that (hypothetically) carried legacy sharedWith/
+// mentionedUsers fields must NOT become readable by a non-member via that
+// wildcard rule — only space membership grants read here.
+await testEnv.withSecurityRulesDisabled(async (ctx) => {
+  await setDoc(doc(ctx.firestore(), `spaces/${TS}/todos/leak`), {
+    spaceId: TS, title: 'secret', body: null, completed: false, waitingOn: null,
+    tags: [], mentions: [], createdBy: ALICE, createdAt: 1, order: 9,
+    sharedWith: [MALLORY], mentionedUsers: [MALLORY] });
+});
+await check('non-member may not read a space todo via legacy sharedWith', assertFails(
+  getDoc(doc(db(MALLORY), `spaces/${TS}/todos/leak`))));
 
 console.log('  todo writes (full collaboration):');
 await check('member (non-creator) may create a todo', assertSucceeds(


### PR DESCRIPTION
Closes #80.

## Problem
The recursive `match /{path=**}/todos/{todoId}` read rule also matches the new `spaces/{spaceId}/todos`. Space todos carry no `sharedWith`/`mentionedUsers` today, so nothing leaks — but it is **latent**: if such a field were ever added to a space todo, the legacy `uid in resource.data.sharedWith` predicate would grant read access beyond space membership.

## Fix
Scope the legacy read rule to `path[0] == 'users'` so it only governs `users/{uid}/todos`.

- ✅ Direct reads (owner / sharee / mentioned) still work.
- ✅ Per-user scoped subcollection queries still work (e.g. the lazy migration reads `users/{uid}/todos`).
- ⛔️ Cross-collection `collectionGroup('todos')` queries are no longer permitted — `path[0]` can't be guaranteed across parents. This deliberately retires legacy "shared with me" enumeration, which the redesign already replaced with space membership. No current client runs such a query (`grep collectionGroup src/` → 0 hits).

## Tests
`tests/firestore-rules.test.mjs`:
- legacy direct + scoped reads still pass,
- the two collection-group queries are now asserted as **denied**,
- a space todo carrying hypothetical legacy `sharedWith`/`mentionedUsers` is **not** readable by a non-member.

All rules tests pass under the Firestore emulator (`firebase-tools@13`, Java 11).

> ℹ️ Rules change only — deploy with `npx -y firebase-tools@13 deploy --only firestore:rules` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)