### PR TITLE
fix(list): keep tag filter from stranding the list when a tag disappears (#74)

### DIFF
--- a/src/components/shell/list/TagFilterBar.tsx
+++ b/src/components/shell/list/TagFilterBar.tsx
@@ -9,7 +9,10 @@ import { useTodos } from "@/lib/contexts/TodosContext";
  */
 export default function TagFilterBar() {
   const { tags, tagFilters, toggleTag, clearTags } = useTodos();
-  if (tags.length === 0) return null;
+  // Render while there are tags to pick OR a filter is still active, so the
+  // "✕ Filter" reset stays reachable even if the last filtered tag just vanished
+  // (issue #74) — otherwise the list could be stuck empty with no affordance.
+  if (tags.length === 0 && tagFilters.length === 0) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -109,6 +109,19 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     return [...set].sort();
   }, [todos]);
 
+  // Drop filters for tags that no longer exist on any todo (issue #74): deleting
+  // or renaming the last todo carrying a filtered tag removes it from `tags`, so
+  // a stale filter would otherwise keep the list empty with no way to recover
+  // (TagFilterBar renders no chips when there are no tags). Pruning the state
+  // keeps the chips honest and stops a vanished tag from silently re-activating
+  // if it later reappears.
+  useEffect(() => {
+    setTagFilters((prev) => {
+      const next = prev.filter((tag) => tags.includes(tag));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [tags]);
+
   const toggleTag = useCallback((tag: string) => {
     setTagFilters((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
@@ -118,10 +131,13 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
   const clearTags = useCallback(() => setTagFilters([]), []);
 
   const filtered = useMemo(() => {
-    if (tagFilters.length === 0) return todos;
+    // Only filter by tags that still exist, so the list never strands empty in
+    // the brief window before the prune effect above runs (issue #74).
+    const active = tagFilters.filter((tag) => tags.includes(tag));
+    if (active.length === 0) return todos;
     // AND filter: a todo must carry every active tag.
-    return todos.filter((t) => tagFilters.every((tag) => t.tags.includes(tag)));
-  }, [todos, tagFilters]);
+    return todos.filter((t) => active.every((tag) => t.tags.includes(tag)));
+  }, [todos, tagFilters, tags]);
 
   const createTodo = useCallback(
     async (input: CreateTodoInput): Promise<boolean> => {


### PR DESCRIPTION
Closes #74.

## Problem
With a tag filter active, deleting/renaming the last todo that carried the filtered tag removed it from `tags` while `tagFilters` kept it → `filtered` returned empty. If `tags` became empty, `TagFilterBar` rendered `null`, so there was no **✕ Filter** to reset — the list stayed empty and could only be recovered by switching spaces.

## Fix
- **`TodosContext`**: `filtered` only applies filters whose tag still exists (no transient empty strand), and an effect prunes `tagFilters` down to the live `tags` so the chips stay consistent and a vanished tag can't silently re-activate if it later reappears.
- **`TagFilterBar`**: renders the bar — and the reset button — whenever a filter is active, even if no tags remain, so the reset affordance is always reachable.

## Verification
`npx tsc --noEmit` clean; `npm run lint` clean (only pre-existing `<img>` warnings elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)