### PR TITLE
fix(board): atomic status-drop reconciliation (#79)

### DIFF
--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -13,7 +13,7 @@ import { buildColumns, type BoardColumn, type GroupBy } from "./columns";
 
 /** Desktop Board view (issue #46): horizontal columns with HTML5 drag & drop. */
 export default function BoardView() {
-  const { todos, loading, setWaitingOn, setCompleted } = useTodos();
+  const { todos, loading, setWaitingOn, setStatus } = useTodos();
   const { activeSpace } = useSpaces();
   const { user } = useAuth();
   const nameOf = useSpaceMemberNames();
@@ -32,9 +32,9 @@ export default function BoardView() {
         currentUid: user?.uid,
         nameOf,
         setWaitingOn,
-        setCompleted,
+        setStatus,
       }),
-    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setCompleted]
+    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setStatus]
   );
 
   const onDrop = async (col: BoardColumn) => {

--- a/src/components/shell/board/MobileBoard.tsx
+++ b/src/components/shell/board/MobileBoard.tsx
@@ -18,7 +18,7 @@ import type { Todo } from "@/lib/types";
  * each card has a "Verschieben" sheet listing the other columns as targets.
  */
 export default function MobileBoard() {
-  const { todos, loading, setWaitingOn, setCompleted } = useTodos();
+  const { todos, loading, setWaitingOn, setStatus } = useTodos();
   const { activeSpace } = useSpaces();
   const { user } = useAuth();
   const nameOf = useSpaceMemberNames();
@@ -36,9 +36,9 @@ export default function MobileBoard() {
         currentUid: user?.uid,
         nameOf,
         setWaitingOn,
-        setCompleted,
+        setStatus,
       }),
-    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setCompleted]
+    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setStatus]
   );
 
   const targets = columns.filter((c) => c.apply);

--- a/src/components/shell/board/columns.ts
+++ b/src/components/shell/board/columns.ts
@@ -19,7 +19,7 @@ interface BuildArgs {
   currentUid: string | undefined;
   nameOf: (uid: string) => string;
   setWaitingOn: (id: string, waitingOn: string | null) => Promise<void>;
-  setCompleted: (id: string, completed: boolean) => Promise<void>;
+  setStatus: (id: string, status: { completed: boolean; waitingOn: string | null }) => Promise<void>;
 }
 
 /**
@@ -37,7 +37,7 @@ export function buildColumns({
   currentUid,
   nameOf,
   setWaitingOn,
-  setCompleted,
+  setStatus,
 }: BuildArgs): BoardColumn[] {
   if (groupBy === "person") {
     const open = todos.filter((t) => !t.completed);
@@ -65,16 +65,16 @@ export function buildColumns({
     return columns;
   }
 
-  // Status grouping
+  // Status grouping. Each drop is a single atomic write of completed + waitingOn
+  // (issue #79): "Offen" clears both flags, "Erledigt" also clears waitingOn so a
+  // done card stops showing "bei X" and doesn't reappear in a person column when
+  // reopened. One updateDoc → no visible half-applied state, no double load.
   return [
     {
       id: "offen",
       label: "Offen",
       todos: todos.filter((t) => !t.completed && !t.waitingOn),
-      apply: async (id) => {
-        await setWaitingOn(id, null);
-        await setCompleted(id, false);
-      },
+      apply: (id) => setStatus(id, { completed: false, waitingOn: null }),
     },
     {
       id: "wartet",
@@ -86,7 +86,7 @@ export function buildColumns({
       id: "erledigt",
       label: "Erledigt",
       todos: todos.filter((t) => t.completed),
-      apply: (id) => setCompleted(id, true),
+      apply: (id) => setStatus(id, { completed: true, waitingOn: null }),
     },
   ];
 }

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -19,6 +19,7 @@ import {
   editTodoContent,
   setTodoCompleted,
   setTodoWaitingOn,
+  setTodoStatus,
   deleteTodo,
 } from "@/lib/firebase/firebaseUtils";
 import type { Todo, TiptapContent } from "@/lib/types";
@@ -45,6 +46,8 @@ interface TodosContextType {
   editContent: (id: string, title: string, body: TiptapContent | null) => Promise<boolean>;
   setCompleted: (id: string, completed: boolean) => Promise<void>;
   setWaitingOn: (id: string, waitingOn: string | null) => Promise<void>;
+  /** Atomic status transition (completed + waitingOn in one write); board drops. */
+  setStatus: (id: string, status: { completed: boolean; waitingOn: string | null }) => Promise<void>;
   remove: (id: string) => Promise<void>;
 }
 
@@ -184,6 +187,19 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     [activeSpaceId, showError]
   );
 
+  const setStatus = useCallback(
+    async (id: string, status: { completed: boolean; waitingOn: string | null }) => {
+      if (!activeSpaceId) return;
+      try {
+        await setTodoStatus(activeSpaceId, id, status);
+      } catch (e) {
+        console.error("setStatus failed", e);
+        showError("Status konnte nicht geändert werden.");
+      }
+    },
+    [activeSpaceId, showError]
+  );
+
   const remove = useCallback(
     async (id: string) => {
       if (!activeSpaceId) return;
@@ -210,6 +226,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     editContent,
     setCompleted,
     setWaitingOn,
+    setStatus,
     remove,
   };
 

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -243,6 +243,17 @@ export const setTodoWaitingOn = (
   waitingOn: string | null
 ) => updateDoc(todoRef(spaceId, todoId), { waitingOn });
 
+// Atomic status transition for the board status drops (issue #79): writes
+// `completed` and `waitingOn` together in one updateDoc, so a card never flashes
+// a half-applied intermediate state and completing one can't leave a stale
+// `waitingOn` behind (which would keep showing "bei X" and re-surface it in the
+// person column when reopened).
+export const setTodoStatus = (
+  spaceId: string,
+  todoId: string,
+  status: { completed: boolean; waitingOn: string | null }
+) => updateDoc(todoRef(spaceId, todoId), status);
+
 export const setTodoOrder = (spaceId: string, todoId: string, order: number) =>
   updateDoc(todoRef(spaceId, todoId), { order });
 


### PR DESCRIPTION
Closes #79.

## Problem
Board **status** view (`columns.ts`):
- **"Erledigt"** drop set only `completed:true` and left `waitingOn` in place → the done card kept showing "bei X" and re-surfaced in that person's column once reopened.
- **"Offen"** drop did **two** sequential writes (`setWaitingOn(null)` + `setCompleted(false)`), each its own update → not atomic, a visible intermediate state, and double the write/refresh load.

## Fix
New atomic helper `setTodoStatus(spaceId, id, {completed, waitingOn})` → one `updateDoc`, surfaced through `TodosContext.setStatus`. The status drops now bundle the transition:
- **Offen** → `{ completed: false, waitingOn: null }`
- **Erledigt** → `{ completed: true, waitingOn: null }` (completing clears the assignee — the recommended decision)

The **person** view still uses `setWaitingOn`; the card checkbox still uses `setCompleted` (unchanged scope).

## Verification
`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)