### PR TITLE
fix(mentions): unicode-aware @mention resolution for Heute + todo titles (#75, #76)

### DIFF
--- a/src/components/shell/heute/HeuteInput.tsx
+++ b/src/components/shell/heute/HeuteInput.tsx
@@ -14,7 +14,9 @@ export default function HeuteInput() {
   const resolver = useMemberResolver();
   const [value, setValue] = useState("");
 
-  const tokenMatch = value.match(/@(\w*)$/);
+  // Unicode-aware trailing @token so the popover also opens on non-ASCII
+  // initials (e.g. "@Mü…", "@Jo…") — \w would miss them (issue #75).
+  const tokenMatch = value.match(/@([\p{L}\p{N}_]*)$/u);
   const query = tokenMatch ? tokenMatch[1].toLowerCase() : null;
   const suggestions =
     query !== null
@@ -23,7 +25,7 @@ export default function HeuteInput() {
   const showSuggestions = query !== null && suggestions.length > 0;
 
   const pick = (uid: string) => {
-    setValue(value.replace(/@(\w*)$/, `@${resolver.firstName(uid)} `));
+    setValue(value.replace(/@([\p{L}\p{N}_]*)$/u, `@${resolver.firstName(uid)} `));
   };
 
   const send = async () => {

--- a/src/components/shell/heute/useMemberResolver.ts
+++ b/src/components/shell/heute/useMemberResolver.ts
@@ -2,6 +2,11 @@
 
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
+import {
+  extractMentionTokens,
+  resolveMentionToken,
+  type MentionMember,
+} from "@/lib/utils/textUtils";
 
 export interface MemberResolver {
   members: string[];
@@ -24,18 +29,17 @@ export function useMemberResolver(): MemberResolver {
   const nameOf = (uid: string) => profiles[uid]?.displayName ?? "jemand";
   const firstName = (uid: string) => nameOf(uid).split(/\s+/)[0];
 
+  // Resolve the first @mention in the text to exactly one member uid. Unicode-
+  // aware and exact: an ambiguous or partial token resolves to null rather than
+  // silently picking the first matching member (issue #75).
   const matchMention = (text: string): string | null => {
-    const match = text.match(/@(\w+)/);
-    if (!match) return null;
-    const word = match[1].toLowerCase();
-    return (
-      members.find((uid) =>
-        (profiles[uid]?.displayName ?? "")
-          .toLowerCase()
-          .split(/\s+/)
-          .some((part) => part.startsWith(word))
-      ) ?? null
-    );
+    const tokens = extractMentionTokens(text);
+    if (tokens.length === 0) return null;
+    const list: MentionMember[] = members.map((uid) => ({
+      uid,
+      displayName: profiles[uid]?.displayName ?? null,
+    }));
+    return resolveMentionToken(tokens[0], list);
   };
 
   return { members, nameOf, firstName, matchMention };

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -12,6 +12,7 @@ import React, {
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useToast } from "@/lib/contexts/ToastContext";
+import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
 import {
   getTodosForSpace,
   subscribeTodosForSpace,
@@ -21,6 +22,7 @@ import {
   setTodoWaitingOn,
   deleteTodo,
 } from "@/lib/firebase/firebaseUtils";
+import type { MentionMember } from "@/lib/utils/textUtils";
 import type { Todo, TiptapContent } from "@/lib/types";
 
 interface CreateTodoInput {
@@ -56,11 +58,24 @@ const TodosContext = createContext<TodosContextType | undefined>(undefined);
  */
 export const TodosProvider = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
-  const { activeSpaceId, setOpenCount } = useSpaces();
+  const { activeSpaceId, activeSpace, setOpenCount } = useSpaces();
   const { showError } = useToast();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(true);
   const [tagFilters, setTagFilters] = useState<string[]>([]);
+
+  // Member profiles of the active space, used to resolve plain-text @mentions in
+  // a todo title against members (issue #76) — symmetric with #tags, which are
+  // already derived from the title.
+  const memberProfiles = useMemberProfiles(activeSpace?.members ?? []);
+  const mentionMembers = useMemo<MentionMember[]>(
+    () =>
+      (activeSpace?.members ?? []).map((uid) => ({
+        uid,
+        displayName: memberProfiles[uid]?.displayName ?? null,
+      })),
+    [activeSpace, memberProfiles]
+  );
 
   // Manual one-shot reload, kept as a fallback. Live updates flow through the
   // onSnapshot subscription below (issue #72), so mutations no longer call this.
@@ -132,6 +147,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
           title: input.title,
           body: input.body ?? null,
           order: maxOrder + 1,
+          mentionMembers,
         });
         return true;
       } catch (e) {
@@ -140,14 +156,14 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, user, todos, showError]
+    [activeSpaceId, user, todos, mentionMembers, showError]
   );
 
   const editContent = useCallback(
     async (id: string, title: string, body: TiptapContent | null): Promise<boolean> => {
       if (!activeSpaceId) return false;
       try {
-        await editTodoContent(activeSpaceId, id, title, body);
+        await editTodoContent(activeSpaceId, id, title, body, mentionMembers);
         return true;
       } catch (e) {
         console.error("editContent failed", e);
@@ -155,7 +171,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, showError]
+    [activeSpaceId, mentionMembers, showError]
   );
 
   const setCompleted = useCallback(

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -29,7 +29,7 @@ import {
   type DocumentData,
 } from "firebase/firestore";
 import { getSpaceColor } from "../theme/colors";
-import { deriveTags, deriveMentions, extractPlainText } from "../utils/textUtils";
+import { deriveTags, deriveMentions, extractPlainText, type MentionMember } from "../utils/textUtils";
 import type { Space, Todo, Daily, TiptapContent } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
@@ -172,6 +172,8 @@ export const createTodo = async (
     body?: TiptapContent | null;
     waitingOn?: string | null;
     order?: number;
+    // Space members for resolving plain-text @mentions in the title (issue #76).
+    mentionMembers?: MentionMember[];
   }
 ): Promise<string> => {
   if (!spaceId || !uid) throw new Error("Missing space or user.");
@@ -183,7 +185,7 @@ export const createTodo = async (
     completed: false,
     waitingOn: input.waitingOn ?? null,
     tags: deriveTags(input.title, body),
-    mentions: deriveMentions(body),
+    mentions: deriveMentions(body, input.title, input.mentionMembers),
     createdBy: uid,
     createdAt: serverTimestamp(),
     order: input.order ?? 0,
@@ -221,17 +223,19 @@ export const getOpenTodoCount = async (spaceId: string): Promise<number> => {
 };
 
 // Edit title/body together and re-derive tags/mentions from the new content.
+// `mentionMembers` lets plain-text @mentions in the title resolve too (issue #76).
 export const editTodoContent = (
   spaceId: string,
   todoId: string,
   title: string,
-  body: TiptapContent | null
+  body: TiptapContent | null,
+  mentionMembers?: MentionMember[]
 ) =>
   updateDoc(todoRef(spaceId, todoId), {
     title: title.trim(),
     body,
     tags: deriveTags(title, body),
-    mentions: deriveMentions(body),
+    mentions: deriveMentions(body, title, mentionMembers),
   });
 
 export const setTodoCompleted = (spaceId: string, todoId: string, completed: boolean) =>

--- a/src/lib/utils/textUtils.ts
+++ b/src/lib/utils/textUtils.ts
@@ -74,7 +74,64 @@ export function deriveTags(title: string, body?: any): string[] {
   ];
 }
 
-/** Derives the unique @mention UIDs of a todo from its (Tiptap) body. */
-export function deriveMentions(body?: any): string[] {
-  return extractMentionIds(body);
+/** A space member as needed to resolve a plain-text @mention to a uid. */
+export interface MentionMember {
+  uid: string;
+  displayName: string | null;
+}
+
+/**
+ * Extracts the @mention tokens (the word after each `@`) from PLAIN text.
+ *
+ * Unicode-aware (issue #75): the previous `\w`-based regex dropped ü/é/ß etc., so
+ * German names like "Müller" or "José" never matched. Unicode property escapes
+ * (`\p{L}\p{N}`) with the `u` flag handle them. A leading lookbehind keeps `@`
+ * from matching mid-word (e.g. inside an e-mail address `a@b.com`).
+ */
+export function extractMentionTokens(text: string): string[] {
+  if (!text) return [];
+  const matches = text.match(/(?<![\p{L}\p{N}_])@([\p{L}\p{N}_]+)/gu);
+  if (!matches) return [];
+  // Strip the leading "@" (and any character the lookbehind let through).
+  return [...new Set(matches.map((m) => m.slice(m.indexOf('@') + 1)))];
+}
+
+/**
+ * Resolves a single plain-text @token to exactly one member uid, or null.
+ *
+ * Matches the token case-insensitively against each member's full display name
+ * or any one of its whitespace-separated words — so both "@Michi" (the first
+ * name the autocomplete inserts) and a hand-typed "@Müller" (last name) resolve.
+ * The match is EXACT per word, not a prefix: returns null on no match OR on
+ * ambiguity (more than one member), so it never silently picks the first member,
+ * which could mislabel a different person (issue #75, privacy-sensitive).
+ */
+export function resolveMentionToken(token: string, members: MentionMember[]): string | null {
+  const t = token.trim().toLowerCase();
+  if (!t) return null;
+  const hits = members.filter((m) => {
+    const name = (m.displayName ?? '').trim().toLowerCase();
+    if (!name) return false;
+    return name === t || name.split(/\s+/).includes(t);
+  });
+  return hits.length === 1 ? hits[0].uid : null;
+}
+
+/**
+ * Derives the unique @mention UIDs of a todo from its (Tiptap) body and,
+ * optionally, plain-text @mentions in its title resolved against space members
+ * (issue #76). Without `members`, only structured body mentions are returned —
+ * preserving the previous behavior for callers that can't resolve names.
+ */
+export function deriveMentions(
+  body?: any,
+  title?: string,
+  members?: MentionMember[]
+): string[] {
+  const fromBody = extractMentionIds(body);
+  if (!title || !members || members.length === 0) return fromBody;
+  const fromTitle = extractMentionTokens(title)
+    .map((token) => resolveMentionToken(token, members))
+    .filter((uid): uid is string => uid !== null);
+  return [...new Set([...fromBody, ...fromTitle])];
 }


### PR DESCRIPTION
Closes #75, closes #76.

These two are the same concern — resolving **plain-text** `@mentions` against space members — so they share one helper set in `textUtils.ts` (`extractMentionTokens`, `resolveMentionToken`, `MentionMember`) and ship together.

## #75 — regex broke on umlaut/non-ASCII names + loose mis-attribution
- `matchMention` used `/@(\w+)/` without the `u` flag → `ü/é/ß` were dropped, so "@Müller"/"@José" failed to resolve; the autocomplete token `/@(\w*)$/` never triggered on non-ASCII initials.
- It matched by **loose name prefix, first member wins** → the direction label could name the wrong person.

**Fix:** Unicode-aware tokenisation (`\p{L}\p{N}` + `u` flag, plus a lookbehind so `@` inside `a@b.com` isn't treated as a mention) and **exact, per-word, unambiguous** resolution. Both "@Michi" (first name) and a hand-typed "@Müller" (last name) resolve; an **ambiguous** token (two "Michi"s) or a **partial** one resolves to `null` rather than guessing. `HeuteInput`'s trailing token + insertion regex are Unicode-aware too.

## #76 — quick-add/title @mentions silently dropped
`deriveMentions(body)` only read Tiptap body nodes, so `#tags` from the plain-text title were captured but `@mentions` weren't — inconsistent with the "@ Personen, # Tags" placeholder.

**Fix:** `deriveMentions(body, title?, members?)` now also resolves plain-text title mentions; `createTodo`/`editTodoContent` accept the member list, and `TodosContext` supplies it from the active space's member profiles (symmetric with how `#tags` already come from the title).

## Verification
`npx tsc --noEmit` clean; `npm run lint` clean. Resolution logic spot-checked (Unicode names, ambiguity → null, partial → null, e-mail not matched).

> Note: this keeps the lightweight plain-text approach. Storing mentions structurally (uid) — the issue's first option — would also let an ambiguous first-name pick survive; that's a larger data-model change deferred for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)