### PR TITLE
feat(spaces): rename/delete UI + robust new-space color (#78)

### DIFF
--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -6,6 +6,7 @@ import MobileHeader from "./MobileHeader";
 import BottomTabs, { type MobileTab } from "./BottomTabs";
 import BottomSheet from "./BottomSheet";
 import MemberManager from "./MemberManager";
+import SpaceManager from "./SpaceManager";
 import AccountActions from "./AccountActions";
 import MobileTodos from "./list/MobileTodos";
 import MobileHeute from "./heute/MobileHeute";
@@ -116,8 +117,12 @@ export default function MobileShell() {
         <NewSpaceForm onDone={() => setAddSpaceOpen(false)} />
       </BottomSheet>
 
-      <BottomSheet open={membersOpen} onClose={() => setMembersOpen(false)}>
-        <MemberManager />
+      <BottomSheet open={membersOpen} onClose={() => setMembersOpen(false)} title="Space">
+        <div className="flex flex-col gap-4 pb-2">
+          <SpaceManager onDone={() => setMembersOpen(false)} />
+          <div className="border-t border-border" />
+          <MemberManager />
+        </div>
       </BottomSheet>
 
       <BottomSheet open={accountOpen} onClose={() => setAccountOpen(false)} title="Konto">

--- a/src/components/shell/SpaceHeader.tsx
+++ b/src/components/shell/SpaceHeader.tsx
@@ -7,6 +7,7 @@ import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "./Avatar";
 import SegmentedControl from "./SegmentedControl";
 import InvitePopover from "./InvitePopover";
+import SpaceMenu from "./SpaceMenu";
 
 export default function SpaceHeader() {
   const { activeSpace } = useSpaces();
@@ -38,6 +39,7 @@ export default function SpaceHeader() {
       </div>
 
       <InvitePopover />
+      <SpaceMenu />
 
       <div className="ml-auto">
         <SegmentedControl />

--- a/src/components/shell/SpaceManager.tsx
+++ b/src/components/shell/SpaceManager.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+
+/**
+ * Space management for the active space (issue #78): rename (any member) and
+ * delete (creator only — also enforced by firestore.rules). Shared by the
+ * desktop space menu and the mobile space sheet; touch targets stay ≥40px.
+ * Calls onDone() after a successful delete so the host popover/sheet closes.
+ */
+export default function SpaceManager({ onDone }: { onDone?: () => void }) {
+  const { user } = useAuth();
+  const { activeSpace, renameSpace, deleteSpace } = useSpaces();
+  const [name, setName] = useState(activeSpace?.name ?? "");
+  const [busy, setBusy] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  if (!activeSpace) return null;
+  const isCreator = user?.uid === activeSpace.createdBy;
+  const trimmed = name.trim();
+  const canRename = trimmed.length > 0 && trimmed !== activeSpace.name && !busy;
+
+  const save = async () => {
+    if (!canRename) return;
+    setBusy(true);
+    try {
+      await renameSpace(activeSpace.id, name);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const ok = await deleteSpace(activeSpace.id);
+      if (ok) onDone?.();
+    } finally {
+      setBusy(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="px-1 text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">
+        Space
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          value={name}
+          disabled={busy}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") save();
+          }}
+          placeholder="Space-Name"
+          aria-label="Space-Name"
+          className="min-w-0 flex-1 rounded-lg border border-border bg-bg-card px-3 text-sm outline-none"
+          style={{ minHeight: 40 }}
+        />
+        <button
+          type="button"
+          onClick={save}
+          disabled={!canRename}
+          className="shrink-0 rounded-full px-3 text-sm font-extrabold text-white disabled:opacity-50"
+          style={{ background: "var(--accent)", minHeight: 40 }}
+        >
+          Umbenennen
+        </button>
+      </div>
+
+      {!isCreator ? (
+        <p className="px-1 text-xs text-text-dim">Nur der Ersteller kann diesen Space löschen.</p>
+      ) : confirmDelete ? (
+        <div className="flex items-center gap-2">
+          <span className="flex-1 text-sm text-text-dim">Space „{activeSpace.name}“ wirklich löschen?</span>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(false)}
+            disabled={busy}
+            className="shrink-0 rounded-full px-3 text-sm text-text-dim"
+            style={{ minHeight: 40 }}
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            onClick={remove}
+            disabled={busy}
+            className="shrink-0 rounded-full px-3 text-sm font-extrabold text-white disabled:opacity-50"
+            style={{ background: "var(--danger)", minHeight: 40 }}
+          >
+            Löschen
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirmDelete(true)}
+          className="self-start px-1 text-sm font-semibold text-danger hover:underline"
+        >
+          Space löschen
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/SpaceMenu.tsx
+++ b/src/components/shell/SpaceMenu.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import SpaceManager from "./SpaceManager";
+
+/**
+ * Desktop space "⋯" menu (issue #78): a kebab button next to the space name that
+ * opens a popover with rename / delete (SpaceManager). Closes on outside click,
+ * mirroring InvitePopover.
+ */
+export default function SpaceMenu() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Space-Optionen"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex items-center justify-center rounded-full border border-border text-text-dim hover:text-text"
+        style={{ width: 30, height: 30 }}
+      >
+        ⋯
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-40 mt-2 w-72 rounded-xl border border-border bg-bg-pop p-3 shadow-soft">
+          <SpaceManager onDone={() => setOpen(false)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -15,10 +15,25 @@ import {
   subscribeSpacesForUser,
   getOpenTodoCount,
   createSpace as createSpaceDoc,
+  renameSpace as renameSpaceDoc,
+  deleteSpace as deleteSpaceDoc,
   addSpaceMember,
   removeSpaceMember,
 } from "@/lib/firebase/firebaseUtils";
+import { SPACE_COLORS } from "@/lib/theme/colors";
 import type { Space } from "@/lib/types";
+
+// Pick a palette hue for a new space, preferring one not already used by the
+// user's spaces; if all four are taken, pick any at random. Random (rather than
+// count-based) makes it robust to the create race — two spaces created in quick
+// succession before the live list updates are very unlikely to collide, instead
+// of both landing on the same count-derived color (issue #78).
+const pickSpaceColor = (existing: Space[]): number => {
+  const used = new Set(existing.map((s) => s.color));
+  const free = SPACE_COLORS.filter((c) => !used.has(c.hue));
+  const pool = free.length > 0 ? free : SPACE_COLORS;
+  return pool[Math.floor(Math.random() * pool.length)].hue;
+};
 
 export type SpaceView = "liste" | "board";
 
@@ -33,8 +48,12 @@ interface SpacesContextType {
   setActiveSpace: (id: string) => void;
   setView: (view: SpaceView) => void;
   refreshSpaces: () => Promise<void>;
-  /** Create a space (creator = first member, cyclic palette color) and select it. */
+  /** Create a space (creator = first member, free palette color) and select it. */
   createSpace: (name: string) => Promise<string | null>;
+  /** Rename a space (any member). Returns true on success. */
+  renameSpace: (spaceId: string, name: string) => Promise<boolean>;
+  /** Delete a space (creator only; rules-enforced). Returns true on success. */
+  deleteSpace: (spaceId: string) => Promise<boolean>;
   addMember: (spaceId: string, uid: string) => Promise<void>;
   removeMember: (spaceId: string, uid: string) => Promise<void>;
   /** Update one space's open-todo badge locally (e.g. after add/complete). */
@@ -128,7 +147,7 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     async (name: string): Promise<string | null> => {
       if (!user || !name.trim()) return null;
       try {
-        const id = await createSpaceDoc(user.uid, name, spaces.length);
+        const id = await createSpaceDoc(user.uid, name, pickSpaceColor(spaces));
         // The new space arrives via the live subscription; select it now.
         setActiveSpaceId(id);
         return id;
@@ -138,7 +157,38 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
         return null;
       }
     },
-    [user, spaces.length, showError]
+    [user, spaces, showError]
+  );
+
+  const renameSpace = useCallback(
+    async (spaceId: string, name: string): Promise<boolean> => {
+      if (!name.trim()) return false;
+      try {
+        await renameSpaceDoc(spaceId, name);
+        return true;
+      } catch (e) {
+        console.error("renameSpace failed", e);
+        showError("Space konnte nicht umbenannt werden.");
+        return false;
+      }
+    },
+    [showError]
+  );
+
+  const deleteSpace = useCallback(
+    async (spaceId: string): Promise<boolean> => {
+      try {
+        await deleteSpaceDoc(spaceId);
+        // The space disappears via the live subscription, which re-selects a
+        // remaining space (or null) in applyLoaded.
+        return true;
+      } catch (e) {
+        console.error("deleteSpace failed", e);
+        showError("Space konnte nicht gelöscht werden.");
+        return false;
+      }
+    },
+    [showError]
   );
 
   const addMember = useCallback(
@@ -182,6 +232,8 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     setView,
     refreshSpaces,
     createSpace,
+    renameSpace,
+    deleteSpace,
     addMember,
     removeMember,
     setOpenCount,

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -53,18 +53,19 @@ export const signInWithGoogle = async () => {
 
 const SPACES_COLLECTION = "spaces";
 
-// Create a space with the creator as the first member. The color is assigned
-// cyclically from the design palette based on how many spaces the user already
-// has, so the Nth space gets the Nth palette hue (wrapping around).
+// Create a space with the creator as the first member. The caller picks the
+// palette hue (see SpacesContext.createSpace) — passing an explicit color avoids
+// the race where deriving it from a stale space count gave two quickly-created
+// spaces the same color (issue #78). Falls back to the first palette hue.
 export const createSpace = async (
   uid: string,
   name: string,
-  existingSpaceCount = 0
+  colorHue: number = getSpaceColor(0).hue
 ): Promise<string> => {
   if (!uid) throw new Error("User not authenticated.");
   const ref = await addDoc(collection(db, SPACES_COLLECTION), {
     name: name.trim(),
-    color: getSpaceColor(existingSpaceCount).hue,
+    color: colorHue,
     members: [uid],
     createdBy: uid,
     createdAt: serverTimestamp(),


### PR DESCRIPTION
Closes #78.

## Problem
- `renameSpace` / `deleteSpace` were exported from `firebaseUtils` but **wired into no UI** — a space could neither be renamed nor deleted, so it was effectively permanent.
- `createSpace` used `spaces.length` as the palette index, so two spaces created in quick succession (before the live list refreshed) landed on the **same color**.

## Fix
**Color race** — `SpacesContext.createSpace` now picks a hue *not already used* by the user's spaces (random among the free hues; random among all four if the palette is full) and passes it explicitly; `firebaseUtils.createSpace` takes a `colorHue` instead of a count. Random-from-free is race-tolerant: two near-simultaneous creates are very unlikely to collide.

**Rename/delete UI**
- New `SpaceManager` — inline **rename** (any member) + **delete** (creator only, two-step inline confirm; `firestore.rules` also enforces creator-only). After a successful delete the live `spaces` subscription re-selects a remaining space (`applyLoaded`).
- **Desktop**: a `SpaceMenu` "⋯" popover next to the space name in `SpaceHeader` (closes on outside click, like `InvitePopover`).
- **Mobile**: `SpaceManager` added to the members bottom sheet (now titled **"Space"**), above the member manager.
- `SpacesContext` gains `renameSpace` / `deleteSpace` (with error toasts).

## Verification
`npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)