### PR TITLE
perf(data): shared profile cache + single-source open counts (#77)

### DIFF
--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useRef,
   useCallback,
   ReactNode,
 } from "react";
@@ -98,31 +99,49 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
     return unsubscribe;
   }, [user, applyLoaded, showError]);
 
-  // Open-todo counts per space (sidebar badges). Best-effort, recomputed when
-  // the set of spaces changes; the active space's count is also kept live by
-  // TodosContext via setOpenCount. A failure must not break the shell.
-  const spaceIdsKey = spaces.map((s) => s.id).join(",");
+  // Open-todo counts per space for the sidebar/pill badges (best-effort; a
+  // failure must not break the shell). Single source per space (issue #77):
+  //  - The ACTIVE space's count comes solely from TodosContext, which derives it
+  //    from its live onSnapshot and pushes it via setOpenCount. We never server-
+  //    count the active space, so there is no second source to drift/flicker
+  //    against.
+  //  - Every OTHER space is server-counted exactly once (getCountFromServer),
+  //    the first time it's seen as non-active (tracked in countedRef) — instead
+  //    of recomputing all spaces on every change. When a space later switches
+  //    from active to non-active it gets counted then, refreshing it.
+  const countedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!spaceIdsKey) return;
+    const toCount = spaces
+      .filter((s) => s.id !== activeSpaceId && !countedRef.current.has(s.id))
+      .map((s) => s.id);
+    if (toCount.length === 0) return;
     let cancelled = false;
     (async () => {
-      const ids = spaceIdsKey.split(",");
-      const counts: Record<string, number> = {};
-      await Promise.all(
-        ids.map(async (id) => {
+      const results = await Promise.all(
+        toCount.map(async (id) => {
           try {
-            counts[id] = await getOpenTodoCount(id);
+            return [id, await getOpenTodoCount(id)] as const;
           } catch {
-            /* ignore per-space count errors */
+            return [id, null] as const; // count again on a later run
           }
         })
       );
-      if (!cancelled) setOpenCounts((prev) => ({ ...prev, ...counts }));
+      if (cancelled) return;
+      const counts: Record<string, number> = {};
+      for (const [id, count] of results) {
+        if (count !== null) {
+          counts[id] = count;
+          countedRef.current.add(id);
+        }
+      }
+      if (Object.keys(counts).length > 0) {
+        setOpenCounts((prev) => ({ ...prev, ...counts }));
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, [spaceIdsKey]);
+  }, [spaces, activeSpaceId]);
 
   const createSpace = useCallback(
     async (name: string): Promise<string | null> => {

--- a/src/lib/hooks/useMemberProfiles.ts
+++ b/src/lib/hooks/useMemberProfiles.ts
@@ -4,38 +4,76 @@ import { useEffect, useState } from "react";
 import { getPublicProfile, type PublicProfile } from "@/lib/firebase/firebaseUtils";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 
+// Module-level profile cache shared by EVERY consumer (issue #77). The desktop
+// and mobile shells are both mounted, and 6+ components resolve member profiles
+// (headers, member manager, mention resolver, board names, …), so without this
+// each uid was fetched once per consumer per mount. `inFlight` collapses
+// concurrent fetches of the same uid into a single request. Public profiles are
+// effectively static within a session (display name / photo), so a plain cache
+// with no TTL is fine; it's repopulated fresh on the next page load.
+const profileCache = new Map<string, PublicProfile>();
+const inFlight = new Map<string, Promise<PublicProfile | null>>();
+
+function loadProfile(uid: string): Promise<PublicProfile | null> {
+  const cached = profileCache.get(uid);
+  if (cached) return Promise.resolve(cached);
+  const existing = inFlight.get(uid);
+  if (existing) return existing;
+  const p = getPublicProfile(uid)
+    .then((profile) => {
+      if (profile) profileCache.set(uid, profile);
+      return profile;
+    })
+    .catch(() => null)
+    .finally(() => inFlight.delete(uid));
+  inFlight.set(uid, p);
+  return p;
+}
+
+function seedFromCache(uids: string[]): Record<string, PublicProfile> {
+  const out: Record<string, PublicProfile> = {};
+  for (const uid of uids) {
+    const cached = profileCache.get(uid);
+    if (cached) out[uid] = cached;
+  }
+  return out;
+}
+
 /**
  * Loads public profiles for a list of member uids (for avatar initials / names).
- * Shared by the desktop space header and the mobile header (issues #42/#43).
+ * Shared by the desktop space header and the mobile header (issues #42/#43) and
+ * backed by a module-level cache so repeat consumers don't refetch (issue #77).
  */
 export function useMemberProfiles(memberUids: string[]): Record<string, PublicProfile> {
-  const [profiles, setProfiles] = useState<Record<string, PublicProfile>>({});
   const key = memberUids.join(",");
+  // Render any already-cached profiles synchronously (no flash on revisit).
+  const [profiles, setProfiles] = useState<Record<string, PublicProfile>>(() =>
+    seedFromCache(key ? key.split(",") : [])
+  );
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      const entries = await Promise.all(
-        memberUids.map(async (uid) => {
-          try {
-            return [uid, await getPublicProfile(uid)] as const;
-          } catch {
-            return [uid, null] as const;
-          }
-        })
-      );
+    const uids = key ? key.split(",") : [];
+    // Reset to the cached subset for the current member set, then fill in the
+    // rest from the cache / a single shared fetch per missing uid.
+    setProfiles(seedFromCache(uids));
+    Promise.all(uids.map(async (uid) => [uid, await loadProfile(uid)] as const)).then((entries) => {
       if (cancelled) return;
-      const next: Record<string, PublicProfile> = {};
-      for (const [uid, profile] of entries) {
-        if (profile) next[uid] = profile;
-      }
-      setProfiles(next);
-    })();
+      setProfiles((prev) => {
+        let changed = false;
+        const next = { ...prev };
+        for (const [uid, profile] of entries) {
+          if (profile && next[uid] !== profile) {
+            next[uid] = profile;
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    });
     return () => {
       cancelled = true;
     };
-    // `key` is the stable dependency derived from memberUids
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 
   return profiles;


### PR DESCRIPTION
Closes #77.

The first bullet of the issue — `TodosContext`/`DailyContext` doing a full `refresh()` after **every** mutation — was already resolved by #72 (todos/daily/spaces now flow through `onSnapshot`; mutations don't refetch). The recompute-after-every-member-toggle problem is gone with it: the count effect no longer keys off a value that a member toggle changes. This PR handles the **remaining** items.

## Profile cache (`useMemberProfiles`)
`useMemberProfiles` had no cache, so with the desktop + mobile shells both mounted and 6+ consumers (headers, member manager, mention resolver, board names, todo context…), the same uid was fetched many times per session.

- Module-level `profileCache` (uid → profile) shared by all consumers.
- `inFlight` map collapses concurrent fetches of the same uid into one request.
- Cached profiles render **synchronously** (no avatar/name flash on revisit).

Public profiles are effectively static within a session, so a no-TTL cache is fine (repopulated on next page load).

## Single-source open counts (`SpacesContext`)
The open-todo badge had **two** sources for the active space — the server `getCountFromServer` effect *and* `TodosContext` pushing a live count — which drifted/flickered.

- The **active** space is now never server-counted; its badge comes solely from `TodosContext`'s live `onSnapshot` (`setOpenCount`).
- **Other** spaces are server-counted **once**, the first time they're seen as non-active (tracked in a ref), instead of recomputing all spaces' counts whenever the set changes. A space switching active → non-active gets counted then, refreshing it.

## Verification
`npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds.

> Out of scope (kept minimal): optimistic local mutation echoes — `onSnapshot` round-trips are already fast and avoid the optimistic/rollback complexity; can revisit if latency shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)