### PR TITLE
Remove dead setTodoOrder; document order as insertion order (#83)

### DIFF
--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -259,9 +259,6 @@ export const setTodoStatus = (
   status: { completed: boolean; waitingOn: string | null }
 ) => updateDoc(todoRef(spaceId, todoId), status);
 
-export const setTodoOrder = (spaceId: string, todoId: string, order: number) =>
-  updateDoc(todoRef(spaceId, todoId), { order });
-
 export const deleteTodo = (spaceId: string, todoId: string) =>
   deleteDoc(todoRef(spaceId, todoId));
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,7 +44,11 @@ export interface Todo {
   /** Author; immutable after creation. */
   createdBy: string;
   createdAt: Timestamp | null;
-  /** Manual sort order (board drag & drop / list ordering). */
+  /**
+   * Insertion order (`maxOrder + 1` at creation); drives the stable
+   * `orderBy("order","asc")` list/board sort. There is no manual reordering UI,
+   * so it is set once and not mutated afterwards.
+   */
   order: number;
 }
 


### PR DESCRIPTION
## Summary

Resolves the half-built reordering apparatus flagged in #83. `setTodoOrder` was exported but had **no callers**, and the `Todo.order` doc comment implied a manual drag-to-reorder feature that doesn't exist.

Decision: **remove the dead setter, keep the field.** Wiring a full manual-reorder DnD feature is out of scope for a tech-debt cleanup, and the board's DnD only moves cards between status/person columns (#79) — it never reorders within a column. The `order` field itself is live and worth keeping: it's set to `maxOrder + 1` at creation (`TodosContext.createTodo`) and drives the stable `orderBy("order", "asc")` sort used by both the Liste and Board queries.

Closes #83

## Changes
- Remove the unused `setTodoOrder` export from `src/lib/firebase/firebaseUtils.ts`.
- Rewrite the misleading `Todo.order` doc comment in `src/lib/types.ts` to describe it accurately as insertion order (set once, never mutated).

## Test Plan
- [x] `npx tsc --noEmit` — clean (no app errors)
- [x] `npm run lint` — only pre-existing `<img>` warnings, none from this change
- [x] `grep setTodoOrder src` — no remaining references
- [ ] Vercel check green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)