### PR TITLE
Extract shared shell helpers: outside-click, accent, token-highlight, member-name (#81)

### DIFF
--- a/src/components/shell/AccountMenu.tsx
+++ b/src/components/shell/AccountMenu.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { useAuth } from "@/lib/hooks/useAuth";
+import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 import Avatar from "./Avatar";
 import AccountActions from "./AccountActions";
 
@@ -13,15 +14,7 @@ export default function AccountMenu() {
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
+  useOutsideClick(ref, open, () => setOpen(false));
 
   return (
     <div className="relative" ref={ref}>

--- a/src/components/shell/InvitePopover.tsx
+++ b/src/components/shell/InvitePopover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
+import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 import MemberManager from "./MemberManager";
 
 /**
@@ -10,15 +11,7 @@ import MemberManager from "./MemberManager";
 export default function InvitePopover() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
+  useOutsideClick(ref, open, () => setOpen(false));
 
   return (
     <div className="relative" ref={ref}>

--- a/src/components/shell/SpaceHeader.tsx
+++ b/src/components/shell/SpaceHeader.tsx
@@ -3,14 +3,13 @@
 import React from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
-import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "./Avatar";
 import SegmentedControl from "./SegmentedControl";
 import InvitePopover from "./InvitePopover";
 import SpaceMenu from "./SpaceMenu";
 
 export default function SpaceHeader() {
-  const { activeSpace } = useSpaces();
+  const { activeSpace, accent } = useSpaces();
   const members = activeSpace?.members ?? [];
   const profiles = useMemberProfiles(members);
 
@@ -24,7 +23,7 @@ export default function SpaceHeader() {
           width: 14,
           height: 14,
           borderRadius: 5,
-          backgroundColor: spaceColorFromHue(activeSpace.color),
+          backgroundColor: accent,
         }}
       />
       <h1 className="text-2xl font-black">{activeSpace.name}</h1>

--- a/src/components/shell/SpaceMenu.tsx
+++ b/src/components/shell/SpaceMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
+import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 import SpaceManager from "./SpaceManager";
 
 /**
@@ -11,15 +12,7 @@ import SpaceManager from "./SpaceManager";
 export default function SpaceMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
+  useOutsideClick(ref, open, () => setOpen(false));
 
   return (
     <div className="relative" ref={ref}>

--- a/src/components/shell/TokenizedText.tsx
+++ b/src/components/shell/TokenizedText.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+
+// Splits on @mentions and #tags while keeping the delimiters.
+const TOKEN = /(@[\w]+|#[\w]+)/g;
+
+/**
+ * Renders text with @mention and #tag highlighting (issue #81), shared by the
+ * Liste title (`list/TodoTitle`) and the Board card title (`board/TodoCard`),
+ * which previously each carried their own copy of this regex + markup.
+ *
+ * When `onTagClick` is given, #tags render as buttons that call it (the Liste's
+ * tag filter); otherwise they're static spans (board cards).
+ */
+export default function TokenizedText({
+  text,
+  onTagClick,
+}: {
+  text: string;
+  onTagClick?: (tag: string) => void;
+}) {
+  return (
+    <>
+      {text.split(TOKEN).map((part, i) => {
+        if (part.startsWith("@")) {
+          return (
+            <span
+              key={i}
+              className="rounded px-1"
+              style={{ color: "var(--mention)", background: "var(--mention-bg)" }}
+            >
+              {part}
+            </span>
+          );
+        }
+        if (part.startsWith("#")) {
+          if (onTagClick) {
+            const tag = part.slice(1);
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTagClick(tag);
+                }}
+                className="font-mono"
+                style={{ color: "var(--tag)" }}
+              >
+                {part}
+              </button>
+            );
+          }
+          return (
+            <span key={i} className="font-mono" style={{ color: "var(--tag)" }}>
+              {part}
+            </span>
+          );
+        }
+        return <span key={i}>{part}</span>;
+      })}
+    </>
+  );
+}

--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -5,7 +5,6 @@ import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
-import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "../Avatar";
 import BoardGroupToggle from "./BoardGroupToggle";
 import TodoCard from "./TodoCard";
@@ -14,10 +13,9 @@ import { buildColumns, type BoardColumn, type GroupBy } from "./columns";
 /** Desktop Board view (issue #46): horizontal columns with HTML5 drag & drop. */
 export default function BoardView() {
   const { todos, loading, setWaitingOn, setStatus } = useTodos();
-  const { activeSpace } = useSpaces();
+  const { activeSpace, accent } = useSpaces();
   const { user } = useAuth();
   const nameOf = useSpaceMemberNames();
-  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
 
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
   const [dragId, setDragId] = useState<string | null>(null);

--- a/src/components/shell/board/MobileBoard.tsx
+++ b/src/components/shell/board/MobileBoard.tsx
@@ -5,7 +5,6 @@ import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
-import { spaceColorFromHue } from "@/lib/theme/colors";
 import Avatar from "../Avatar";
 import BottomSheet from "../BottomSheet";
 import BoardGroupToggle from "./BoardGroupToggle";
@@ -19,10 +18,9 @@ import type { Todo } from "@/lib/types";
  */
 export default function MobileBoard() {
   const { todos, loading, setWaitingOn, setStatus } = useTodos();
-  const { activeSpace } = useSpaces();
+  const { activeSpace, accent } = useSpaces();
   const { user } = useAuth();
   const nameOf = useSpaceMemberNames();
-  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
 
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
   const [moveCard, setMoveCard] = useState<Todo | null>(null);

--- a/src/components/shell/board/TodoCard.tsx
+++ b/src/components/shell/board/TodoCard.tsx
@@ -4,30 +4,8 @@ import React from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { checklistProgress } from "@/lib/utils/checklist";
 import Avatar from "../Avatar";
+import TokenizedText from "../TokenizedText";
 import type { Todo } from "@/lib/types";
-
-const TOKEN = /(@[\w]+|#[\w]+)/g;
-
-/** Non-interactive @mention/#tag highlight for board card titles. */
-function highlight(title: string) {
-  return title.split(TOKEN).map((part, i) => {
-    if (part.startsWith("@")) {
-      return (
-        <span key={i} className="rounded px-1" style={{ color: "var(--mention)", background: "var(--mention-bg)" }}>
-          {part}
-        </span>
-      );
-    }
-    if (part.startsWith("#")) {
-      return (
-        <span key={i} className="font-mono" style={{ color: "var(--tag)" }}>
-          {part}
-        </span>
-      );
-    }
-    return <span key={i}>{part}</span>;
-  });
-}
 
 interface TodoCardProps {
   todo: Todo;
@@ -67,7 +45,7 @@ export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart,
           {todo.completed && <span className="text-white" style={{ fontSize: 11 }}>✓</span>}
         </button>
         <span className={`flex-1 text-sm font-bold ${todo.completed ? "line-through opacity-60" : ""}`}>
-          {highlight(todo.title)}
+          <TokenizedText text={todo.title} />
         </span>
       </div>
 

--- a/src/components/shell/heute/useMemberResolver.ts
+++ b/src/components/shell/heute/useMemberResolver.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { useMemberProfiles } from "@/lib/hooks/useMemberProfiles";
+import { useMemberProfiles, nameFromProfiles } from "@/lib/hooks/useMemberProfiles";
 import {
   extractMentionTokens,
   resolveMentionToken,
@@ -26,7 +26,7 @@ export function useMemberResolver(): MemberResolver {
   const members = activeSpace?.members ?? [];
   const profiles = useMemberProfiles(members);
 
-  const nameOf = (uid: string) => profiles[uid]?.displayName ?? "jemand";
+  const nameOf = (uid: string) => nameFromProfiles(profiles, uid);
   const firstName = (uid: string) => nameOf(uid).split(/\s+/)[0];
 
   // Resolve the first @mention in the text to exactly one member uid. Unicode-

--- a/src/components/shell/list/TodoComposer.tsx
+++ b/src/components/shell/list/TodoComposer.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { spaceColorFromHue } from "@/lib/theme/colors";
 import TodoEditor from "./TodoEditor";
 
 /**
@@ -12,10 +11,9 @@ import TodoEditor from "./TodoEditor";
  */
 export default function TodoComposer() {
   const { createTodo } = useTodos();
-  const { activeSpace } = useSpaces();
+  const { accent } = useSpaces();
   const [open, setOpen] = useState(false);
   const [quick, setQuick] = useState("");
-  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
 
   const quickAdd = async () => {
     const value = quick.trim();

--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { spaceColorFromHue } from "@/lib/theme/colors";
+import { useOutsideClick } from "@/lib/hooks/useOutsideClick";
 import TodoTitle from "./TodoTitle";
 import TodoBody from "./TodoBody";
 import TodoEditor from "./TodoEditor";
@@ -21,8 +21,7 @@ interface TodoRowProps {
 
 export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActions }: TodoRowProps) {
   const { setCompleted, editContent } = useTodos();
-  const { activeSpace } = useSpaces();
-  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
+  const { accent } = useSpaces();
 
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -32,14 +31,7 @@ export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActio
   const hasBody = !!todo.body && Array.isArray((todo.body as any).content) && (todo.body as any).content.length > 0;
   const progress = hasBody ? checklistProgress(todo.body) : { done: 0, total: 0 };
 
-  useEffect(() => {
-    if (!menuOpen) return;
-    const onDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [menuOpen]);
+  useOutsideClick(menuRef, menuOpen, () => setMenuOpen(false));
 
   if (editing) {
     return (

--- a/src/components/shell/list/TodoTitle.tsx
+++ b/src/components/shell/list/TodoTitle.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
-
-// Splits on @mentions and #tags while keeping the delimiters.
-const TOKEN = /(@[\w]+|#[\w]+)/g;
+import TokenizedText from "../TokenizedText";
 
 /**
  * Renders a todo title with @mention and #tag highlighting (issue #45).
@@ -12,41 +10,10 @@ const TOKEN = /(@[\w]+|#[\w]+)/g;
  */
 export default function TodoTitle({ title, completed }: { title: string; completed?: boolean }) {
   const { toggleTag } = useTodos();
-  const parts = title.split(TOKEN);
 
   return (
     <span className={`text-[15px] font-bold ${completed ? "line-through opacity-60" : ""}`}>
-      {parts.map((part, i) => {
-        if (part.startsWith("@")) {
-          return (
-            <span
-              key={i}
-              className="rounded px-1"
-              style={{ color: "var(--mention)", background: "var(--mention-bg)" }}
-            >
-              {part}
-            </span>
-          );
-        }
-        if (part.startsWith("#")) {
-          const tag = part.slice(1);
-          return (
-            <button
-              key={i}
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                toggleTag(tag);
-              }}
-              className="font-mono"
-              style={{ color: "var(--tag)" }}
-            >
-              {part}
-            </button>
-          );
-        }
-        return <span key={i}>{part}</span>;
-      })}
+      <TokenizedText text={title} onTagClick={toggleTag} />
     </span>
   );
 }

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -21,7 +21,7 @@ import {
   addSpaceMember,
   removeSpaceMember,
 } from "@/lib/firebase/firebaseUtils";
-import { SPACE_COLORS } from "@/lib/theme/colors";
+import { SPACE_COLORS, spaceColorFromHue } from "@/lib/theme/colors";
 import type { Space } from "@/lib/types";
 
 // Pick a palette hue for a new space, preferring one not already used by the
@@ -43,6 +43,8 @@ interface SpacesContextType {
   loading: boolean;
   activeSpaceId: string | null;
   activeSpace: Space | null;
+  /** Active space's accent color, or `var(--accent)` when none is selected. */
+  accent: string;
   /** Open-todo counts per spaceId (best-effort; absent until loaded). */
   openCounts: Record<string, number>;
   view: SpaceView;
@@ -239,12 +241,16 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   const activeSpace = spaces.find((s) => s.id === activeSpaceId) ?? null;
+  // Single source for the redesign's accent color (issue #81): the active
+  // space's hue, or the neutral token when no space is selected.
+  const accent = activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)";
 
   const value: SpacesContextType = {
     spaces,
     loading,
     activeSpaceId,
     activeSpace,
+    accent,
     openCounts,
     view,
     setActiveSpace: setActiveSpaceId,

--- a/src/lib/hooks/useMemberProfiles.ts
+++ b/src/lib/hooks/useMemberProfiles.ts
@@ -79,6 +79,21 @@ export function useMemberProfiles(memberUids: string[]): Record<string, PublicPr
   return profiles;
 }
 
+/** Fallback name for a member whose public profile hasn't resolved (yet). */
+export const UNKNOWN_MEMBER = "jemand";
+
+/**
+ * Resolves a member uid to a display name against a loaded profile map, falling
+ * back to {@link UNKNOWN_MEMBER}. Single source for the name + fallback shared by
+ * `useSpaceMemberNames` and the Heute `useMemberResolver` (issue #81).
+ */
+export function nameFromProfiles(
+  profiles: Record<string, PublicProfile>,
+  uid: string
+): string {
+  return profiles[uid]?.displayName ?? UNKNOWN_MEMBER;
+}
+
 /**
  * Returns a `nameOf(uid)` resolver for the active space's members (issue #45):
  * member display name, or "jemand" as a fallback.
@@ -86,5 +101,5 @@ export function useMemberProfiles(memberUids: string[]): Record<string, PublicPr
 export function useSpaceMemberNames(): (uid: string) => string {
   const { activeSpace } = useSpaces();
   const profiles = useMemberProfiles(activeSpace?.members ?? []);
-  return (uid: string) => profiles[uid]?.displayName ?? "jemand";
+  return (uid: string) => nameFromProfiles(profiles, uid);
 }

--- a/src/lib/hooks/useOutsideClick.ts
+++ b/src/lib/hooks/useOutsideClick.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { RefObject, useEffect, useRef } from "react";
+
+/**
+ * Closes a popover/menu on a mousedown outside `ref` while `active` (issue #81).
+ * Shared by the shell's outside-click consumers (InvitePopover, SpaceMenu,
+ * AccountMenu, list/TodoRow), which previously each inlined this effect.
+ *
+ * The latest `onOutside` is read through a ref, so the listener is (re)attached
+ * only when `active` toggles — not on every render, even if callers pass an
+ * inline closure.
+ */
+export function useOutsideClick<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  active: boolean,
+  onOutside: () => void
+): void {
+  const cb = useRef(onOutside);
+  cb.current = onOutside;
+
+  useEffect(() => {
+    if (!active) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) cb.current();
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [active, ref]);
+}


### PR DESCRIPTION
## Summary

Consolidates the four copy-pasted shell patterns flagged by `/code-review` (#81) into shared helpers, so they can no longer drift apart. **No behavior change** — pure refactor.

Closes #81

## Changes
- **`useOutsideClick(ref, active, onOutside)`** (`src/lib/hooks/useOutsideClick.ts`) — replaces the identical inline `mousedown` effect in `InvitePopover`, `SpaceMenu`, `AccountMenu`, and `list/TodoRow`. Reads the latest callback through a ref, so the document listener attaches only when `active` toggles (matching the old `[open]`-dep behavior).
- **`accent` on `SpacesContext`** — single source for `activeSpace ? spaceColorFromHue(activeSpace.color) : "var(--accent)"`, which was repeated in `BoardView`, `MobileBoard`, `TodoComposer`, `TodoRow`, and (as a direct `spaceColorFromHue` call) `SpaceHeader`.
- **`<TokenizedText text onTagClick?>`** (`src/components/shell/TokenizedText.tsx`) — one `@mention`/`#tag` highlighter for both `list/TodoTitle` (clickable tags → tag filter) and `board/TodoCard` (static), replacing two private `TOKEN` regexes + duplicated markup.
- **`nameFromProfiles` / `UNKNOWN_MEMBER`** (`src/lib/hooks/useMemberProfiles.ts`) — single source for the `displayName ?? "jemand"` fallback, now shared by `useSpaceMemberNames` and Heute's `useMemberResolver`.

### Deliberately left alone
`Sidebar` and `MobileHeader` keep calling `spaceColorFromHue(space.color)` directly — they color each space in a list by its *own* hue, which is not the active-space accent.

## Test Plan
- [x] `npx tsc --noEmit` — clean (no app errors)
- [x] `npm run lint` — only pre-existing `<img>` warnings, none from this change
- [x] grep sweep: no leftover accent ternary, inline outside-click effects, or duplicate TOKEN regex in `src/components/shell`
- [ ] Vercel check green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)