### PR TITLE
De-duplicate desktop/mobile view pairs (Board, Todos, New-Space) (#82)

### DIFF
--- a/src/components/shell/MobileShell.tsx
+++ b/src/components/shell/MobileShell.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useCreateSpace } from "./useCreateSpace";
 import MobileHeader from "./MobileHeader";
 import BottomTabs, { type MobileTab } from "./BottomTabs";
 import BottomSheet from "./BottomSheet";
@@ -26,25 +27,7 @@ function MobileContent({ tab }: { tab: MobileTab }) {
 
 /** "+ Space" creation form, shown inside the bottom sheet (issue #47). */
 function NewSpaceForm({ onDone }: { onDone: () => void }) {
-  const { createSpace } = useSpaces();
-  const [name, setName] = useState("");
-  const [busy, setBusy] = useState(false);
-
-  const submit = async () => {
-    const value = name.trim();
-    if (!value) return;
-    setBusy(true);
-    try {
-      const id = await createSpace(value);
-      // Only clear/close on success; keep the input on failure (toast shown) (#68).
-      if (id) {
-        setName("");
-        onDone();
-      }
-    } finally {
-      setBusy(false);
-    }
-  };
+  const { name, setName, busy, submit } = useCreateSpace();
 
   return (
     <div className="flex flex-col gap-3 pb-2">
@@ -54,14 +37,14 @@ function NewSpaceForm({ onDone }: { onDone: () => void }) {
         disabled={busy}
         onChange={(e) => setName(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter") submit();
+          if (e.key === "Enter") submit(onDone);
         }}
         placeholder="Space-Name"
         className="rounded-xl border border-border bg-bg-card px-4 py-3 text-base outline-none"
       />
       <button
         type="button"
-        onClick={submit}
+        onClick={() => submit(onDone)}
         disabled={busy || !name.trim()}
         className="rounded-full px-4 text-base font-extrabold text-white disabled:opacity-50"
         style={{ background: "var(--accent)", minHeight: 48 }}

--- a/src/components/shell/NewSpaceButton.tsx
+++ b/src/components/shell/NewSpaceButton.tsx
@@ -1,41 +1,25 @@
 "use client";
 
 import React, { useState } from "react";
-import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useCreateSpace } from "./useCreateSpace";
 
 /**
  * Sidebar "+ Neuer Space" entry (issue #47): a dim button that turns into an
  * inline input on click. Enter confirms, Escape/blur cancels.
  */
 export default function NewSpaceButton() {
-  const { createSpace } = useSpaces();
+  const { name, setName, busy, submit } = useCreateSpace();
   const [editing, setEditing] = useState(false);
-  const [name, setName] = useState("");
-  const [busy, setBusy] = useState(false);
 
   const cancel = () => {
     setName("");
     setEditing(false);
   };
 
-  const submit = async () => {
-    const value = name.trim();
-    if (!value) {
-      cancel();
-      return;
-    }
-    setBusy(true);
-    try {
-      const id = await createSpace(value);
-      // Keep the input open with the typed name on failure so it can be retried
-      // (createSpace shows an error toast); only clear/close on success (#68).
-      if (id) {
-        setName("");
-        setEditing(false);
-      }
-    } finally {
-      setBusy(false);
-    }
+  // Enter on an empty input closes the inline editor (matching the original).
+  const onEnter = () => {
+    if (!name.trim()) cancel();
+    else submit(() => setEditing(false));
   };
 
   if (!editing) {
@@ -57,7 +41,7 @@ export default function NewSpaceButton() {
       disabled={busy}
       onChange={(e) => setName(e.target.value)}
       onKeyDown={(e) => {
-        if (e.key === "Enter") submit();
+        if (e.key === "Enter") onEnter();
         else if (e.key === "Escape") cancel();
       }}
       onBlur={() => {

--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -1,39 +1,18 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
-import { useTodos } from "@/lib/contexts/TodosContext";
-import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { useAuth } from "@/lib/hooks/useAuth";
-import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
-import Avatar from "../Avatar";
+import React, { useState } from "react";
 import BoardGroupToggle from "./BoardGroupToggle";
+import ColumnHeader from "./ColumnHeader";
 import TodoCard from "./TodoCard";
-import { buildColumns, type BoardColumn, type GroupBy } from "./columns";
+import { useBoardColumns } from "./useBoardColumns";
+import { type BoardColumn, type GroupBy } from "./columns";
 
 /** Desktop Board view (issue #46): horizontal columns with HTML5 drag & drop. */
 export default function BoardView() {
-  const { todos, loading, setWaitingOn, setStatus } = useTodos();
-  const { activeSpace, accent } = useSpaces();
-  const { user } = useAuth();
-  const nameOf = useSpaceMemberNames();
-
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
+  const { columns, loading, accent, nameOf } = useBoardColumns(groupBy);
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<string | null>(null);
-
-  const columns = useMemo(
-    () =>
-      buildColumns({
-        groupBy,
-        todos,
-        members: activeSpace?.members ?? [],
-        currentUid: user?.uid,
-        nameOf,
-        setWaitingOn,
-        setStatus,
-      }),
-    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setStatus]
-  );
 
   const onDrop = async (col: BoardColumn) => {
     const id = dragId;
@@ -77,11 +56,7 @@ export default function BoardView() {
                 transition: "background 0.15s, border-color 0.15s",
               }}
             >
-              <div className="flex items-center gap-2 px-1 pb-1">
-                {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
-                <span className="text-xs font-extrabold uppercase tracking-wide text-text-dim">{col.label}</span>
-                {col.todos.length > 0 && <span className="ml-auto text-xs text-text-dim">{col.todos.length}</span>}
-              </div>
+              <ColumnHeader col={col} nameOf={nameOf} className="px-1 pb-1" />
               {col.todos.map((t) => (
                 <TodoCard
                   key={t.id}

--- a/src/components/shell/board/ColumnHeader.tsx
+++ b/src/components/shell/board/ColumnHeader.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React from "react";
+import Avatar from "../Avatar";
+import type { BoardColumn } from "./columns";
+
+/**
+ * Board column header (issue #82): optional member avatar + label + count,
+ * shared by the desktop and mobile boards. `className` lets the desktop add its
+ * column padding (`px-1 pb-1`).
+ */
+export default function ColumnHeader({
+  col,
+  nameOf,
+  className,
+}: {
+  col: BoardColumn;
+  nameOf: (uid: string) => string;
+  className?: string;
+}) {
+  return (
+    <div className={`flex items-center gap-2${className ? ` ${className}` : ""}`}>
+      {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
+      <span className="text-xs font-extrabold uppercase tracking-wide text-text-dim">{col.label}</span>
+      {col.todos.length > 0 && <span className="ml-auto text-xs text-text-dim">{col.todos.length}</span>}
+    </div>
+  );
+}

--- a/src/components/shell/board/MobileBoard.tsx
+++ b/src/components/shell/board/MobileBoard.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
-import { useTodos } from "@/lib/contexts/TodosContext";
-import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { useAuth } from "@/lib/hooks/useAuth";
-import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import React, { useState } from "react";
 import Avatar from "../Avatar";
 import BottomSheet from "../BottomSheet";
 import BoardGroupToggle from "./BoardGroupToggle";
+import ColumnHeader from "./ColumnHeader";
 import TodoCard from "./TodoCard";
-import { buildColumns, type GroupBy } from "./columns";
+import { useBoardColumns } from "./useBoardColumns";
+import { type GroupBy } from "./columns";
 import type { Todo } from "@/lib/types";
 
 /**
@@ -17,27 +15,9 @@ import type { Todo } from "@/lib/types";
  * each card has a "Verschieben" sheet listing the other columns as targets.
  */
 export default function MobileBoard() {
-  const { todos, loading, setWaitingOn, setStatus } = useTodos();
-  const { activeSpace, accent } = useSpaces();
-  const { user } = useAuth();
-  const nameOf = useSpaceMemberNames();
-
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
+  const { columns, loading, accent, nameOf } = useBoardColumns(groupBy);
   const [moveCard, setMoveCard] = useState<Todo | null>(null);
-
-  const columns = useMemo(
-    () =>
-      buildColumns({
-        groupBy,
-        todos,
-        members: activeSpace?.members ?? [],
-        currentUid: user?.uid,
-        nameOf,
-        setWaitingOn,
-        setStatus,
-      }),
-    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setStatus]
-  );
 
   const targets = columns.filter((c) => c.apply);
 
@@ -50,11 +30,7 @@ export default function MobileBoard() {
       ) : (
         columns.map((col) => (
           <section key={col.id} className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              {col.badgeUid && <Avatar uid={col.badgeUid} name={nameOf(col.badgeUid)} size={20} />}
-              <span className="text-xs font-extrabold uppercase tracking-wide text-text-dim">{col.label}</span>
-              {col.todos.length > 0 && <span className="ml-auto text-xs text-text-dim">{col.todos.length}</span>}
-            </div>
+            <ColumnHeader col={col} nameOf={nameOf} />
             {col.todos.map((t) => (
               <TodoCard key={t.id} todo={t} accent={accent} nameOf={nameOf} onMove={() => setMoveCard(t)} />
             ))}

--- a/src/components/shell/board/useBoardColumns.ts
+++ b/src/components/shell/board/useBoardColumns.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import { buildColumns, type BoardColumn, type GroupBy } from "./columns";
+
+export interface BoardColumnsState {
+  columns: BoardColumn[];
+  loading: boolean;
+  accent: string;
+  nameOf: (uid: string) => string;
+}
+
+/**
+ * Shared Board state for the desktop and mobile boards (issue #82): builds the
+ * grouped columns and exposes the accent + name resolver they both need. The two
+ * boards previously carried an identical hooks block + `buildColumns` useMemo and
+ * differ only in chrome (desktop drag & drop grid vs. mobile stacked sections +
+ * "Verschieben" sheet).
+ */
+export function useBoardColumns(groupBy: GroupBy): BoardColumnsState {
+  const { todos, loading, setWaitingOn, setStatus } = useTodos();
+  const { activeSpace, accent } = useSpaces();
+  const { user } = useAuth();
+  const nameOf = useSpaceMemberNames();
+
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        groupBy,
+        todos,
+        members: activeSpace?.members ?? [],
+        currentUid: user?.uid,
+        nameOf,
+        setWaitingOn,
+        setStatus,
+      }),
+    [groupBy, todos, activeSpace, user, nameOf, setWaitingOn, setStatus]
+  );
+
+  return { columns, loading, accent, nameOf };
+}

--- a/src/components/shell/list/ListView.tsx
+++ b/src/components/shell/list/ListView.tsx
@@ -1,60 +1,21 @@
 "use client";
 
-import React, { useState } from "react";
-import { useTodos } from "@/lib/contexts/TodosContext";
-import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import React from "react";
 import TagFilterBar from "./TagFilterBar";
 import TodoComposer from "./TodoComposer";
-import TodoRow from "./TodoRow";
+import TodoSections from "./TodoSections";
 
 /**
  * Desktop Liste view (issue #45): tag filter + composer + open todos + a
  * collapsible "Erledigt" section.
  */
 export default function ListView() {
-  const { filtered, loading } = useTodos();
-  const nameOf = useSpaceMemberNames();
-  const [showDone, setShowDone] = useState(false);
-
-  const open = filtered.filter((t) => !t.completed);
-  const done = filtered.filter((t) => t.completed);
-
   return (
     <div className="flex flex-col gap-3">
       <div className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Todos</div>
       <TagFilterBar />
       <TodoComposer />
-
-      {loading ? (
-        <p className="py-2 text-sm text-text-dim">Lädt …</p>
-      ) : (
-        <>
-          <div className="flex flex-col gap-1">
-            {open.map((t) => (
-              <TodoRow key={t.id} todo={t} nameOf={nameOf} />
-            ))}
-            {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
-          </div>
-
-          {done.length > 0 && (
-            <div className="flex flex-col gap-1">
-              <button
-                type="button"
-                onClick={() => setShowDone((s) => !s)}
-                className="self-start text-sm font-semibold text-text-dim hover:text-text"
-              >
-                Erledigt ({done.length}) {showDone ? "▲" : "▼"}
-              </button>
-              {showDone &&
-                done.map((t) => (
-                  <div key={t.id} style={{ opacity: 0.55 }}>
-                    <TodoRow todo={t} nameOf={nameOf} />
-                  </div>
-                ))}
-            </div>
-          )}
-        </>
-      )}
+      <TodoSections />
     </div>
   );
 }

--- a/src/components/shell/list/MobileTodos.tsx
+++ b/src/components/shell/list/MobileTodos.tsx
@@ -5,7 +5,7 @@ import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
 import TagFilterBar from "./TagFilterBar";
 import TodoComposer from "./TodoComposer";
-import TodoRow from "./TodoRow";
+import TodoSections from "./TodoSections";
 import TodoActions from "./TodoActions";
 import TodoEditor from "./TodoEditor";
 import BottomSheet from "../BottomSheet";
@@ -16,50 +16,16 @@ import type { Todo } from "@/lib/types";
  * and edit form open as bottom sheets (the sheet covers the mobile shell root).
  */
 export default function MobileTodos() {
-  const { filtered, loading, editContent } = useTodos();
+  const { editContent } = useTodos();
   const nameOf = useSpaceMemberNames();
-  const [showDone, setShowDone] = useState(false);
   const [actionsFor, setActionsFor] = useState<Todo | null>(null);
   const [editFor, setEditFor] = useState<Todo | null>(null);
-
-  const open = filtered.filter((t) => !t.completed);
-  const done = filtered.filter((t) => t.completed);
 
   return (
     <div className="flex flex-col gap-3">
       <TagFilterBar />
       <TodoComposer />
-
-      {loading ? (
-        <p className="py-2 text-sm text-text-dim">Lädt …</p>
-      ) : (
-        <>
-          <div className="flex flex-col gap-2">
-            {open.map((t) => (
-              <TodoRow key={t.id} todo={t} nameOf={nameOf} variant="mobile" onOpenActions={setActionsFor} />
-            ))}
-            {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
-          </div>
-
-          {done.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <button
-                type="button"
-                onClick={() => setShowDone((s) => !s)}
-                className="self-start text-sm font-semibold text-text-dim"
-              >
-                Erledigt ({done.length}) {showDone ? "▲" : "▼"}
-              </button>
-              {showDone &&
-                done.map((t) => (
-                  <div key={t.id} style={{ opacity: 0.55 }}>
-                    <TodoRow todo={t} nameOf={nameOf} variant="mobile" onOpenActions={setActionsFor} />
-                  </div>
-                ))}
-            </div>
-          )}
-        </>
-      )}
+      <TodoSections variant="mobile" onOpenActions={setActionsFor} />
 
       <BottomSheet open={!!actionsFor} onClose={() => setActionsFor(null)}>
         {actionsFor && (

--- a/src/components/shell/list/TodoSections.tsx
+++ b/src/components/shell/list/TodoSections.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
+import TodoRow from "./TodoRow";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Shared open + collapsible "Erledigt" todo sections (issue #82) for the desktop
+ * Liste (`ListView`) and the mobile Todos tab (`MobileTodos`). The two views
+ * differ only in row chrome: desktop rows use an inline actions popover; mobile
+ * rows open a bottom sheet via `onOpenActions` (handled by the caller).
+ */
+export default function TodoSections({
+  variant = "desktop",
+  onOpenActions,
+}: {
+  variant?: "desktop" | "mobile";
+  onOpenActions?: (todo: Todo) => void;
+}) {
+  const { filtered, loading } = useTodos();
+  const nameOf = useSpaceMemberNames();
+  const [showDone, setShowDone] = useState(false);
+
+  const open = filtered.filter((t) => !t.completed);
+  const done = filtered.filter((t) => t.completed);
+  const gap = variant === "mobile" ? "gap-2" : "gap-1";
+
+  if (loading) return <p className="py-2 text-sm text-text-dim">Lädt …</p>;
+
+  return (
+    <>
+      <div className={`flex flex-col ${gap}`}>
+        {open.map((t) => (
+          <TodoRow key={t.id} todo={t} nameOf={nameOf} variant={variant} onOpenActions={onOpenActions} />
+        ))}
+        {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
+      </div>
+
+      {done.length > 0 && (
+        <div className={`flex flex-col ${gap}`}>
+          <button
+            type="button"
+            onClick={() => setShowDone((s) => !s)}
+            className="self-start text-sm font-semibold text-text-dim hover:text-text"
+          >
+            Erledigt ({done.length}) {showDone ? "▲" : "▼"}
+          </button>
+          {showDone &&
+            done.map((t) => (
+              <div key={t.id} style={{ opacity: 0.55 }}>
+                <TodoRow todo={t} nameOf={nameOf} variant={variant} onOpenActions={onOpenActions} />
+              </div>
+            ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/shell/useCreateSpace.ts
+++ b/src/components/shell/useCreateSpace.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+
+/**
+ * Shared "create a space" form state (issue #82) for the desktop sidebar
+ * (`NewSpaceButton`) and the mobile bottom-sheet form (`MobileShell`). Holds the
+ * name + busy state and a `submit()` that keeps the input on failure (#68) and
+ * only runs `onSuccess` after a successful create.
+ */
+export function useCreateSpace() {
+  const { createSpace } = useSpaces();
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const submit = async (onSuccess?: () => void): Promise<boolean> => {
+    const value = name.trim();
+    if (!value) return false;
+    setBusy(true);
+    try {
+      const id = await createSpace(value);
+      // Keep the input with the typed name on failure so it can be retried
+      // (createSpace shows an error toast); only clear/close on success (#68).
+      if (id) {
+        setName("");
+        onSuccess?.();
+        return true;
+      }
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return { name, setName, busy, submit };
+}


### PR DESCRIPTION
## Summary

The desktop/mobile component pairs flagged in #82 carried ~90% identical logic that would drift apart. This extracts the shared parts into hooks/components; each view keeps only its distinct chrome. **No behavior change** — pure refactor.

Closes #82

## Changes

**Board** — `useBoardColumns(groupBy)` (`board/useBoardColumns.ts`) + `<ColumnHeader>` (`board/ColumnHeader.tsx`)
- `BoardView` and `MobileBoard` shared an identical hooks block, `buildColumns` `useMemo`, and column-header markup. Both now call the hook and render `<ColumnHeader>`.
- Desktop keeps its horizontal DnD grid; mobile keeps its stacked sections + "Verschieben" bottom sheet.

**Todos** — `<TodoSections variant onOpenActions?>` (`list/TodoSections.tsx`)
- `ListView` and `MobileTodos` shared the open/done partition and the collapsible "Erledigt" rendering. Both now render `<TodoSections>`.
- Desktop rows use the inline actions popover; mobile rows open a bottom sheet via `onOpenActions` (MobileTodos keeps its actions/edit sheets).

**New space** — `useCreateSpace()` (`useCreateSpace.ts`)
- `NewSpaceButton` (sidebar) and `MobileShell`'s `NewSpaceForm` shared the `name`/`busy` state and a `submit()` carrying the #68 keep-input-on-failure logic. Both now use the hook; each keeps its own markup (inline button↔input with Escape/blur cancel vs. sheet form with an "Anlegen" button).

### Deliberately left alone
`Heute` / `MobileHeute` already delegate to the shared `HeuteList` / `HeuteInput` and differ only in header chrome (container, icon, counter, input placement), so there was nothing left to extract.

## Test Plan
- [x] `npx tsc --noEmit` — clean (no app errors)
- [x] `npm run lint` — only pre-existing `<img>` warnings, none from this change
- [x] Manual read-through: desktop DnD grid, mobile move-sheet, and mobile actions/edit sheets all preserved
- [ ] Vercel check green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)