### PR TITLE
Drop the .dark dual-system; key dark: variants on data-theme (#84)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,9 +5,10 @@
 /* === Redesign design tokens (issue #39) ===========================
  * Source of truth: docs/design_handoff_aido_redesign/README.md → "Design Tokens".
  * Dark is the default (:root); light is an override on html[data-theme="light"].
- * ThemeContext toggles BOTH data-theme (new token system) and the legacy
- * .dark class (existing Tailwind dark: variants) so old and new UI stay in sync
- * during the migration. Tailwind utilities map onto these vars in tailwind.config.ts.
+ * `data-theme` is the single theme mechanism (issue #84): it drives these tokens,
+ * Tailwind's `dark:` variants (darkMode keyed on [data-theme="dark"]), and the
+ * legacy `:is([data-theme="dark"] .ProseMirror …)` overrides below. Tailwind
+ * utilities map onto these vars in tailwind.config.ts.
  */
 :root {
   --bg: oklch(0.22 0.02 270);
@@ -81,7 +82,7 @@ body {
 }
 
 /* Dark mode text color override */
-:is(.dark .ProseMirror) {
+:is([data-theme="dark"] .ProseMirror) {
    color: #f3f4f6 !important; /* Tailwind gray-100 */
 }
 
@@ -153,11 +154,11 @@ body {
 }
 
 /* Dark mode specific overrides if needed */
-:is(.dark .ProseMirror blockquote) {
+:is([data-theme="dark"] .ProseMirror blockquote) {
    border-color: #4b5563 !important; /* Assuming default dark gray-600/700 */
 }
 
-:is(.dark .ProseMirror pre) {
+:is([data-theme="dark"] .ProseMirror pre) {
   background-color: #374151 !important; /* Tailwind gray-700 */
 }
 
@@ -195,7 +196,7 @@ body {
   font-weight: 600; /* ADDED semi-bold */
 }
 
-:is(.dark .ProseMirror .mention) {
+:is([data-theme="dark"] .ProseMirror .mention) {
   color: #bfdbfe; /* Tailwind blue-200 */
   font-weight: 600; /* ADDED semi-bold */
 }
@@ -211,7 +212,7 @@ body {
   text-decoration: underline; /* Underline on hover */
 }
 
-:is(.dark .ProseMirror a) {
+:is([data-theme="dark"] .ProseMirror a) {
   color: #60a5fa; /* Tailwind blue-400 */
 }
 
@@ -221,7 +222,7 @@ body {
   /* font-weight: 600; */ /* Keep semi-bold if desired? */
 }
 
-:is(.dark .ProseMirror .hashtag) {
+:is([data-theme="dark"] .ProseMirror .hashtag) {
   color: #4ade80; /* Tailwind green-400 */
   /* font-weight: 600; */
 }

--- a/src/lib/contexts/ThemeContext.tsx
+++ b/src/lib/contexts/ThemeContext.tsx
@@ -19,11 +19,11 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-// applyTheme resolves the effective theme and applies it to <html>:
-//  - data-theme="light|dark" drives the redesign oklch tokens (globals.css).
-//  - the legacy .dark class keeps existing Tailwind `dark:` variants working
-//    until every screen is migrated. Both are toggled together so old and new
-//    UI never disagree about the active theme.
+// applyTheme resolves the effective theme and applies it to <html> via the
+// single `data-theme="light|dark"` attribute (issue #84): it drives the redesign
+// oklch tokens (globals.css) AND Tailwind's `dark:` variants, which key off
+// [data-theme="dark"] (tailwind.config.ts) — so there is one theme mechanism and
+// the legacy UI can never disagree with the new UI about the active theme.
 const applyTheme = (theme: Theme, pathname: string): 'light' | 'dark' => {
   let effectiveTheme: 'light' | 'dark';
 
@@ -36,9 +36,7 @@ const applyTheme = (theme: Theme, pathname: string): 'light' | 'dark' => {
     effectiveTheme = theme;
   }
 
-  const root = document.documentElement;
-  root.setAttribute('data-theme', effectiveTheme);
-  root.classList.toggle('dark', effectiveTheme === 'dark');
+  document.documentElement.setAttribute('data-theme', effectiveTheme);
 
   return effectiveTheme;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,10 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: 'class',
+  // Single theme mechanism (issue #84): `dark:` variants key off the same
+  // `data-theme="dark"` attribute that drives the redesign oklch tokens, so
+  // ThemeContext no longer needs a parallel `.dark` class for the legacy UI.
+  darkMode: ['selector', '[data-theme="dark"]'],
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary

`ThemeContext` toggled **both** `data-theme` **and** a legacy `.dark` class in parallel — a transitional dual-system that would silently diverge if future code ever touched only one mechanism. This collapses theming onto a **single mechanism: `data-theme`**.

Closes #84

## Approach

The issue flagged ~100 remaining `dark:` consumers. They're **all legacy UI** (contacts, login, settings, `UserSettings`, `TiptapToolbar`, `ErrorDialog`, `ApiKeySettings`, `SuggestionList`) — none are in the redesigned token-based shell. Rather than visually restyle all ~100 to semantic tokens (a large, risky redesign of legacy pages, out of scope for a cleanup), I repoint the **mechanism** so `data-theme` is the single source of truth — which is exactly what "ein einziger Theme-Mechanismus" asks for, with **zero visual change**.

## Changes
- **`tailwind.config.ts`** — `darkMode: 'class'` → `darkMode: ['selector', '[data-theme="dark"]']`, so `dark:` variants key off the same attribute as the oklch tokens.
- **`globals.css`** — the six `:is(.dark .ProseMirror …)` overrides → `:is([data-theme="dark"] .ProseMirror …)`; header comment updated.
- **`ThemeContext.tsx`** — drop `root.classList.toggle('dark', …)`; `applyTheme` now sets only `data-theme`. (`applyTheme` already set `data-theme="dark"` explicitly, so the attribute selector is always valid.)

## Why this is safe
- `dark:` class names in JSX are unchanged (`dark:bg-gray-800` etc.); only the **condition** moves from `.dark` ancestor to `[data-theme="dark"]` ancestor.
- No JS anywhere reads the `.dark` class (grep-verified).
- The `.dark` class was JS-applied after hydration, exactly like `data-theme` — so the pre-hydration flash behavior is unchanged.

## Test Plan
- [x] `npm run build` — succeeds (runs lint + type-check)
- [x] Built CSS verified: `.dark\:bg-gray-900:where([data-theme=dark],[data-theme=dark] *){…}` — every legacy `dark:` utility now keys on `[data-theme=dark]`
- [x] Built CSS verified: the `.dark .ProseMirror` overrides now emit `[data-theme=dark] .ProseMirror …`
- [x] Built CSS verified: **no** bare `.dark ` compound selector survives
- [ ] Vercel check green before merge
- [ ] Manual: toggle light/dark in Settings → legacy pages (Kontakte, Settings) + Tiptap editor still theme correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)