### PR TITLE
Pilot: migrate settings page chrome to design tokens (#107)

### DIFF
--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -9,9 +9,9 @@ export const metadata: Metadata = {
 
 export default function SettingsPage() {
   return (
-    <main className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+    <main className="min-h-screen bg-bg py-8">
       <div className="mx-auto mb-4 max-w-3xl px-4">
-        <Link href="/todos" className="text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100">
+        <Link href="/todos" className="text-sm text-text-dim hover:text-text">
           ← Zurück zu aido
         </Link>
       </div>


### PR DESCRIPTION
## Summary

First, smallest-chunk **pilot** for #107 (legacy `dark:`-gray → design-token migration). Migrates the `/settings` page wrapper to semantic tokens and establishes the gray→token mapping convention the rest of #107 will follow.

Part of #107 (does **not** close it — one of ~9 files).

## Changes
`src/app/(protected)/settings/page.tsx`:
- `bg-gray-50 dark:bg-gray-900` → `bg-bg`
- `text-gray-500 dark:text-gray-400` → `text-text-dim`
- `hover:text-gray-800 dark:hover:text-gray-100` → `hover:text-text`

## Mapping convention established for #107
| Legacy | Token |
|--------|-------|
| `bg-gray-50 dark:bg-gray-900` (page) | `bg-bg` |
| `bg-white dark:bg-gray-800` (card) | `bg-bg-card` |
| `text-gray-900 dark:text-gray-100` | `text-text` |
| `text-gray-500/600 dark:text-gray-400` | `text-text-dim` |
| `hover:text-gray-800 dark:hover:text-gray-100` | `hover:text-text` |
| `border-gray-300 dark:border-gray-600/700` | `border-border` |
| accent (`blue-500/600`) | `accent` (`text-/border-/bg-accent`) |

## Why low-risk
The token values closely match the gray shades they replace (e.g. light `--bg` ≈ `gray-50`, dark `--bg` ≈ `gray-900`), so the page looks near-identical — it just now themes via `data-theme` like the redesign shell. The `<UserSettings>` child still carries its own `dark:` palette and migrates in a follow-up; the interim mix (token page bg + gray card) is expected and visually fine.

## Test Plan
- [x] `grep dark:`/`gray-` in the file — empty
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — only pre-existing `<img>` warnings
- [ ] Vercel check green before merge
- [ ] Manual: toggle Light/Dark/System on `/settings` — background + back-link theme correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)