### PR TITLE
Migrate login + protected-layout chrome to design tokens (#107)

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -25,8 +25,8 @@ export default function ProtectedLayout({
   if (loading || !user) {
     // You can replace this with a nicer loading spinner component
     return (
-        <div className="min-h-screen flex items-center justify-center dark:bg-gray-900">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 dark:border-blue-400"></div>
+        <div className="min-h-screen flex items-center justify-center bg-bg">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent"></div>
         </div>
     );
   }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,12 +19,12 @@ export default function LoginPage() {
   // Show loading indicator or null while checking auth state
   if (loading || user) {
       // Or a loading spinner
-      return <div className="min-h-screen flex items-center justify-center dark:bg-gray-900">Loading...</div>; 
+      return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
   }
 
   // Render Login section only if not loading and no user
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-bg">
       <div className="flex flex-col items-center mb-8">
         <Image
           src="/aido_logo_big.png"
@@ -33,13 +33,13 @@ export default function LoginPage() {
           height={240}
           className="rounded-full mb-4"
         />
-        <h2 className="text-4xl font-bold text-gray-800 dark:text-gray-100 mb-8">
+        <h2 className="text-4xl font-bold text-text mb-8">
           Aido
         </h2>
       </div>
       <button
         onClick={signInWithGoogle}
-        className="inline-flex items-center px-6 py-3 bg-white border border-gray-300 rounded-md shadow-sm text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-600 dark:focus:ring-offset-gray-900"
+        className="inline-flex items-center px-6 py-3 bg-bg-card border border-border rounded-md shadow-sm text-base font-medium text-text hover:bg-row-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg focus:ring-accent"
       >
         Sign in with Google
       </button>


### PR DESCRIPTION
## Summary

Next two small chunks of #107 after the settings pilot (#108) — both are auth/loading chrome.

Part of #107 (does **not** close it).

## Changes

**`src/app/login/page.tsx`**
- `bg-gray-50 dark:bg-gray-900` → `bg-bg`
- `text-gray-800 dark:text-gray-100` → `text-text`
- Google button: `bg-white border-gray-300 text-gray-700 hover:bg-gray-50 ring-blue-500` + all `dark:` variants → `bg-bg-card border-border text-text hover:bg-row-hover focus:ring-accent focus:ring-offset-bg`
- loading fallback: `dark:bg-gray-900` → `bg-bg text-text` (the text token keeps "Loading…" legible on the token background — it was effectively invisible before on the dark-only bg)

**`src/app/(protected)/layout.tsx`**
- loading container: `dark:bg-gray-900` → `bg-bg`
- spinner: `border-blue-500 dark:border-blue-400` → `border-accent`

## New token utilities — build-verified
These weren't used before, so I confirmed they generate in the production build:
- `.border-accent{border-color:var(--accent)}`
- `.focus\:ring-accent:focus{--tw-ring-color:var(--accent)}`
- `.focus\:ring-offset-bg:focus{--tw-ring-offset-color:var(--bg)}`

## Notes
The login page is force-dark (`ThemeContext` pins `/login` to dark), so its tokens resolve to the dark palette — visually near-identical to before, now via `data-theme`. The spinner shifts from blue to the redesign accent (intended — it adopts the token design language).

## Test Plan
- [x] `npm run build` — succeeds (runs lint + type-check)
- [x] Built CSS verified for the three new token utilities above
- [x] `grep dark:/gray-/blue-` in both files — empty
- [ ] Vercel check green before merge
- [ ] Manual: `/login` (dark) + a protected route's loading flash render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)