### PR TITLE
Migrate ErrorDialog to design tokens (#107)

### DIFF
--- a/src/components/ErrorDialog.tsx
+++ b/src/components/ErrorDialog.tsx
@@ -36,22 +36,22 @@ ${error.stack || 'N/A'}
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center p-4">
-      <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full">
-        <h2 className="text-xl font-semibold text-red-600 dark:text-red-400 mb-4">Ein Fehler ist aufgetreten</h2>
-        <p className="text-gray-700 dark:text-gray-300 mb-4">
+      <div className="bg-bg-card p-6 rounded-lg shadow-xl max-w-md w-full">
+        <h2 className="text-xl font-semibold text-danger mb-4">Ein Fehler ist aufgetreten</h2>
+        <p className="text-text mb-4">
           Entschuldigung, es ist ein unerwartetes Problem aufgetreten. Bitte versuchen Sie es später erneut oder kontaktieren Sie den Support, falls das Problem weiterhin besteht.
         </p>
 
         <details className="mb-4" open={isDetailsOpen} onToggle={(e) => setIsDetailsOpen(e.currentTarget.open)}>
-          <summary className="cursor-pointer text-sm text-blue-600 dark:text-blue-400 hover:underline">
+          <summary className="cursor-pointer text-sm text-accent-text hover:underline">
             Technische Details anzeigen
           </summary>
-          <pre className="mt-2 p-3 bg-gray-100 dark:bg-gray-700 rounded text-xs text-gray-800 dark:text-gray-200 overflow-auto max-h-40">
+          <pre className="mt-2 p-3 bg-bg rounded text-xs text-text overflow-auto max-h-40">
             {technicalDetails.trim()}
           </pre>
           <button
             onClick={copyToClipboard}
-            className="mt-2 text-xs px-3 py-1 bg-blue-500 hover:bg-blue-600 text-white rounded disabled:opacity-50"
+            className="mt-2 text-xs px-3 py-1 bg-accent hover:opacity-90 text-white rounded disabled:opacity-50"
             disabled={!navigator.clipboard} // Disable if clipboard API not available
           >
             Details kopieren
@@ -60,7 +60,7 @@ ${error.stack || 'N/A'}
 
         <button
           onClick={onClose}
-          className="w-full px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 rounded hover:bg-gray-400 dark:hover:bg-gray-500"
+          className="w-full px-4 py-2 bg-row-hover text-text rounded hover:bg-border"
         >
           Schließen
         </button>


### PR DESCRIPTION
## Summary

Continues #107. Migrates the error dialog (`src/components/ErrorDialog.tsx`) off the gray palette onto semantic tokens, introducing two semantic mappings the rest of #107 will reuse: **`text-danger`** for error red and **`text-accent-text`** for inline accent links.

Part of #107 (does **not** close it).

## Changes
- card: `bg-white dark:bg-gray-800` → `bg-bg-card`
- heading: `text-red-600 dark:text-red-400` → `text-danger`
- body: `text-gray-700 dark:text-gray-300` → `text-text`
- details link: `text-blue-600 dark:text-blue-400` → `text-accent-text`
- `<pre>`: `bg-gray-100 dark:bg-gray-700` + `text-gray-800 dark:text-gray-200` → `bg-bg` + `text-text`
- copy button: `bg-blue-500 hover:bg-blue-600` → `bg-accent hover:opacity-90`
- close button: `bg-gray-300 dark:bg-gray-600 text-gray-800 dark:text-gray-200 hover:bg-gray-400 dark:hover:bg-gray-500` → `bg-row-hover text-text hover:bg-border`

The `bg-black bg-opacity-50` modal scrim is theme-agnostic and left as-is.

## Mapping additions for #107
| Legacy | Token |
|--------|-------|
| `text-red-600 dark:text-red-400` (error) | `text-danger` |
| `text-blue-600 dark:text-blue-400` (link) | `text-accent-text` |
| `bg-blue-500 hover:bg-blue-600` (primary btn) | `bg-accent hover:opacity-90` |
| `bg-gray-300 dark:bg-gray-600 … hover:…` (neutral btn) | `bg-row-hover text-text hover:bg-border` |

## Test Plan
- [x] `npm run build` — succeeds (lint + type-check)
- [x] Built CSS verified: `.text-danger{color:var(--danger)}`, `.text-accent-text{color:var(--accent-text)}`, `.bg-accent{background-color:var(--accent)}`, `hover\:bg-border:hover{background-color:var(--border)}`
- [x] `grep dark:/gray-/blue-/red-` in file — empty
- [ ] Vercel check green before merge
- [ ] Manual: trigger an error → dialog themes correctly in light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)