### PR TITLE
Migrate ApiKeySettings to design tokens (#107)

### DIFF
--- a/src/components/ApiKeySettings.tsx
+++ b/src/components/ApiKeySettings.tsx
@@ -83,24 +83,24 @@ export default function ApiKeySettings() {
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-      <h2 className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100">API Key</h2>
-      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+    <div className="bg-bg-card p-6 rounded-lg shadow">
+      <h2 className="text-xl font-semibold mb-2 text-text">API Key</h2>
+      <p className="text-sm text-text-dim mb-4">
         Personal key for connecting external tools (e.g. MCP clients) to your account.
       </p>
 
       {freshKey && (
-        <div className="mb-4 p-3 border border-amber-400 bg-amber-50 dark:bg-amber-900/30 rounded-lg">
-          <p className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-2">
+        <div className="mb-4 p-3 border border-wait-text bg-wait-bg rounded-lg">
+          <p className="text-sm font-medium text-wait-text mb-2">
             Copy this key now — it will not be shown again.
           </p>
           <div className="flex items-center gap-2">
-            <code className="flex-1 p-2 text-xs break-all bg-white dark:bg-gray-900 border dark:border-gray-700 rounded text-gray-900 dark:text-gray-100">
+            <code className="flex-1 p-2 text-xs break-all bg-bg border border-border rounded text-text">
               {freshKey}
             </code>
             <button
               onClick={handleCopy}
-              className="px-3 py-2 text-sm bg-amber-600 text-white rounded hover:bg-amber-700"
+              className="px-3 py-2 text-sm bg-accent text-white rounded hover:opacity-90"
             >
               {copied ? 'Copied' : 'Copy'}
             </button>
@@ -109,16 +109,16 @@ export default function ApiKeySettings() {
       )}
 
       {metadata === null && !error ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400">Loading…</p>
+        <p className="text-sm text-text-dim">Loading…</p>
       ) : (
         <div className="space-y-3">
           {metadata?.exists ? (
-            <div className="text-sm text-gray-700 dark:text-gray-300">
+            <div className="text-sm text-text">
               <p>
                 Active key: <code className="text-xs">{metadata.keyPrefix}…</code>
               </p>
               {metadata.createdAt && (
-                <p className="text-gray-500 dark:text-gray-400">
+                <p className="text-text-dim">
                   Created {new Date(metadata.createdAt).toLocaleString()}
                   {metadata.lastUsedAt
                     ? `, last used ${new Date(metadata.lastUsedAt).toLocaleString()}`
@@ -127,14 +127,14 @@ export default function ApiKeySettings() {
               )}
             </div>
           ) : (
-            <p className="text-sm text-gray-500 dark:text-gray-400">No API key yet.</p>
+            <p className="text-sm text-text-dim">No API key yet.</p>
           )}
 
           <div className="flex gap-2">
             <button
               onClick={handleGenerate}
               disabled={busy}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              className="px-4 py-2 bg-accent text-white rounded-lg hover:opacity-90 disabled:opacity-50"
             >
               {metadata?.exists ? 'Rotate Key' : 'Generate Key'}
             </button>
@@ -142,7 +142,7 @@ export default function ApiKeySettings() {
               <button
                 onClick={handleRevoke}
                 disabled={busy}
-                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+                className="px-4 py-2 bg-danger text-white rounded-lg hover:opacity-90 disabled:opacity-50"
               >
                 Revoke
               </button>
@@ -152,7 +152,7 @@ export default function ApiKeySettings() {
       )}
 
       {error && (
-        <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+        <p className="mt-3 text-sm text-danger">{error}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Continues #107. Tokenizes `src/components/ApiKeySettings.tsx`, mapping the amber "copy this key now" warning callout onto the app's existing amber **`wait`** semantic tokens (the same ones the board uses for "wartet auf").

Part of #107 (does **not** close it).

## Changes
- card / headings / body: `bg-white dark:bg-gray-800`, `text-gray-900/600/500/700` + `dark:` → `bg-bg-card`, `text-text`, `text-text-dim`
- fresh-key warning callout: `border-amber-400 bg-amber-50 dark:bg-amber-900/30`, `text-amber-800 dark:text-amber-200` → `border-wait-text bg-wait-bg text-wait-text`
- fresh-key `<code>`: `bg-white dark:bg-gray-900 border dark:border-gray-700 text-gray-900 dark:text-gray-100` → `bg-bg border border-border text-text`
- generate / copy buttons: `bg-blue-600 hover:bg-blue-700` → `bg-accent hover:opacity-90`
- revoke button: `bg-red-600 hover:bg-red-700` → `bg-danger hover:opacity-90`
- error text: `text-red-600 dark:text-red-400` → `text-danger`

## Mapping addition for #107
| Legacy | Token |
|--------|-------|
| `amber-*` warning callout | `wait` tokens (`border-wait-text`, `bg-wait-bg`, `text-wait-text`) |
| `bg-red-600` (destructive btn) | `bg-danger` |

## Test Plan
- [x] `npm run build` — succeeds (lint + type-check)
- [x] Built CSS verified: `.bg-danger{…var(--danger)}`, `.border-wait-text{…var(--wait-text)}`, `.bg-wait-bg{…var(--wait-bg)}`, `.text-wait-text{…var(--wait-text)}`
- [x] `grep dark:/gray-/blue-/red-/amber-` in file — empty
- [ ] Vercel check green before merge
- [ ] Manual: Settings → API Key card themes correctly (light + dark), incl. the fresh-key warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)