### PR TITLE
Migrate UserSettings to design tokens; add success token (#107)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,9 @@
   --wait-text: oklch(0.82 0.1 75);
   --wait-bg: oklch(0.75 0.14 75 / 0.16);
   --danger: oklch(0.68 0.18 25);
+  --danger-soft: oklch(0.68 0.18 25 / 0.18);
+  --success: oklch(0.72 0.15 150);
+  --success-soft: oklch(0.72 0.15 150 / 0.18);
 
   /* Translucent nav background for the mobile header/tab-bar blur (issue #43). */
   --nav-bg: oklch(0.19 0.02 270 / 0.8);
@@ -52,6 +55,9 @@ html[data-theme="light"] {
   --tag: oklch(0.55 0.12 40);
   --wait-text: oklch(0.5 0.12 75);
   --danger: oklch(0.55 0.2 25);
+  --danger-soft: oklch(0.55 0.2 25 / 0.14);
+  --success: oklch(0.5 0.13 150);
+  --success-soft: oklch(0.5 0.13 150 / 0.14);
 
   --nav-bg: oklch(1 0 0 / 0.8);
   --shadow: 0 8px 28px oklch(0 0 0 / 0.14);

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -139,21 +139,21 @@ export default function UserSettings() {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 dark:border-blue-400"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-accent"></div>
       </div>
     );
   }
 
   return (
     <div className="max-w-2xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-6 text-gray-900 dark:text-gray-100">User Settings</h1>
+      <h1 className="text-2xl font-bold mb-6 text-text">User Settings</h1>
 
       <div className="space-y-6">
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Profile</h2>
+        <div className="bg-bg-card p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-4 text-text">Profile</h2>
           <div className="space-y-4">
             <div className="flex items-center space-x-4">
-              <div className="relative w-20 h-20 rounded-full overflow-hidden border dark:border-gray-700">
+              <div className="relative w-20 h-20 rounded-full overflow-hidden border border-border">
                 {settings.photoURL ? (
                   <Image
                     src={settings.photoURL}
@@ -164,8 +164,8 @@ export default function UserSettings() {
                     priority
                   />
                 ) : (
-                  <div className="w-full h-full bg-gray-200 dark:bg-gray-600 flex items-center justify-center">
-                    <span className="text-2xl text-gray-500 dark:text-gray-300">
+                  <div className="w-full h-full bg-row-hover flex items-center justify-center">
+                    <span className="text-2xl text-text-dim">
                       {settings.displayName?.[0]?.toUpperCase() || '?'}
                     </span>
                   </div>
@@ -179,7 +179,7 @@ export default function UserSettings() {
                   value={settings.displayName}
                   onChange={(e) => setSettings({ ...settings, displayName: e.target.value })}
                   placeholder="Display Name"
-                  className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700"
+                  className="w-full p-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent text-text bg-bg-card"
                 />
               </div>
             </div>
@@ -191,17 +191,17 @@ export default function UserSettings() {
                 value={settings.email}
                 onChange={(e) => setSettings({ ...settings, email: e.target.value })}
                 placeholder="Email"
-                className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700"
+                className="w-full p-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent text-text bg-bg-card"
               />
             </div>
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Preferences</h2>
+        <div className="bg-bg-card p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-4 text-text">Preferences</h2>
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <label className="block text-sm font-medium text-text-dim mb-2">
                 Theme
               </label>
               <div className="flex items-center space-x-4">
@@ -213,9 +213,9 @@ export default function UserSettings() {
                       value={mode}
                       checked={theme === mode}
                       onChange={() => handleThemeChange(mode)}
-                      className="form-radio h-4 w-4 text-blue-600 transition duration-150 ease-in-out focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600"
+                      className="form-radio h-4 w-4 text-accent transition duration-150 ease-in-out focus:ring-accent bg-bg-card border-border"
                     />
-                    <span className="text-sm text-gray-700 dark:text-gray-300 capitalize">
+                    <span className="text-sm text-text-dim capitalize">
                       {mode}
                     </span>
                   </label>
@@ -224,14 +224,14 @@ export default function UserSettings() {
             </div>
 
             <div>
-              <label htmlFor="language" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <label htmlFor="language" className="block text-sm font-medium text-text-dim mb-2">
                 Language
               </label>
               <select
                 id="language"
                 value={settings.language}
                 onChange={(e) => setSettings({ ...settings, language: e.target.value })}
-                className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700"
+                className="w-full p-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent text-text bg-bg-card"
               >
                 <option value="en">English</option>
                 <option value="de">German</option>
@@ -241,14 +241,14 @@ export default function UserSettings() {
             </div>
 
             <div>
-              <label htmlFor="timezone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              <label htmlFor="timezone" className="block text-sm font-medium text-text-dim mb-2">
                 Timezone
               </label>
               <select
                 id="timezone"
                 value={settings.timezone}
                 onChange={(e) => setSettings({ ...settings, timezone: e.target.value })}
-                className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700"
+                className="w-full p-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent text-text bg-bg-card"
               >
                 {Intl.supportedValuesOf('timeZone').map((tz) => (
                   <option key={tz} value={tz}>
@@ -260,11 +260,11 @@ export default function UserSettings() {
           </div>
         </div>
 
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Notifications</h2>
+        <div className="bg-bg-card p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-4 text-text">Notifications</h2>
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="text-sm font-medium text-text-dim">
                 Email Notifications
               </label>
               <input
@@ -274,11 +274,11 @@ export default function UserSettings() {
                   ...settings,
                   notifications: { ...settings.notifications, email: e.target.checked }
                 })}
-                className="form-checkbox h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700"
+                className="form-checkbox h-4 w-4 text-accent focus:ring-accent border-border rounded bg-bg-card"
               />
             </div>
             <div className="flex items-center justify-between">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="text-sm font-medium text-text-dim">
                 Push Notifications
               </label>
               <input
@@ -288,7 +288,7 @@ export default function UserSettings() {
                   ...settings,
                   notifications: { ...settings.notifications, push: e.target.checked }
                 })}
-                className="form-checkbox h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded dark:bg-gray-700"
+                className="form-checkbox h-4 w-4 text-accent focus:ring-accent border-border rounded bg-bg-card"
               />
             </div>
           </div>
@@ -297,15 +297,15 @@ export default function UserSettings() {
         <ApiKeySettings />
 
         {error && (
-          <div className="bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-200 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-danger-soft border border-danger text-danger px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{error}</span>
           </div>
         )}
         {success && (
-          <div className="bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-700 text-green-700 dark:text-green-200 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-success-soft border border-success text-success px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{success}</span>
             <span className="absolute top-0 bottom-0 right-0 px-4 py-3" onClick={() => setSuccess('')}>
-              <svg className="fill-current h-6 w-6 text-green-500 dark:text-green-300" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+              <svg className="fill-current h-6 w-6 text-success" role="button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
             </span>
           </div>
         )}
@@ -314,7 +314,7 @@ export default function UserSettings() {
           <button
             onClick={handleSave}
             disabled={saving}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-offset-gray-800 disabled:opacity-50"
+            className="px-4 py-2 bg-accent text-white rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Save Settings'}
           </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -43,7 +43,14 @@ const config: Config = {
           text: "var(--wait-text)",
           bg: "var(--wait-bg)",
         },
-        danger: "var(--danger)",
+        danger: {
+          DEFAULT: "var(--danger)",
+          soft: "var(--danger-soft)",
+        },
+        success: {
+          DEFAULT: "var(--success)",
+          soft: "var(--success-soft)",
+        },
         "nav-bg": "var(--nav-bg)",
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

The largest legacy screen so far — `src/components/UserSettings.tsx` (28 `dark:` usages). Maps cards, headings, body text, inputs/selects, radios, checkboxes, avatar, spinner and buttons onto the semantic tokens. Also adds a **`success`** design token (green) and `*-soft` translucent variants for `danger`/`success`, which this file's alert boxes need.

Part of #107 (does **not** close it).

## Component changes (`UserSettings.tsx`)
- cards: `bg-white dark:bg-gray-800` → `bg-bg-card`
- headings: `text-gray-900 dark:text-gray-100` → `text-text`
- labels/body: `text-gray-700 dark:text-gray-300` → `text-text-dim`
- inputs/selects (×4): `border-gray-300 dark:border-gray-600 … focus:ring-blue-500 text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700` → `border-border … focus:ring-accent text-text bg-bg-card`
- radio/checkbox: `text-blue-600 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600` → `text-accent focus:ring-accent bg-bg-card border-border`
- avatar border/fallback/initial: → `border-border` / `bg-row-hover` / `text-text-dim`
- spinner: `border-blue-500 dark:border-blue-400` → `border-accent`
- error alert: → `bg-danger-soft border-danger text-danger`
- success alert (+ close icon): → `bg-success-soft border-success text-success`
- save button: `bg-blue-600 hover:bg-blue-700 focus:ring-blue-500` → `bg-accent hover:opacity-90 focus:ring-accent`

## Design-system additions
`globals.css` (dark + light) and `tailwind.config.ts`:
- new **`success`** token (green: `oklch(0.72 0.15 150)` dark / `oklch(0.5 0.13 150)` light)
- `danger` and `success` restructured to `{ DEFAULT, soft }`, with translucent `--danger-soft` / `--success-soft` (mirrors the existing `accent-soft` / `wait-bg` convention)

> **Why `*-soft` tokens, not `bg-danger/15`?** The `/opacity` modifier produces **no rule** on `var()`-based colors in Tailwind v3 (build-verified — the soft alert backgrounds would have been transparent). Dedicated translucent tokens are the palette's established pattern.

## Test Plan
- [x] `npm run build` — succeeds (lint + type-check)
- [x] Built CSS verified: `.bg-danger-soft`, `.bg-success-soft`, `.text-success`, `.border-success` generate; `.text-danger` (DEFAULT) still resolves after the object restructure
- [x] `grep dark:/gray-/blue-/red-/green-` in UserSettings — empty
- [ ] Vercel check green before merge
- [ ] Manual: Settings page — profile/preferences/notifications cards, theme radios, and the save success/error banners theme correctly (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)