### PR TITLE
Drop darkMode config — retire the dark: variant, closes #107

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,10 +5,10 @@
 /* === Redesign design tokens (issue #39) ===========================
  * Source of truth: docs/design_handoff_aido_redesign/README.md → "Design Tokens".
  * Dark is the default (:root); light is an override on html[data-theme="light"].
- * `data-theme` is the single theme mechanism (issue #84): it drives these tokens,
- * Tailwind's `dark:` variants (darkMode keyed on [data-theme="dark"]), and the
- * legacy `:is([data-theme="dark"] .ProseMirror …)` overrides below. Tailwind
- * utilities map onto these vars in tailwind.config.ts.
+ * `data-theme` is the single theme mechanism (issues #84, #107): it drives these
+ * tokens and the `:is([data-theme="dark"] .ProseMirror …)` overrides below.
+ * Tailwind utilities map onto these vars in tailwind.config.ts; the `dark:`
+ * variant is no longer used anywhere (style with the token utilities instead).
  */
 :root {
   --bg: oklch(0.22 0.02 270);

--- a/src/lib/contexts/ThemeContext.tsx
+++ b/src/lib/contexts/ThemeContext.tsx
@@ -20,10 +20,10 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 // applyTheme resolves the effective theme and applies it to <html> via the
-// single `data-theme="light|dark"` attribute (issue #84): it drives the redesign
-// oklch tokens (globals.css) AND Tailwind's `dark:` variants, which key off
-// [data-theme="dark"] (tailwind.config.ts) — so there is one theme mechanism and
-// the legacy UI can never disagree with the new UI about the active theme.
+// single `data-theme="light|dark"` attribute (issues #84, #107): it drives the
+// redesign oklch tokens (globals.css), which every screen now styles against —
+// so there is one theme mechanism and no legacy `.dark`/`dark:` path left to
+// disagree with it.
 const applyTheme = (theme: Theme, pathname: string): 'light' | 'dark' => {
   let effectiveTheme: 'light' | 'dark';
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,10 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  // Single theme mechanism (issue #84): `dark:` variants key off the same
-  // `data-theme="dark"` attribute that drives the redesign oklch tokens, so
-  // ThemeContext no longer needs a parallel `.dark` class for the legacy UI.
-  darkMode: ['selector', '[data-theme="dark"]'],
+  // No `darkMode` strategy (issue #107): the `dark:` variant is no longer used
+  // anywhere — theming is entirely token-based (oklch CSS vars switched by
+  // `data-theme`, see globals.css). Use the `bg-bg`/`text-text`/… token
+  // utilities for theme-aware styling, never `dark:`.
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary

Capstone for #107. With the contacts page (#114) migrated, **no `dark:` utility remains anywhere in `src/`** — so the Tailwind `dark:` variant is dead and the `darkMode` strategy can go. Theming is now entirely token-based: oklch CSS variables switched by `data-theme`.

Closes #107

## Changes
- **`tailwind.config.ts`** — remove `darkMode: ['selector', '[data-theme="dark"]']`. The replacement comment points future styling at the token utilities (`bg-bg`, `text-text`, …), never `dark:`.
- **`globals.css` / `ThemeContext.tsx`** — refresh the theme-mechanism comments: one mechanism (`data-theme` → oklch tokens), no `.dark`/`dark:` path left to diverge.

## Verification
- [x] `npm run build` — succeeds; removing the darkMode strategy changes nothing (there were no `dark:` utilities left to generate)
- [x] `grep -rn 'className=.*dark:' src` → **empty** (zero `dark:` utilities)
- [x] `grep -rn 'dark:' src` → only two doc comments that explain the variant is retired
- [ ] Vercel check green before merge

## #107 recap (8 PRs)
settings (#108) · layout+login (#109) · ErrorDialog (#110) · SuggestionList + dead TiptapToolbar removed (#111) · ApiKeySettings (#112) · UserSettings + `success` token (#113) · contacts (#114) · this capstone. Net: ~106 `dark:`/gray-palette usages → semantic tokens; added `success` token and `danger`/`success` `*-soft` translucent variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)