### PR TITLE
docs: spec for Firestore-backed MCP tools

### DIFF
--- a/docs/01-konzept-mcp-firestore-tools.md
+++ b/docs/01-konzept-mcp-firestore-tools.md
@@ -1,0 +1,59 @@
+# Konzept: MCP-Tools an die echten App-Features (Firestore) anbinden
+
+## 1. Zusammenfassung
+
+Der MCP-Endpoint (`/api/mcp/sse`) bietet heute nur zwei Demo-Tools (`list-todos`, `add-todo`) auf einem flüchtigen In-Memory-Mock ohne jede Verbindung zu den echten Daten. Dieses Konzept beschreibt, den MCP-Server so umzubauen, dass seine Tools über das Firebase Admin-SDK auf die **realen, aktuellen** Datenmodelle der App zugreifen — Spaces, space-scoped Todos und Daily/„Heute" — und dabei strikt auf den Besitzer des verwendeten persönlichen API-Keys (uid) eingegrenzt sind.
+
+## 2. Problemstellung
+
+- Die MCP-Tools arbeiten auf `mockTodoStore` (`src/lib/mcp/tool-logic.ts`) — sie sehen weder Spaces noch echte Todos. Externe Tools (z. B. Claude) können die App faktisch nicht steuern.
+- Das Tool-Vokabular (`list-todos`/`add-todo` ohne Space) entspricht dem **alten**, vor-Redesign Datenmodell („My Todos"). Die App ist seit Epic #38 aber **Spaces-zentriert** (`spaces/{id}/todos`, `spaces/{id}/daily`).
+- Der Auth-Guard (`requireMcpAuth`) verifiziert zwar einen persönlichen API-Key, **gibt aber die zugehörige uid nicht zurück** — ohne uid kann kein Tool „nur meine Daten" durchsetzen.
+- Sessions liegen in einer prozesslokalen Map (`session-manager.ts`) → auf Vercel (serverless) nicht stabil über Instanzen hinweg.
+
+## 3. Zielsetzung
+
+- MCP-Tools greifen auf die **echten** Firestore-Daten zu (Spaces/Todos/Daily), nicht auf einen Mock.
+- Das Tool-Set ist an die **heutigen** Features angepasst: Spaces auflisten, Todos je Space lesen/anlegen/abschließen, „wartet auf" setzen, Daily lesen/anlegen.
+- **Sicherheit:** Jeder Datenzugriff ist an die uid des persönlichen API-Keys gebunden; ein Nutzer sieht/ändert ausschließlich Spaces, in denen er Mitglied ist. Die Tools spiegeln die Constraints der `firestore.rules` (Admin-SDK umgeht die Rules — die Prüfungen müssen daher im Tool-Code passieren).
+- Messbar: Ein per persönlichem Key verbundener Client kann (a) seine Spaces listen, (b) in einem Space Todos lesen und anlegen, (c) ein Todo abschließen — und kann nachweislich **nicht** auf fremde Spaces zugreifen.
+
+## 4. Lösungsidee
+
+1. **Auth liefert die uid.** `requireMcpAuth` → `authenticateMcp(req)`, das bei persönlichem Key die uid (aus der Doc-ID von `userApiKeys`) zurückgibt; beim Shared-Token einen uid-losen Kontext. Datentools verlangen eine uid.
+2. **Firestore-gebundene Tool-Logik** über das Admin-SDK (`getAdminDb()`), in neuen Helfern, die die Rules-Constraints serverseitig nachbilden (Membership-Check via `spaces/{id}.members`, `createdBy`/`author` = uid, `waitingOn` muss Mitglied sein, Feldvalidierung).
+3. **Neues Tool-Set** (an die Features angepasst): `list-spaces`, `list-todos` (pro Space), `add-todo`, `complete-todo`, `set-waiting-on`, `list-daily`, `add-daily`.
+4. **Sessions entschärfen:** Datentools stateless/idempotent gestalten (jeder `tools/call` in sich abgeschlossen), sodass die nicht-durable Session-Map keine korrekten Antworten verhindert; echte SSE-Streams (sticky sessions / externer Store) bleiben außen vor.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) |
+|---|---|
+| MCP-Auth | `src/lib/mcp/auth.ts` |
+| Tool-Schemas | `src/lib/mcp/schemas.ts` |
+| Tool-Logik (Mock → echt) | `src/lib/mcp/tool-logic.ts` |
+| Tool-Registrierung (`tools/list`, `tools/call`) | `src/app/api/mcp/sse/route.ts` |
+| Session-Handling | `src/lib/mcp/session-manager.ts` |
+| Datenzugriff (Admin) | `src/lib/firebase/admin.ts`, neue `src/lib/mcp/data.ts` (o. ä.) |
+| API-Keys (uid↔Key) | `src/lib/apiKeys.ts`, `userApiKeys/{uid}` |
+| Sicherheitsreferenz | `firestore.rules` (Spiegelung im Tool-Code) |
+
+## 6. Abgrenzung
+
+**Nicht** Teil dieser Anforderung:
+- Keine MCP-Tools zum **Anlegen/Löschen von Spaces** oder **Mitglieder einladen/entfernen** (sicherheitssensibel; bleibt UI-exklusiv).
+- Keine Kontakte-/`publicProfiles`-Verwaltung über MCP (nur lesende Namensauflösung für Anzeige, falls nötig).
+- Keine Änderung am Firestore-Datenmodell oder an den `firestore.rules` (die Tools nutzen das bestehende Modell).
+- Kein echtzeitfähiges Streaming/Subscriptions über MCP; keine vollständige Lösung der serverless-Session-Persistenz (nur Entschärfung).
+- Keine Migration der Legacy-`users/{uid}/todos`.
+
+## 7. Entscheidungen (Review-Ergebnis)
+
+Im Review bestätigt:
+
+1. **Shared-Token bei Datentools:** ❌ **Nicht erlaubt.** Datentools verlangen einen persönlichen Key (→ uid → nur eigene Spaces). `MCP_AUTH_TOKEN` (ohne uid) bleibt nur für Transport-/operative Zwecke und wird von Datentools abgelehnt.
+2. **Schreibumfang:** ✅ **Nur Todos + Daily.** Spaces anlegen/löschen und Mitglieder einladen/entfernen bleiben UI-exklusiv (sicherheitssensibel).
+3. **`list-todos`-Scope:** ✅ **Immer mit explizitem `spaceId`**, plus `list-spaces` zum Discovern.
+4. **Session-Persistenz:** ✅ **Stateless jetzt.** Datentools idempotent/ohne Cross-Request-State; echtes SSE-Streaming bzw. externer Session-Store ist ein separates Folge-Thema.
+5. **Rate-Limiting:** ✅ Leichtgewichtig pro uid für Schreibtools (analog `apiKeys.ts` `rateLimit`).
+6. **Antwortformat:** ✅ MCP-konforme `content`-Blöcke statt der heutigen Custom-`{ result: … }`-Struktur.

--- a/docs/02-ist-analyse-mcp-firestore-tools.md
+++ b/docs/02-ist-analyse-mcp-firestore-tools.md
@@ -1,0 +1,71 @@
+# Ist-Analyse: MCP-Server & aktuelle Datenmodelle
+
+## 1. Aktueller Zustand
+
+### 1.1 MCP-Server
+- Endpoint `src/app/api/mcp/sse/route.ts` mit `POST` (Streamable HTTP, JSON-RPC), `GET` (SSE) und `DELETE` (Session beenden). Wegen der Node-`http`-Erwartungen des MCP-SDK werden Requests über `node-mocks-http` + `ManualMockServerResponse` (`src/lib/mcp/http-utils.ts`) geshimmt.
+- Server-Info: `name: "aido-mcp-server"`, `version: "0.1.0"`. Es sind nur `tools/list` und `tools/call` registriert.
+- **`tools/list`** meldet genau zwei Tools:
+  - `list-todos` — input `{}`, output `{ items: [...] }`
+  - `add-todo` — input `{ text: string }` (required), output Todo-Objekt
+- **`tools/call`** dispatcht per `switch` auf `handleListTodosLogic` / `handleAddTodoLogic`.
+
+### 1.2 Tool-Logik (Mock)
+- `src/lib/mcp/tool-logic.ts` hält `const mockTodoStore: Record<string, {id,text,completed}> = {}` — **prozesslokal, flüchtig, keine Firestore-Anbindung**.
+- `handleAddTodoLogic` legt `{ id: randomUUID(), text, completed:false }` an; `handleListTodosLogic` gibt `Object.values(mockTodoStore)` zurück.
+- Antwortstruktur ist Custom (`{ result: { items } }` bzw. `{ result: newTodo }`), nicht das MCP-`content`-Blockformat.
+
+### 1.3 Auth
+- `src/lib/mcp/auth.ts` → `requireMcpAuth(req)` akzeptiert `Authorization: Bearer <token>` mit zwei Pfaden:
+  1. **Shared Secret** `MCP_AUTH_TOKEN` (timing-safe Vergleich).
+  2. **Persönlicher API-Key** `aido_…`: `looksLikeApiKey` → `where("keyHash","==",hashApiKey(provided))` in `userApiKeys` → bei Treffer `true`.
+- **Gibt nur `null` (ok) bzw. eine Error-`NextResponse` zurück — nicht die uid.** Bei fehlender Konfiguration (weder `MCP_AUTH_TOKEN` noch Admin-SDK): `503`.
+- `userApiKeys/{uid}` ist **per uid dokumentiert** (Doc-ID = uid), Felder `keyHash`, `keyPrefix`, `createdAt`, `lastUsedAt`. ⇒ Aus einem Key-Treffer ist die uid trivial ableitbar (`snapshot.docs[0].id`), wird aktuell aber verworfen.
+
+### 1.4 Sessions
+- `src/lib/mcp/session-manager.ts` hält `activeServers`/`activeTransports` in **prozesslokalen Maps**. Keine Persistenz, kein TTL.
+- Der POST-Handler erzeugt bei nicht gefundener Session notfalls einen neuen Server/Transport — funktional, aber auf Vercel können `initialize` und Folge-Calls auf verschiedenen Instanzen landen.
+
+### 1.5 Datenmodell (heute, Quelle: `firestore.rules` + `firebaseUtils.ts`)
+- `spaces/{spaceId}`: `name`, `color` (number/hue), `members[]`, `createdBy`, `createdAt`. Mitglied = Voll-Lese/Schreibrecht; `createdBy/createdAt` immutable; nur Creator darf löschen.
+- `spaces/{spaceId}/todos/{id}`: `spaceId`, `title`, `body` (Tiptap-JSON|null), `completed`, `waitingOn` (uid|null, **muss Mitglied sein**), `tags[]`, `mentions[]`, `createdBy` (immutable), `createdAt`, `order`. Jedes Mitglied liest/schreibt.
+- `spaces/{spaceId}/daily/{id}`: `spaceId`, `text`, `completed`, `date` (`YYYY-MM-DD`, strikt), `author` (immutable), `createdAt`.
+- `publicProfiles/{uid}`: `displayName`, `displayNameLower`, `photoURL`, `emailHash` (für Namensauflösung).
+- Bestehende Client-Helfer (Client-SDK, rules-pflichtig) in `firebaseUtils.ts`: `getSpacesForUser`, `getTodosForSpace`/`subscribeTodosForSpace`, `createTodo`, `setTodoCompleted`, `setTodoWaitingOn`, `setTodoStatus`, `getOpenTodoCount`, Daily-CRUD. **Diese laufen client-seitig — der MCP-Server braucht Admin-SDK-Äquivalente.**
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/app/api/mcp/sse/route.ts` | MCP-Endpoint, Tool-Registrierung & Dispatch | Tool-Set & Antwortformat erweitern |
+| `src/lib/mcp/tool-logic.ts` | Mock-Tool-Logik | **Kernumbau** → echte Firestore-Logik |
+| `src/lib/mcp/schemas.ts` | Zod-Schemas der Tools | Neue Tool-Schemas (spaceId, todoId, …) |
+| `src/lib/mcp/auth.ts` | Auth-Guard | Muss **uid zurückgeben** |
+| `src/lib/mcp/session-manager.ts` | In-Memory-Sessions | Stateless-Betrieb absichern |
+| `src/lib/firebase/admin.ts` | Admin-SDK (`getAdminDb`) | Datenzugriff bypassed Rules |
+| `src/lib/apiKeys.ts` / `userApiKeys/{uid}` | Key↔uid-Mapping | uid-Auflösung |
+| `firestore.rules` | Sicherheitsmodell | **Referenz** für serverseitige Checks |
+| `src/lib/firebase/firebaseUtils.ts` | Client-Datenhelfer | Vorlage für Admin-Äquivalente |
+
+## 3. Bestehende Abhängigkeiten
+
+- **Extern:** `@modelcontextprotocol/sdk` (Streamable HTTP/Server), `firebase-admin` (Firestore/Auth), `node-mocks-http`, `zod` (v4), Web-Streams-Polyfills.
+- **Intern:** Auth → `apiKeys`/`admin`; Tool-Logik (künftig) → `admin`; Route → Schemas + Tool-Logik + Session-Manager + Auth.
+- **Konfiguration:** Persönliche Keys funktionieren nur mit gesetztem `FIREBASE_SERVICE_ACCOUNT_KEY` (sonst `getAdminDb() === null` → 503).
+
+## 4. Bekannte Einschränkungen
+
+- **Admin-SDK umgeht `firestore.rules` vollständig** — jede Autorisierung (Membership, `createdBy`, `waitingOn`-Mitgliedschaft, Feldtypen) muss im Tool-Code nachgebaut werden.
+- **Keine uid im Auth-Pfad** (heutiger Stand) → ohne Refactor keine nutzerbezogenen Tools möglich.
+- **Session-Map nicht durable** (Vercel) — funktioniert lokal, kann serverless brechen.
+- **Shared-Token hat keine uid** → für Datentools ungeeignet.
+- Antwortformat aktuell Custom statt MCP-`content`-Blöcke → manche Clients erwarten den Standard.
+- Zod v4 + `setRequestHandler` stoßen an TS-Rekursionslimits (siehe Kommentare in `schemas.ts`) — neue Schemas müssen demselben „standalone object"-Muster folgen.
+
+## 5. Risiken bei Änderung
+
+- **Sicherheit (höchstes Risiko):** Ein fehlender Membership-Check im Admin-Pfad würde Cross-Tenant-Zugriff erlauben (Rules greifen hier nicht). Jede Tool-Operation muss die Space-Mitgliedschaft der uid prüfen, bevor sie liest/schreibt.
+- **Konsistenz mit Rules:** Schreibt ein Tool z. B. `waitingOn` = Nicht-Mitglied oder ein falsches Feldformat, entstehen Datensätze, die der Client/​die Rules sonst nie erzeugen würden (Board/Counts brechen). Tools müssen `hasValidWaitingOn`, `hasValidTodoFields`, Daily-`date`-Regex etc. spiegeln.
+- **Bestehende Clients:** Wer heute `list-todos`/`add-todo` (Mock, ohne `spaceId`) nutzt, bricht bei Signaturwechsel. Mitigation: bewusster Breaking Change dokumentieren (das Mock-Tool war nie produktiv).
+- **Serverless:** Bei beibehaltener In-Memory-Session können `initialize`→`tools/call` divergieren; Datentools müssen ohne Cross-Request-State korrekt sein.
+- **Kosten/Last:** Ungebremste Schreibtools laden zu Key-Churn/Spam ein → Rate-Limit nötig.

--- a/docs/03-anforderungsanalyse-mcp-firestore-tools.md
+++ b/docs/03-anforderungsanalyse-mcp-firestore-tools.md
@@ -1,0 +1,58 @@
+# Anforderungsanalyse: Firestore-gebundene MCP-Tools
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Auth liefert uid | **Muss** | `authenticateMcp(req)` gibt bei persönlichem Key die uid zurück (Doc-ID aus `userApiKeys`); bei Shared-Token einen uid-losen Kontext; sonst Error. |
+| FA-02 | Datentools erfordern uid | **Muss** | Tools mit Datenzugriff lehnen Aufrufe ohne uid (z. B. Shared-Token) mit klarer Fehlermeldung ab. |
+| FA-03 | Membership-Enforcement | **Muss** | Vor jedem Lese-/Schreibzugriff auf einen Space wird geprüft, dass die uid in `spaces/{id}.members` ist; sonst „nicht gefunden/keine Berechtigung". |
+| FA-04 | `list-spaces` | **Muss** | Listet die Spaces der uid: `id`, `name`, `color`, Mitgliederzahl, offene Todos (Count). |
+| FA-05 | `list-todos` (pro Space) | **Muss** | Parameter `spaceId`, optional `includeCompleted`, optional `tag`. Liefert Todos (`id`, `title`, `completed`, `waitingOn`, `tags`, `order`). Body als Plaintext-Auszug optional. |
+| FA-06 | `add-todo` | **Muss** | Parameter `spaceId`, `title`, optional `bodyText`, optional `waitingOn`. Setzt `createdBy=uid`, `order=max+1`, leitet `tags`/`mentions` ab. `waitingOn` muss Mitglied sein. |
+| FA-07 | `complete-todo` | **Soll** | Parameter `spaceId`, `todoId`, `completed`. Setzt `completed` (analog `setTodoStatus`, ohne `waitingOn` zu verwaisen). |
+| FA-08 | `set-waiting-on` | **Soll** | Parameter `spaceId`, `todoId`, `userId`\|null. `userId` muss Mitglied sein. |
+| FA-09 | `list-daily` | **Soll** | Parameter `spaceId`, optional `date` (Default heute). Liefert Heute-Items (`id`, `text`, `completed`, `date`). |
+| FA-10 | `add-daily` | **Soll** | Parameter `spaceId`, `text`. Setzt `author=uid`, `date=heute` (`YYYY-MM-DD`), `completed=false`. |
+| FA-11 | MCP-konformes Antwortformat | **Soll** | Tool-Ergebnisse als `content`-Blöcke (`{ content: [{ type:"text", text }] }`), zusätzlich strukturierte Daten wo sinnvoll. |
+| FA-12 | `tools/list` aktualisiert | **Muss** | Meldet das neue Tool-Set mit korrekten `inputSchema` (inkl. `required`). |
+| FA-13 | `delete-todo` | **Kann** | Parameter `spaceId`, `todoId`. Mitglied darf löschen. |
+| FA-14 | `whoami` / `list-members` | **Kann** | uid/Anzeigename des Keys bzw. Mitglieder eines Space (via `publicProfiles`). |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Mandantentrennung | Sicherheit | Kein Tool darf Daten außerhalb der Spaces der uid lesen/schreiben (Admin-SDK umgeht Rules → Code-seitige Prüfung zwingend). |
+| NFA-02 | Rules-Parität | Sicherheit/Integrität | Schreibtools spiegeln `firestore.rules`: `createdBy`/`author`=uid & immutable, `waitingOn`∈members, Feldtypen, Daily-`date`-Regex. |
+| NFA-03 | Kein Datenleck im Log | Sicherheit | Keine Tokens/Keys/PII in Logs (bestehende Praxis fortführen). |
+| NFA-04 | Rate-Limiting | Sicherheit/Stabilität | Schreibtools pro uid leichtgewichtig begrenzt (analog `rateLimit` in `apiKeys.ts`). |
+| NFA-05 | Stateless-Korrektheit | Zuverlässigkeit | Datentools liefern korrekte Ergebnisse unabhängig von der nicht-durablen Session-Map (kein Cross-Request-State nötig). |
+| NFA-06 | Graceful Degradation | Robustheit | Ohne `FIREBASE_SERVICE_ACCOUNT_KEY`: klare 503/Tool-Fehlermeldung statt Crash. |
+| NFA-07 | Performance | Performance | `list-spaces`/Counts mit serverseitigen Count-Queries; keine N+1-Vollscans. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] Ein per **persönlichem Key** verbundener Client kann `list-spaces` aufrufen und erhält genau seine Spaces.
+- [ ] `list-todos`/`add-todo`/`complete-todo` wirken auf **echte** `spaces/{id}/todos` und sind in der Web-UI sichtbar (und umgekehrt).
+- [ ] Ein Aufruf mit `spaceId`, in dem die uid **kein** Mitglied ist, liefert einen Berechtigungsfehler und **keine** Daten.
+- [ ] `add-todo` mit `waitingOn` = Nicht-Mitglied wird abgelehnt; mit Mitglied akzeptiert.
+- [ ] `add-daily` erzeugt ein Item mit korrektem `date` (`YYYY-MM-DD`) und `author=uid`.
+- [ ] Datentools mit **Shared-Token** (ohne uid) werden mit klarer Meldung abgelehnt.
+- [ ] Angelegte Todos tragen `createdBy=uid`, valides `order`, abgeleitete `tags`/`mentions`.
+- [ ] Ohne `FIREBASE_SERVICE_ACCOUNT_KEY` antworten Datentools mit einem klaren Konfigurationsfehler (kein Crash).
+- [ ] `tools/list` listet das neue Tool-Set mit korrekten Schemas.
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Baut auf den persönlichen API-Keys (Issue #21) und dem Spaces-Datenmodell (Issues #40/#41) auf.
+- FA-04…FA-14 hängen alle an **FA-01/FA-03** (uid + Membership) — diese zuerst.
+- Keine Abhängigkeit zur Token-Migration (#107) oder zu offenen Issues.
+
+## 5. Priorisierung
+
+1. **Fundament (Muss):** FA-01, FA-02, FA-03, FA-12 — uid-Auth + Membership + Tool-Registrierung.
+2. **Lese-Kern (Muss):** FA-04, FA-05.
+3. **Schreib-Kern (Muss/Soll):** FA-06, dann FA-07, FA-08.
+4. **Daily (Soll):** FA-09, FA-10.
+5. **Komfort/Format (Soll/Kann):** FA-11, FA-13, FA-14.

--- a/docs/04-spezifikation-mcp-firestore-tools.md
+++ b/docs/04-spezifikation-mcp-firestore-tools.md
@@ -1,0 +1,123 @@
+# Spezifikation: Firestore-gebundene MCP-Tools
+
+## 1. Übersicht
+
+Der MCP-Server wird von einem Mock auf echten Firestore-Zugriff (Admin-SDK) umgestellt. Kern ist (1) ein Auth-Refactor, der die **uid** des persönlichen API-Keys liefert, (2) eine **Datenzugriffsschicht**, die die `firestore.rules`-Constraints serverseitig spiegelt (Admin-SDK umgeht die Rules), und (3) ein an die heutigen Features angepasstes **Tool-Set** rund um Spaces/Todos/Daily. Umgesetzt in Schritten gemäß Anforderungsanalyse (Fundament → Lesen → Schreiben → Daily).
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+```
+Client (Bearer aido_…)
+   │  POST /api/mcp/sse  (tools/call)
+   ▼
+route.ts ── authenticateMcp(req) ─▶ { uid } | { shared:true } | 401/503
+   │            (uid via userApiKeys Doc-ID)
+   ▼
+tools/call dispatch ─▶ tool-logic (pro Tool)
+   │                      │ requireMember(uid, spaceId)  ◀─ Admin getAdminDb()
+   │                      │ Rules-Parität (createdBy, waitingOn∈members, Feldtypen)
+   ▼                      ▼
+MCP content-Antwort ◀── Firestore (spaces/{id}/todos|daily, publicProfiles)
+```
+
+### 2.2 Datenmodell
+
+**Keine Änderungen** am Firestore-Schema und an `firestore.rules`. Die Tools nutzen die bestehenden Collections (`spaces`, `spaces/{id}/todos`, `spaces/{id}/daily`, `publicProfiles`, `userApiKeys`). `userApiKeys/{uid}` (Doc-ID = uid) bleibt die Quelle der uid-Auflösung.
+
+### 2.3 Schnittstellen
+
+**(a) Auth** — `src/lib/mcp/auth.ts`
+```ts
+type McpPrincipal = { kind: 'user'; uid: string } | { kind: 'shared' };
+// null bei nicht-konfiguriert/unautorisiert wird durch ein Result-Objekt ersetzt:
+async function authenticateMcp(req): Promise<
+  | { ok: true; principal: McpPrincipal }
+  | { ok: false; response: NextResponse }   // 401/503
+>;
+// matchesPersonalApiKey gibt künftig die uid (snapshot.docs[0].id) zurück.
+// requireMcpAuth bleibt als dünner Wrapper (Transport-Auth) erhalten.
+```
+
+**(b) Datenzugriffsschicht** — neu, `src/lib/mcp/data.ts` (Admin-SDK)
+```ts
+async function requireMember(uid, spaceId): Promise<SpaceDoc>;     // wirft McpToolError, wenn kein Mitglied
+async function listSpacesForUid(uid): Promise<SpaceSummary[]>;     // + openCount via getCountFromServer
+async function listTodos(uid, spaceId, opts): Promise<TodoView[]>;
+async function addTodo(uid, spaceId, input): Promise<TodoView>;    // createdBy=uid, order=max+1, tags/mentions, waitingOn∈members
+async function setTodoCompleted(uid, spaceId, todoId, completed): Promise<TodoView>;
+async function setWaitingOn(uid, spaceId, todoId, userId|null): Promise<TodoView>;
+async function listDaily(uid, spaceId, date?): Promise<DailyView[]>;
+async function addDaily(uid, spaceId, text): Promise<DailyView>;
+```
+Jede Funktion ruft zuerst `requireMember`. Schreibfunktionen prüfen die Rules-Parität (siehe NFA-02). `McpToolError` (mit Code: `unauthorized`/`not_found`/`invalid`) wird im Dispatch in eine MCP-Fehlerantwort übersetzt.
+
+**(c) Tools** (`inputSchema`, alle `spaceId` required wo angegeben)
+
+| Tool | Input | Wirkung |
+|---|---|---|
+| `list-spaces` | `{}` | Spaces der uid + openCount |
+| `list-todos` | `{ spaceId, includeCompleted?, tag? }` | Todos des Space |
+| `add-todo` | `{ spaceId, title, bodyText?, waitingOn? }` | Todo anlegen |
+| `complete-todo` | `{ spaceId, todoId, completed }` | Completion setzen |
+| `set-waiting-on` | `{ spaceId, todoId, userId\|null }` | „wartet auf" setzen |
+| `list-daily` | `{ spaceId, date? }` | Heute-Items |
+| `add-daily` | `{ spaceId, text }` | Heute-Item anlegen |
+| `delete-todo` *(Kann)* | `{ spaceId, todoId }` | Todo löschen |
+| `whoami` *(Kann)* | `{}` | uid + Anzeigename |
+
+**Antwortformat:** MCP-`content`-Block mit menschenlesbarem Text **und** maschinenlesbarem JSON, z. B.
+`{ content: [{ type: 'text', text: '<JSON oder Zusammenfassung>' }] }`.
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/mcp/auth.ts` | `matchesPersonalApiKey` → uid; `authenticateMcp` mit Principal | Klein |
+| `src/lib/mcp/data.ts` (neu) | Admin-Datenzugriff + Membership/Rules-Parität | **Groß** |
+| `src/lib/mcp/tool-logic.ts` | Mock entfernen; Handler je Tool auf `data.ts` | Mittel |
+| `src/lib/mcp/schemas.ts` | Neue Zod-Schemas (standalone-Muster) | Mittel |
+| `src/app/api/mcp/sse/route.ts` | `tools/list`-Array + `tools/call`-Dispatch + Principal/Fehler-Mapping | Mittel |
+| `src/lib/mcp/session-manager.ts` | Stateless-Betrieb dokumentieren/absichern (kein Cross-Request-State) | Klein |
+| `src/lib/apiKeys.ts` | ggf. `rateLimit`-Key-Schema für MCP-Writes wiederverwenden | Klein |
+| `tests/` | MCP-Tool-Tests (Emulator) | Mittel |
+
+### 3.2 Reihenfolge der Implementierung
+
+1. **Auth-Refactor (FA-01/02):** uid aus Key; `authenticateMcp`; Datentools verlangen uid.
+2. **Datenschicht-Fundament (FA-03):** `data.ts` mit `requireMember` + Admin-Helfern; `McpToolError`.
+3. **Lese-Tools (FA-04/05/12):** `list-spaces`, `list-todos`; `tools/list` + Dispatch + content-Format.
+4. **Schreib-Tools (FA-06/07/08):** `add-todo`, `complete-todo`, `set-waiting-on` inkl. Rules-Parität + Rate-Limit.
+5. **Daily (FA-09/10):** `list-daily`, `add-daily`.
+6. **Komfort (FA-11/13/14, Kann):** Format-Feinschliff, `delete-todo`, `whoami`/`list-members`.
+
+> **Hinweis Reihenfolge:** Schritte 1–2 sind ein gemeinsames Fundament-Issue; ab Schritt 3 ist jedes Tool(-Cluster) ein eigenständiges, sessionweise abarbeitbares Issue.
+
+## 4. Testplan
+
+- **Security-Rules-Suite (`tests/`, Emulator):** unverändert grün halten (keine Rules-Änderung).
+- **MCP-Tool-Tests (neu, Emulator + Admin-SDK):**
+  - `requireMember`: Mitglied → ok; Nicht-Mitglied → `unauthorized`; unbekannter Space → `not_found`.
+  - `add-todo`: `createdBy=uid`, `order=max+1`, `tags`/`mentions` abgeleitet; `waitingOn` Nicht-Mitglied → `invalid`.
+  - `complete-todo`/`set-waiting-on`: korrekte Felder, kein verwaister `waitingOn`.
+  - `add-daily`: `date`-Regex, `author=uid`.
+  - Auth: persönlicher Key → uid; Shared-Token → Datentool abgelehnt; fehlendes Admin-SDK → 503/Fehler.
+- **Manuell:** Claude/`mcp-remote` mit persönlichem Key → `list-spaces` → `add-todo` → in Web-UI verifizieren (und umgekehrt).
+- **Negativ/Isolation:** Zwei Test-uids; sicherstellen, dass uid A `spaceId` von B weder lesen noch schreiben kann.
+
+## 5. Migration / Deployment
+
+- **Breaking Change:** `list-todos`/`add-todo` ändern Signatur (jetzt `spaceId`-pflichtig). Das alte Verhalten war nur ein Mock — im Changelog/PR klar kennzeichnen.
+- **Voraussetzung:** `FIREBASE_SERVICE_ACCOUNT_KEY` muss im Deployment gesetzt sein (sonst Datentools 503). `.env.example` ggf. ergänzen/kommentieren.
+- **Reihenfolge:** App-Deploy vor Bewerbung der neuen Tools; keine Rules-Deployments nötig.
+- **Session/Serverless:** Tools stateless halten; falls später echtes SSE-Streaming gewünscht ist, ist Sticky-Session bzw. externer Session-Store ein **separates** Folge-Thema (außerhalb dieser Spec).
+
+## 6. Referenzen
+
+- [Konzeptdokument](01-konzept-mcp-firestore-tools.md)
+- [Ist-Analyse](02-ist-analyse-mcp-firestore-tools.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-mcp-firestore-tools.md)
+- Code: `src/app/api/mcp/sse/route.ts`, `src/lib/mcp/{auth,tool-logic,schemas,session-manager}.ts`, `src/lib/firebase/admin.ts`, `src/lib/apiKeys.ts`, `firestore.rules`


### PR DESCRIPTION
## Summary

Bestandsanalyse + requirement/spec to move the MCP server from its mock demo tools (`list-todos`/`add-todo` on an in-memory store) to **real, Firestore-backed, per-user MCP tools** adapted to today's Spaces/Todos/Daily model.

Four review documents under `docs/`:
- `01-konzept-mcp-firestore-tools.md` — concept, scope, decisions
- `02-ist-analyse-mcp-firestore-tools.md` — current-state analysis (MCP server + data models)
- `03-anforderungsanalyse-mcp-firestore-tools.md` — FRs/NFRs + acceptance criteria
- `04-spezifikation-mcp-firestore-tools.md` — technical design, implementation plan, test plan

## Key findings
- Tools run on a mock store (`tool-logic.ts`) — no Firestore; tool vocab predates the Spaces redesign.
- `userApiKeys/{uid}` is keyed by uid (doc id = uid), so a key resolves to a uid — but `requireMcpAuth` discards it. The uid refactor is the foundation.
- Admin SDK bypasses `firestore.rules` → every membership/field check must be mirrored in tool code (highest risk).
- In-memory sessions aren't durable on Vercel → tools must be stateless-correct.

## Decisions (from review)
Personal-key-only for data tools · write scope = todos + daily (spaces/members stay UI-only) · explicit `spaceId` per call · stateless tools now · per-uid rate limit · MCP content-block responses.

## Proposed tool set
`list-spaces` · `list-todos` · `add-todo` · `complete-todo` · `set-waiting-on` · `list-daily` · `add-daily` (+ optional `delete-todo`, `whoami`).

Docs-only — per repo policy this can merge without waiting for CI. Implementation issues follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)