### PR TITLE
MCP auth: resolve personal API key to its uid; add authenticateMcp (#117)

### DIFF
--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -5,52 +5,78 @@ import { getAdminDb } from "@/lib/firebase/admin";
 import { API_KEYS_COLLECTION, hashApiKey, looksLikeApiKey } from "@/lib/apiKeys";
 
 // Guards the MCP endpoint. Two accepted credentials:
-// 1. the shared secret MCP_AUTH_TOKEN (ops/back-compat)
-// 2. a personal API key (aido_…, issue #21) — verified by SHA-256 hash
-//    lookup in userApiKeys via the Admin SDK
-// Returns null if the request is authorized, otherwise the error response.
-// With neither mechanism configured all requests are rejected.
+// 1. the shared secret MCP_AUTH_TOKEN (ops/back-compat) — carries NO user
+//    identity, so it can authorize the transport but not per-user data tools.
+// 2. a personal API key (aido_…, issue #21) — verified by SHA-256 hash lookup
+//    in userApiKeys via the Admin SDK; resolves to the owner's uid (the doc id).
+// With neither mechanism configured all requests are rejected (503).
+
+// Who authenticated. `user` carries the uid the personal key belongs to and is
+// what the Firestore-backed data tools scope every read/write to (issue #117);
+// `shared` is the identity-less shared-secret caller (data tools reject it).
+export type McpPrincipal = { kind: "user"; uid: string } | { kind: "shared" };
+
+export type McpAuthResult =
+  | { ok: true; principal: McpPrincipal }
+  | { ok: false; response: NextResponse };
 
 function matchesSharedSecret(provided: string): boolean {
-    const expected = process.env.MCP_AUTH_TOKEN;
-    if (!expected) return false;
-    const providedBuf = Buffer.from(provided);
-    const secretBuf = Buffer.from(expected);
-    return providedBuf.length === secretBuf.length && timingSafeEqual(providedBuf, secretBuf);
+  const expected = process.env.MCP_AUTH_TOKEN;
+  if (!expected) return false;
+  const providedBuf = Buffer.from(provided);
+  const secretBuf = Buffer.from(expected);
+  return providedBuf.length === secretBuf.length && timingSafeEqual(providedBuf, secretBuf);
 }
 
-async function matchesPersonalApiKey(provided: string): Promise<boolean> {
-    if (!looksLikeApiKey(provided)) return false;
-    const db = getAdminDb();
-    if (!db) return false;
+// Resolves a personal API key to its owner's uid, or null if it isn't a valid
+// key. The userApiKeys doc id IS the uid, so a hash match yields the uid directly.
+async function resolvePersonalApiKey(provided: string): Promise<string | null> {
+  if (!looksLikeApiKey(provided)) return null;
+  const db = getAdminDb();
+  if (!db) return null;
 
-    const snapshot = await db
-        .collection(API_KEYS_COLLECTION)
-        .where("keyHash", "==", hashApiKey(provided))
-        .limit(1)
-        .get();
-    if (snapshot.empty) return false;
+  const snapshot = await db
+    .collection(API_KEYS_COLLECTION)
+    .where("keyHash", "==", hashApiKey(provided))
+    .limit(1)
+    .get();
+  if (snapshot.empty) return null;
 
-    // Best-effort usage timestamp; auth must not fail on a metadata write.
-    snapshot.docs[0].ref
-        .update({ lastUsedAt: FieldValue.serverTimestamp() })
-        .catch(() => {});
-    return true;
+  const doc = snapshot.docs[0];
+  // Best-effort usage timestamp; auth must not fail on a metadata write.
+  doc.ref.update({ lastUsedAt: FieldValue.serverTimestamp() }).catch(() => {});
+  return doc.id; // doc id === uid
 }
 
+// Authenticates an MCP request and returns the principal (issue #117). Data
+// tools branch on `principal.kind`: only `user` exposes a uid to scope to.
+export async function authenticateMcp(req: NextRequest): Promise<McpAuthResult> {
+  if (!process.env.MCP_AUTH_TOKEN && !getAdminDb()) {
+    console.error("Neither MCP_AUTH_TOKEN nor Firebase Admin is configured; rejecting MCP request.");
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "MCP endpoint is not configured" }, { status: 503 }),
+    };
+  }
+
+  const header = req.headers.get("authorization") ?? "";
+  const match = header.match(/^Bearer (.+)$/i);
+  if (match) {
+    const provided = match[1];
+    // Shared secret first: it never looks like a personal key, so this avoids a
+    // Firestore lookup for shared-secret callers.
+    if (matchesSharedSecret(provided)) return { ok: true, principal: { kind: "shared" } };
+    const uid = await resolvePersonalApiKey(provided);
+    if (uid) return { ok: true, principal: { kind: "user", uid } };
+  }
+
+  return { ok: false, response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+}
+
+// Back-compat transport guard: returns null if authorized, else the error
+// response. The endpoint handlers (POST/GET/DELETE) use this for transport-level
+// auth; the per-user data tools will call authenticateMcp directly to get the uid.
 export async function requireMcpAuth(req: NextRequest): Promise<NextResponse | null> {
-    if (!process.env.MCP_AUTH_TOKEN && !getAdminDb()) {
-        console.error("Neither MCP_AUTH_TOKEN nor Firebase Admin is configured; rejecting MCP request.");
-        return NextResponse.json({ error: "MCP endpoint is not configured" }, { status: 503 });
-    }
-
-    const header = req.headers.get("authorization") ?? "";
-    const match = header.match(/^Bearer (.+)$/i);
-    if (match) {
-        const provided = match[1];
-        if (matchesSharedSecret(provided)) return null;
-        if (await matchesPersonalApiKey(provided)) return null;
-    }
-
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const result = await authenticateMcp(req);
+  return result.ok ? null : result.response;
 }


### PR DESCRIPTION
## Summary

Foundation for the Firestore-backed MCP tools (epic #124). The auth layer can now identify **who** is calling — the uid the per-user data tools (#119+) will scope every read/write to.

Closes #117

## Changes
- `resolvePersonalApiKey(provided)` returns the owner's **uid** (`userApiKeys` doc id IS the uid) instead of a bare boolean.
- new **`authenticateMcp(req)`** → `{ ok: true, principal }` where `principal` is `{ kind:'user', uid }` (personal key) or `{ kind:'shared' }` (shared secret — no uid; data tools will reject it), or `{ ok:false, response }` for 401/503.
- `requireMcpAuth` is now a thin back-compat wrapper over `authenticateMcp`, so the existing transport guard in `route.ts` (POST/GET/DELETE) is unchanged.
- shared-secret check runs first → a shared-token caller never triggers a Firestore lookup; no tokens/PII logged.

## Notes for review
- `authenticateMcp` has **no caller yet** — by design. It's the API consumed by the data-tool issues (#119 list/#120 write). This PR is the isolated, reviewable foundation per the spec's implementation order.
- No data model / rules changes.

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — only pre-existing `<img>` warnings
- [x] `requireMcpAuth` behavior unchanged (still returns `null` when authorized, error response otherwise) — `route.ts` untouched
- [ ] Vercel check green before merge
- [ ] Full auth-path coverage (personal key → uid, shared → reject on data tools, missing admin → 503) lands with the emulator suite in #122

Refs epic #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)