### PR TITLE
MCP read tools: list-spaces & list-todos (real, Firestore-backed) (#119)

### DIFF
--- a/src/app/api/mcp/sse/route.ts
+++ b/src/app/api/mcp/sse/route.ts
@@ -14,15 +14,14 @@ import type { IncomingMessage, ServerResponse } from 'node:http'; // ServerRespo
 
 // Import Schemas
 import {
-    ListTodosParamsSchema, // Keep for z.infer
-    AddTodoParamsSchema, // Keep for z.infer
+    ListTodosParamsSchema,
     ToolsListRequestSchema,
     type ToolDefinition, // For typing toolsArray
     ToolsCallRequestSchema
 } from '@/lib/mcp/schemas';
 
 // Import Tool Logic Handlers
-import { handleListTodosLogic, handleAddTodoLogic } from '@/lib/mcp/tool-logic';
+import { handleListSpaces, handleListTodos, errorResult } from '@/lib/mcp/tool-logic';
 
 // Import Session Management functions
 import {
@@ -35,7 +34,10 @@ import {
 import { ManualMockServerResponse } from '@/lib/mcp/http-utils';
 
 // Import MCP endpoint auth guard
-import { requireMcpAuth } from '@/lib/mcp/auth';
+import { requireMcpAuth, authenticateMcp } from '@/lib/mcp/auth';
+// Per-request principal context (issue #119) + tool error type
+import { runWithPrincipal } from '@/lib/mcp/context';
+import { McpToolError } from '@/lib/mcp/data';
 
 // const activeTransports: Record<string, StreamableHTTPServerTransport> = {}; // Removed
 // const activeServers: Record<string, McpServer> = {}; // Removed
@@ -60,24 +62,22 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
         console.log(`[${sessionId}] Handling tools/list request:`, _request);
         const toolsArray: ToolDefinition[] = [
             {
-                name: 'list-todos',
-                description: 'Lists all todo items.',
+                name: 'list-spaces',
+                description: 'Lists the spaces you are a member of, with member and open-todo counts.',
                 inputSchema: { type: 'object', properties: {} },
-                outputSchema: {
-                    type: 'object',
-                    properties: {
-                        items: {
-                            type: 'array',
-                            items: { type: 'object' }
-                        }
-                    }
-                }
             },
             {
-                name: 'add-todo',
-                description: 'Adds a new todo item. Requires a "text" parameter.',
-                inputSchema: { type: 'object', properties: { 'text': { 'type': 'string', description: 'The text content of the todo.' } }, required: ['text'] },
-                outputSchema: { type: 'object' }
+                name: 'list-todos',
+                description: 'Lists todos in a space you are a member of.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string', description: 'The space to list todos from (see list-spaces).' },
+                        includeCompleted: { type: 'boolean', description: 'Include completed todos (default true).' },
+                        tag: { type: 'string', description: 'Only todos carrying this #tag (case-insensitive).' },
+                    },
+                    required: ['spaceId'],
+                },
             },
         ];
         const actualResultPayload = { tools: toolsArray };
@@ -87,39 +87,34 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
     // --- tools/call Handler (centralized tool execution) ---
     mcpServer.setRequestHandler(ToolsCallRequestSchema, async (request: z.infer<typeof ToolsCallRequestSchema>) => {
         const toolName = request.params.name;
-        const toolArgs = request.params.arguments;
-        const metaArgs = request.params._meta;
+        const toolArgs = request.params.arguments ?? {};
 
-        console.log(`[${sessionId}] Handling tools/call for tool: ${toolName} with args:`, toolArgs, `and meta:`, metaArgs);
+        // Don't log args — they can contain user content. Tool name only.
+        console.log(`[${sessionId}] Handling tools/call for tool: ${toolName}`);
 
         try {
             switch (toolName) {
-                case 'list-todos':
-                    const listTodosParamsForLogic: z.infer<typeof ListTodosParamsSchema> = { _meta: metaArgs };
-                    ListTodosParamsSchema.parse(listTodosParamsForLogic); // Validate
-                    return await handleListTodosLogic(sessionId, listTodosParamsForLogic);
-                case 'add-todo':
-                    const addTodoParamsForLogic: z.infer<typeof AddTodoParamsSchema> = {
-                        ...(toolArgs || {}),
-                        _meta: metaArgs,
-                        text: toolArgs?.text as string, 
-                    } as z.infer<typeof AddTodoParamsSchema>; 
-                    if (toolArgs && typeof toolArgs.text === 'string') {
-                        addTodoParamsForLogic.text = toolArgs.text;
-                    } 
-                    AddTodoParamsSchema.parse(addTodoParamsForLogic); // Validate
-                    return await handleAddTodoLogic(sessionId, addTodoParamsForLogic);
+                case 'list-spaces':
+                    return await handleListSpaces();
+                case 'list-todos': {
+                    const params = ListTodosParamsSchema.parse(toolArgs);
+                    return await handleListTodos(params);
+                }
                 default:
-                    console.error(`[${sessionId}] Unknown tool called via tools/call: ${toolName}`);
-                    return { error: { code: ErrorCode.MethodNotFound, message: `Tool '${toolName}' not found.` } };
+                    return errorResult(`Tool '${toolName}' not found.`);
             }
         } catch (error) {
-            console.error(`[${sessionId}] Error during tools/call for ${toolName}:`, error);
-            let errorMessage = 'Internal server error during tool execution.';
-            if (error instanceof z.ZodError) {
-                errorMessage = `Invalid arguments for tool '${toolName}': ${error.issues.map(e => `${e.path.join('.')} - ${e.message}`).join(', ')}`;
+            // McpToolError carries the safe, user-facing code/message (membership,
+            // not_found, invalid, unconfigured). ZodError → invalid arguments.
+            if (error instanceof McpToolError) {
+                return errorResult(`${error.code}: ${error.message}`);
             }
-            return { error: { code: ErrorCode.InvalidParams, message: errorMessage } };
+            if (error instanceof z.ZodError) {
+                const msg = error.issues.map(e => `${e.path.join('.')} - ${e.message}`).join(', ');
+                return errorResult(`Invalid arguments for '${toolName}': ${msg}`);
+            }
+            console.error(`[${sessionId}] Error during tools/call for ${toolName}:`, error);
+            return errorResult('Internal error during tool execution.');
         }
     });
 
@@ -131,8 +126,9 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
 }
 
 export async function POST(req: NextRequest) {
-    const authError = await requireMcpAuth(req);
-    if (authError) return authError;
+    const auth = await authenticateMcp(req);
+    if (!auth.ok) return auth.response;
+    const principal = auth.principal;
 
     // Do not log full headers here — they contain the Authorization token.
     console.log("[General POST /api/mcp/sse] Incoming request, session ID:", req.headers.get('mcp-session-id'));
@@ -227,7 +223,10 @@ export async function POST(req: NextRequest) {
     try {
         console.log(`[${transport.sessionId || sessionId}] Calling transport.handleRequest with node-mocks-http req/res. Waiting for response to finish.`);
         
-        await new Promise<void>((resolve, reject) => {
+        // Run the transport (which invokes the tool handlers) inside the
+        // per-request principal scope (issue #119), so tools resolve the uid of
+        // THIS request's credential — never a uid bound to the cached session.
+        await runWithPrincipal(principal, () => new Promise<void>((resolve, reject) => {
             mockRes.on('finish', () => {
                 console.log(`[${sessionId}] mockRes 'finish' event fired.`);
                 resolve();
@@ -246,9 +245,9 @@ export async function POST(req: NextRequest) {
                     if (!mockRes.writableEnded) {
                         try { mockRes.end(); } catch (e) { console.error("Error ending mockRes after transport error:", e); }
                     }
-                    reject(err); 
+                    reject(err);
                 });
-        });
+        }));
 
         const responseData = mockRes._getData();
         console.log(`[POST - ${sessionId}] Raw mockRes._getData():`, responseData);

--- a/src/lib/mcp/context.ts
+++ b/src/lib/mcp/context.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { McpPrincipal } from "./auth";
+
+// Per-request MCP principal (issue #119). The MCP SDK registers tool handlers
+// once per session, but the authenticated identity is per HTTP request (from the
+// Authorization header). Binding the uid to the session would be insecure —
+// a later request on the same session-id could authenticate as a different key.
+// So the POST handler runs each request inside this AsyncLocalStorage scope and
+// the tool handlers read the principal from it, always for the CURRENT request.
+
+const store = new AsyncLocalStorage<{ principal: McpPrincipal }>();
+
+export function runWithPrincipal<T>(principal: McpPrincipal, fn: () => T): T {
+  return store.run({ principal }, fn);
+}
+
+export function getPrincipal(): McpPrincipal | null {
+  return store.getStore()?.principal ?? null;
+}

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -35,6 +35,23 @@ export interface SpaceData {
   createdBy: string;
 }
 
+export interface SpaceSummary {
+  id: string;
+  name: string;
+  color: number;
+  memberCount: number;
+  openTodoCount: number;
+}
+
+export interface TodoView {
+  id: string;
+  title: string;
+  completed: boolean;
+  waitingOn: string | null;
+  tags: string[];
+  order: number;
+}
+
 // Admin Firestore handle, or a clear error when the service account is missing.
 // The feature degrades to a configuration error — never to something insecure.
 export function requireDb(): Firestore {
@@ -78,4 +95,74 @@ export async function requireMember(uid: string, spaceId: string): Promise<Space
     members,
     createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
   };
+}
+
+// Lists the spaces the uid is a member of, with member and open-todo counts.
+// array-contains + orderBy would need a composite index, so (like the client's
+// getSpacesForUser) it sorts oldest-first in memory. Open counts use Firestore
+// aggregate count() — no full todo scan.
+export async function listSpacesForUid(uid: string): Promise<SpaceSummary[]> {
+  if (!uid) throw new McpToolError("invalid", "Missing user.");
+  const db = requireDb();
+  const snap = await db.collection("spaces").where("members", "array-contains", uid).get();
+
+  const rows = await Promise.all(
+    snap.docs.map(async (doc) => {
+      const data = doc.data();
+      const members: string[] = Array.isArray(data.members) ? data.members : [];
+      const countSnap = await doc.ref.collection("todos").where("completed", "==", false).count().get();
+      return {
+        createdAt: data.createdAt?.toMillis?.() ?? 0,
+        summary: {
+          id: doc.id,
+          name: typeof data.name === "string" ? data.name : "",
+          color: typeof data.color === "number" ? data.color : 0,
+          memberCount: members.length,
+          openTodoCount: countSnap.data().count,
+        } as SpaceSummary,
+      };
+    })
+  );
+
+  return rows.sort((a, b) => a.createdAt - b.createdAt).map((r) => r.summary);
+}
+
+function mapTodoView(doc: FirebaseFirestore.QueryDocumentSnapshot): TodoView {
+  const d = doc.data();
+  return {
+    id: doc.id,
+    title: typeof d.title === "string" ? d.title : "",
+    completed: d.completed === true,
+    waitingOn: typeof d.waitingOn === "string" ? d.waitingOn : null,
+    tags: Array.isArray(d.tags) ? d.tags : [],
+    order: typeof d.order === "number" ? d.order : 0,
+  };
+}
+
+// Lists a space's todos (member-gated), sorted by `order` like the web list.
+// `includeCompleted` defaults to true; `tag` filters case-insensitively (with or
+// without a leading '#').
+export async function listTodos(
+  uid: string,
+  spaceId: string,
+  opts: { includeCompleted?: boolean; tag?: string } = {}
+): Promise<TodoView[]> {
+  await requireMember(uid, spaceId);
+  const db = requireDb();
+  const snap = await db
+    .collection("spaces")
+    .doc(spaceId)
+    .collection("todos")
+    .orderBy("order", "asc")
+    .get();
+
+  let todos = snap.docs.map(mapTodoView);
+  if (opts.includeCompleted === false) {
+    todos = todos.filter((t) => !t.completed);
+  }
+  if (opts.tag) {
+    const tag = opts.tag.replace(/^#/, "").toLowerCase();
+    todos = todos.filter((t) => t.tags.some((x) => x.toLowerCase() === tag));
+  }
+  return todos;
 }

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -12,32 +12,21 @@ export const MetaSchema = z.object({
   }).optional()
 });
 
-// Schemas for list-todos
-export const ListTodosParamsSchema = MetaSchema.extend({});
+// Schemas for list-spaces (issue #119): no input params.
+export const ListSpacesParamsSchema = MetaSchema.extend({});
+
+// Schemas for list-todos (issue #119): scoped to one space; optional filters.
+export const ListTodosParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    includeCompleted: z.boolean().optional(),
+    tag: z.string().optional(),
+});
 export const ListTodosRequestSchema = z.object({
     method: z.literal('list-todos'),
     params: ListTodosParamsSchema.optional(),
 });
-export const TodoSchema = z.object({
-    id: z.string(),
-    text: z.string(),
-    completed: z.boolean(),
-});
-export const ListTodosResultSchema = ResultSchema.extend({
-    result: z.object({ items: z.array(TodoSchema) }),
-});
 
-// Schemas for add-todo
-export const AddTodoParamsSchema = MetaSchema.extend({
-  text: z.string(),
-});
-export const AddTodoRequestSchema = z.object({
-    method: z.literal('add-todo'),
-    params: AddTodoParamsSchema,
-});
-export const AddTodoResultSchema = ResultSchema.extend({
-    result: TodoSchema,
-});
+// (add-todo and the other write tools are introduced with real schemas in #120.)
 
 // Schemas for tools/list
 export const ToolsListParamsSchema = MetaSchema.extend({});

--- a/src/lib/mcp/tool-logic.ts
+++ b/src/lib/mcp/tool-logic.ts
@@ -1,27 +1,48 @@
-import { randomUUID } from 'node:crypto';
-import { z } from 'zod';
-import type { ListTodosParamsSchema, AddTodoParamsSchema } from '@/lib/mcp/schemas'; // Import schema types using alias
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { getPrincipal } from "./context";
+import { McpToolError, listSpacesForUid, listTodos } from "./data";
 
-// Mock data store
-const mockTodoStore: Record<string, { id: string, text: string, completed: boolean }> = {};
+// Firestore-backed MCP tool handlers (issue #119). Each handler resolves the
+// current request's user (from the AsyncLocalStorage principal), runs the
+// member-gated data access, and returns an MCP content block. McpToolError
+// thrown by the data layer is mapped to an error result by the tools/call
+// dispatch in route.ts.
 
-// --- Internal handlers for actual tool logic ---
-export async function handleListTodosLogic(sessionId: string, params: z.infer<typeof ListTodosParamsSchema> | undefined) {
-    console.log(`[${sessionId}] (tool-logic) Internal logic for list-todos, params:`, params);
-    // _meta is part of params due to ListTodosParamsSchema extending MetaSchema
-    // No other specific params for list-todos currently used from 'params' object directly
-    const todos = Object.values(mockTodoStore);
-    return { result: { items: todos } };
+export function jsonResult(data: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
 }
 
-export async function handleAddTodoLogic(sessionId: string, params: z.infer<typeof AddTodoParamsSchema>) {
-    console.log(`[${sessionId}] (tool-logic) Internal logic for add-todo, params:`, params);
-    // params already validated by the time it gets here if using Zod in tools/call handler
-    const newTodo = {
-        id: randomUUID(),
-        text: params.text, // Access text directly from parsed params
-        completed: false,
-    };
-    mockTodoStore[newTodo.id] = newTodo;
-    return { result: newTodo };
-} 
+export function errorResult(text: string): CallToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
+// Data tools require a personal API key (→ uid). The shared MCP token has no
+// user identity, so it is rejected here.
+function requireUserUid(): string {
+  const principal = getPrincipal();
+  if (!principal || principal.kind !== "user") {
+    throw new McpToolError(
+      "unauthorized",
+      "This tool requires a personal API key (aido_…); the shared MCP token has no user identity."
+    );
+  }
+  return principal.uid;
+}
+
+export async function handleListSpaces(): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  return jsonResult(await listSpacesForUid(uid));
+}
+
+export async function handleListTodos(args: {
+  spaceId: string;
+  includeCompleted?: boolean;
+  tag?: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  const todos = await listTodos(uid, args.spaceId, {
+    includeCompleted: args.includeCompleted,
+    tag: args.tag,
+  });
+  return jsonResult(todos);
+}


### PR DESCRIPTION
## Summary

Retires the mock store and exposes the first **real, member-gated** MCP read tools, backed by Firestore (Admin SDK) and scoped to the personal API key's uid. Also lands the request-scoped plumbing that the remaining tool issues reuse.

Closes #119 · refs epic #124.

## Key design: per-request uid via AsyncLocalStorage
The MCP SDK registers tool handlers **once per session**, but the credential is **per HTTP request**. Binding the uid to the session would be insecure (a later request on the same session-id could authenticate as a different key). So `POST` authenticates with `authenticateMcp` and runs the transport inside `runWithPrincipal(principal, …)` (`context.ts`); tool handlers read `getPrincipal()` for the **current** request.

## Changes
- **`context.ts`** (new) — `AsyncLocalStorage` principal scope.
- **`data.ts`** — `listSpacesForUid` (members `array-contains` uid; open counts via aggregate `count()`; sorted oldest-first) and `listTodos` (member-gated via `requireMember`; ordered by `order`; optional `includeCompleted`/`tag`).
- **`tool-logic.ts`** — `handleListSpaces`/`handleListTodos`; `requireUserUid` rejects the shared token (no identity); `jsonResult`/`errorResult` typed as `CallToolResult`.
- **`route.ts`** — `POST` → principal scope; `tools/list` advertises the two read tools; `tools/call` dispatch + `McpToolError`/`ZodError` → MCP error content.
- **`schemas.ts`** — `list-todos` params (`spaceId` required, `includeCompleted?`, `tag?`); drop the mock `add-todo`/`Todo` schemas.

## Notes
- **Breaking:** `list-todos` now requires `spaceId`; `add-todo` is temporarily gone (returns real in #120). The old tools were a mock, never productive.
- `GET`/`DELETE` keep the `requireMcpAuth` transport guard.
- No data-model / rules changes.

## Test Plan
- [x] `npm run build` — succeeds (lint + type-check)
- [x] `grep` — no leftover mock symbols (`mockTodoStore`, `handle*Logic`, mock schemas)
- [ ] Vercel check green before merge
- [ ] Manual: personal key → `list-spaces` → `list-todos {spaceId}` returns real data; non-member `spaceId` → error; shared token → rejected
- [ ] Automated isolation/membership coverage in #122 (emulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)