### PR TITLE
MCP write tools: add-todo, complete-todo, set-waiting-on (#120)

### DIFF
--- a/src/app/api/mcp/sse/route.ts
+++ b/src/app/api/mcp/sse/route.ts
@@ -15,13 +15,23 @@ import type { IncomingMessage, ServerResponse } from 'node:http'; // ServerRespo
 // Import Schemas
 import {
     ListTodosParamsSchema,
+    AddTodoParamsSchema,
+    CompleteTodoParamsSchema,
+    SetWaitingOnParamsSchema,
     ToolsListRequestSchema,
     type ToolDefinition, // For typing toolsArray
     ToolsCallRequestSchema
 } from '@/lib/mcp/schemas';
 
 // Import Tool Logic Handlers
-import { handleListSpaces, handleListTodos, errorResult } from '@/lib/mcp/tool-logic';
+import {
+    handleListSpaces,
+    handleListTodos,
+    handleAddTodo,
+    handleCompleteTodo,
+    handleSetWaitingOn,
+    errorResult,
+} from '@/lib/mcp/tool-logic';
 
 // Import Session Management functions
 import {
@@ -79,6 +89,46 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                     required: ['spaceId'],
                 },
             },
+            {
+                name: 'add-todo',
+                description: 'Creates a todo in a space you are a member of.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string', description: 'The space to add the todo to (see list-spaces).' },
+                        title: { type: 'string', description: 'Todo title (may contain #tags and @mentions).' },
+                        bodyText: { type: 'string', description: 'Optional longer body text.' },
+                        waitingOn: { type: 'string', description: 'Optional member uid this todo is waiting on.' },
+                    },
+                    required: ['spaceId', 'title'],
+                },
+            },
+            {
+                name: 'complete-todo',
+                description: 'Marks a todo complete or open again.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string' },
+                        todoId: { type: 'string' },
+                        completed: { type: 'boolean', description: 'true = done, false = reopen.' },
+                    },
+                    required: ['spaceId', 'todoId', 'completed'],
+                },
+            },
+            {
+                name: 'set-waiting-on',
+                description: 'Sets (or clears) the member a todo is waiting on.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string' },
+                        todoId: { type: 'string' },
+                        userId: { type: 'string', description: 'Member uid to wait on, or null to clear.' },
+                    },
+                    required: ['spaceId', 'todoId', 'userId'],
+                },
+            },
         ];
         const actualResultPayload = { tools: toolsArray };
         return { result: actualResultPayload }; 
@@ -99,6 +149,18 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                 case 'list-todos': {
                     const params = ListTodosParamsSchema.parse(toolArgs);
                     return await handleListTodos(params);
+                }
+                case 'add-todo': {
+                    const params = AddTodoParamsSchema.parse(toolArgs);
+                    return await handleAddTodo(params);
+                }
+                case 'complete-todo': {
+                    const params = CompleteTodoParamsSchema.parse(toolArgs);
+                    return await handleCompleteTodo(params);
+                }
+                case 'set-waiting-on': {
+                    const params = SetWaitingOnParamsSchema.parse(toolArgs);
+                    return await handleSetWaitingOn(params);
                 }
                 default:
                     return errorResult(`Tool '${toolName}' not found.`);

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -1,6 +1,7 @@
 import "server-only";
-import type { Firestore } from "firebase-admin/firestore";
+import { FieldValue, type Firestore } from "firebase-admin/firestore";
 import { getAdminDb } from "@/lib/firebase/admin";
+import { deriveTags, deriveMentions, type MentionMember } from "@/lib/utils/textUtils";
 
 // Firestore-backed data access for the MCP tools (issue #118, epic #124).
 //
@@ -15,7 +16,12 @@ import { getAdminDb } from "@/lib/firebase/admin";
 
 // Error codes a tool helper can raise; the MCP tools/call dispatch maps these to
 // JSON-RPC errors / MCP error content.
-export type McpToolErrorCode = "unauthorized" | "not_found" | "invalid" | "unconfigured";
+export type McpToolErrorCode =
+  | "unauthorized"
+  | "not_found"
+  | "invalid"
+  | "unconfigured"
+  | "rate_limited";
 
 export class McpToolError extends Error {
   constructor(
@@ -127,8 +133,8 @@ export async function listSpacesForUid(uid: string): Promise<SpaceSummary[]> {
   return rows.sort((a, b) => a.createdAt - b.createdAt).map((r) => r.summary);
 }
 
-function mapTodoView(doc: FirebaseFirestore.QueryDocumentSnapshot): TodoView {
-  const d = doc.data();
+function mapTodoView(doc: FirebaseFirestore.DocumentSnapshot): TodoView {
+  const d = doc.data() ?? {};
   return {
     id: doc.id,
     title: typeof d.title === "string" ? d.title : "",
@@ -165,4 +171,106 @@ export async function listTodos(
     todos = todos.filter((t) => t.tags.some((x) => x.toLowerCase() === tag));
   }
   return todos;
+}
+
+// --- Writes (member-gated; mirror firestore.rules since the Admin SDK bypasses them) ---
+
+// Loads space members' public display names so plain-text @mentions in a title
+// can be resolved to uids (issue #76 parity), exactly like the web client.
+async function loadMentionMembers(db: Firestore, memberUids: string[]): Promise<MentionMember[]> {
+  if (memberUids.length === 0) return [];
+  const refs = memberUids.map((uid) => db.collection("publicProfiles").doc(uid));
+  const snaps = await db.getAll(...refs);
+  return snaps.map((s) => ({
+    uid: s.id,
+    displayName: s.exists ? ((s.data()!.displayName as string | null) ?? null) : null,
+  }));
+}
+
+// Minimal Tiptap doc wrapping a plain-text body, so an MCP-created todo renders
+// in the web editor and its #tags/@mentions are picked up by the derivations.
+function bodyFromText(text: string | undefined | null): Record<string, unknown> | null {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return null;
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text: trimmed }] }],
+  };
+}
+
+export async function addTodo(
+  uid: string,
+  spaceId: string,
+  input: { title: string; bodyText?: string | null; waitingOn?: string | null }
+): Promise<TodoView> {
+  const space = await requireMember(uid, spaceId);
+  const title = (input.title ?? "").trim();
+  if (!title) throw new McpToolError("invalid", "title is required.");
+
+  const waitingOn = input.waitingOn ?? null;
+  if (waitingOn !== null && !space.members.includes(waitingOn)) {
+    throw new McpToolError("invalid", "waitingOn must be a member of the space.");
+  }
+
+  const db = requireDb();
+  const todosCol = db.collection("spaces").doc(spaceId).collection("todos");
+  const body = bodyFromText(input.bodyText);
+  const members = await loadMentionMembers(db, space.members);
+
+  const lastSnap = await todosCol.orderBy("order", "desc").limit(1).get();
+  const maxOrder = lastSnap.empty
+    ? 0
+    : typeof lastSnap.docs[0].data().order === "number"
+      ? (lastSnap.docs[0].data().order as number)
+      : 0;
+
+  const ref = await todosCol.add({
+    spaceId,
+    title,
+    body,
+    completed: false,
+    waitingOn,
+    tags: deriveTags(title, body),
+    mentions: deriveMentions(body, title, members),
+    createdBy: uid,
+    createdAt: FieldValue.serverTimestamp(),
+    order: maxOrder + 1,
+  });
+
+  return mapTodoView(await ref.get());
+}
+
+export async function completeTodo(
+  uid: string,
+  spaceId: string,
+  todoId: string,
+  completed: boolean
+): Promise<TodoView> {
+  await requireMember(uid, spaceId);
+  if (!todoId) throw new McpToolError("invalid", "todoId is required.");
+  const db = requireDb();
+  const ref = db.collection("spaces").doc(spaceId).collection("todos").doc(todoId);
+  const snap = await ref.get();
+  if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
+  await ref.update({ completed: !!completed });
+  return mapTodoView(await ref.get());
+}
+
+export async function setWaitingOn(
+  uid: string,
+  spaceId: string,
+  todoId: string,
+  userId: string | null
+): Promise<TodoView> {
+  const space = await requireMember(uid, spaceId);
+  if (!todoId) throw new McpToolError("invalid", "todoId is required.");
+  if (userId !== null && !space.members.includes(userId)) {
+    throw new McpToolError("invalid", "waitingOn must be a member of the space, or null.");
+  }
+  const db = requireDb();
+  const ref = db.collection("spaces").doc(spaceId).collection("todos").doc(todoId);
+  const snap = await ref.get();
+  if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
+  await ref.update({ waitingOn: userId });
+  return mapTodoView(await ref.get());
 }

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -26,7 +26,23 @@ export const ListTodosRequestSchema = z.object({
     params: ListTodosParamsSchema.optional(),
 });
 
-// (add-todo and the other write tools are introduced with real schemas in #120.)
+// Write tools (issue #120): all space-scoped.
+export const AddTodoParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    title: z.string().min(1),
+    bodyText: z.string().optional(),
+    waitingOn: z.string().nullable().optional(),
+});
+export const CompleteTodoParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    todoId: z.string().min(1),
+    completed: z.boolean(),
+});
+export const SetWaitingOnParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    todoId: z.string().min(1),
+    userId: z.string().nullable(),
+});
 
 // Schemas for tools/list
 export const ToolsListParamsSchema = MetaSchema.extend({});

--- a/src/lib/mcp/tool-logic.ts
+++ b/src/lib/mcp/tool-logic.ts
@@ -1,6 +1,14 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { rateLimit } from "@/lib/apiKeys";
 import { getPrincipal } from "./context";
-import { McpToolError, listSpacesForUid, listTodos } from "./data";
+import {
+  McpToolError,
+  listSpacesForUid,
+  listTodos,
+  addTodo,
+  completeTodo,
+  setWaitingOn,
+} from "./data";
 
 // Firestore-backed MCP tool handlers (issue #119). Each handler resolves the
 // current request's user (from the AsyncLocalStorage principal), runs the
@@ -29,6 +37,16 @@ function requireUserUid(): string {
   return principal.uid;
 }
 
+// Lightweight per-uid write throttle (issue #120), reusing the fixed-window
+// limiter from apiKeys. Per serverless instance — a brake against scripted
+// spam, not a distributed quota.
+const WRITE_RATE_LIMIT = { max: 30, windowMs: 60_000 };
+function enforceWriteRateLimit(uid: string): void {
+  if (!rateLimit(`mcp:write:${uid}`, WRITE_RATE_LIMIT)) {
+    throw new McpToolError("rate_limited", "Too many writes; slow down and retry shortly.");
+  }
+}
+
 export async function handleListSpaces(): Promise<CallToolResult> {
   const uid = requireUserUid();
   return jsonResult(await listSpacesForUid(uid));
@@ -45,4 +63,40 @@ export async function handleListTodos(args: {
     tag: args.tag,
   });
   return jsonResult(todos);
+}
+
+export async function handleAddTodo(args: {
+  spaceId: string;
+  title: string;
+  bodyText?: string;
+  waitingOn?: string | null;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  const todo = await addTodo(uid, args.spaceId, {
+    title: args.title,
+    bodyText: args.bodyText,
+    waitingOn: args.waitingOn,
+  });
+  return jsonResult(todo);
+}
+
+export async function handleCompleteTodo(args: {
+  spaceId: string;
+  todoId: string;
+  completed: boolean;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await completeTodo(uid, args.spaceId, args.todoId, args.completed));
+}
+
+export async function handleSetWaitingOn(args: {
+  spaceId: string;
+  todoId: string;
+  userId: string | null;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await setWaitingOn(uid, args.spaceId, args.todoId, args.userId));
 }


### PR DESCRIPTION
## Summary

Member-gated **write** tools (Admin SDK) that mirror `firestore.rules` — the Admin SDK bypasses the rules, so this code owns the same invariants.

Closes #120 · refs epic #124.

## Tools
- **`add-todo`** `{ spaceId, title, bodyText?, waitingOn? }` — creates a real todo: `createdBy=uid`, `order=max+1` (queried), `completed=false`; `tags`/`mentions` derived via the shared `textUtils` (plain-text @mentions in the title resolved against members' `publicProfiles`, #76 parity); optional `bodyText` wrapped in a minimal Tiptap doc so it renders in the web editor; `waitingOn` validated ∈ members.
- **`complete-todo`** `{ spaceId, todoId, completed }` — sets `completed` atomically.
- **`set-waiting-on`** `{ spaceId, todoId, userId|null }` — sets/clears `waitingOn` (must be a member, or null).

## Safety / parity
- Every tool goes through `requireMember(uid, spaceId)` first; `requireUserUid` rejects the shared token.
- Field invariants mirror the rules: `createdBy` set to uid, `waitingOn` ∈ members, valid `title/completed/order/spaceId/body` shapes.
- **Per-uid write rate limit** (30/min) reusing `apiKeys.rateLimit`; new `McpToolError` code `rate_limited`.

## Test Plan
- [x] `npm run build` — succeeds (lint + type-check)
- [ ] Vercel check green before merge
- [ ] Manual: `add-todo` → appears in web UI (tags/mentions derived); `complete-todo` toggles; `set-waiting-on` with non-member → `invalid`; non-member space → error; rapid writes → `rate_limited`
- [ ] Automated parity/isolation in #122 (emulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)