### PR TITLE
MCP tool tests: emulator integration suite (#122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,17 @@ npx tsc --noEmit       # type-check (only stale .next/types errors are expected)
 npm run test:rules
 npx -y firebase-tools@13 emulators:exec --only firestore,storage --project demo-rules-test \
   "node tests/firestore-rules.test.mjs && node tests/storage-rules.test.mjs"
+
+# MCP tool tests (issue #122): exercise the real Admin-SDK tool code
+# (src/lib/mcp/data.ts + tool-logic.ts) against the Firestore emulator.
+npm run test:mcp
 ```
 
-There is no unit-test runner; the only automated tests are the emulator-based security-rules suites in `tests/` (plain `node` scripts using `@firebase/rules-unit-testing`, run a single one with `node tests/<file>.mjs` inside `emulators:exec`). `functions/` has its own `package.json` (`npm run build`/`lint` there).
+There is no general unit-test runner; the automated tests are emulator-based and live in `tests/`. Two flavours:
+- **Security-rules + migration suites** — plain `node` `.mjs` scripts using `@firebase/rules-unit-testing` (rules) or `firebase-admin` (migration), run inside `emulators:exec` (e.g. `node tests/<file>.mjs`).
+- **MCP tool tests** (`tests/mcp-tools.test.mts`, `npm run test:mcp`) — TypeScript run via `tsx`; they import the real `src/lib/mcp/*` code. The runner needs `node --conditions=react-server` (so the `server-only` guard resolves to an empty module) and pre-initializes the `admin`-named Firebase app so `admin.ts` reuses the emulator-bound app instead of going through `cert()`.
+
+`functions/` has its own `package.json` (`npm run build`/`lint` there).
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/cli": "^0.1.13",
         "eslint": "8.57.0",
-        "eslint-config-next": "^15.5.19"
+        "eslint-config-next": "^15.5.19",
+        "tsx": "^4.22.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -87,6 +88,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4514,6 +4957,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -9744,6 +10229,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test:rules": "firebase emulators:exec --only firestore,storage --project demo-rules-test \"node tests/firestore-rules.test.mjs && node tests/storage-rules.test.mjs\"",
     "test:migration": "firebase emulators:exec --only firestore --project demo-migration \"node tests/migration-admin.test.mjs\"",
+    "test:mcp": "firebase emulators:exec --only firestore --project demo-mcp \"node --conditions=react-server --import tsx tests/mcp-tools.test.mts\"",
     "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs"
   },
   "dependencies": {
@@ -48,7 +49,8 @@
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/cli": "^0.1.13",
     "eslint": "8.57.0",
-    "eslint-config-next": "^15.5.19"
+    "eslint-config-next": "^15.5.19",
+    "tsx": "^4.22.4"
   },
   "overrides": {
     "next": {

--- a/tests/mcp-tools.test.mts
+++ b/tests/mcp-tools.test.mts
@@ -1,0 +1,135 @@
+// Integration tests for the Firestore-backed MCP tools (epic #124, issue #122).
+//
+// Exercises the REAL tool code (src/lib/mcp/data.ts + tool-logic.ts) against the
+// Firestore emulator with the Admin SDK — the same path the live endpoint takes.
+// Since the Admin SDK bypasses firestore.rules, these tests guard the membership
+// isolation and field invariants the tools must enforce themselves.
+//
+// Run via (needs a JDK + the firestore emulator):
+//   npx -y firebase-tools@13 emulators:exec --only firestore --project demo-mcp \
+//     "node --conditions=react-server --import tsx tests/mcp-tools.test.mts"
+//
+// The `react-server` condition makes the `server-only` guard resolve to an empty
+// module; tsx transpiles the TS + resolves the @/* path alias from tsconfig.
+
+import { initializeApp } from "firebase-admin/app";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("FIRESTORE_EMULATOR_HOST is not set — run inside emulators:exec.");
+  process.exit(1);
+}
+
+// Pre-initialize the app under the name admin.ts expects, BEFORE the tools touch
+// Firestore. admin.ts's getAdminApp() then reuses this emulator-bound app and
+// never goes through cert()/FIREBASE_SERVICE_ACCOUNT_KEY.
+const projectId = process.env.GCLOUD_PROJECT || "demo-mcp";
+const adminApp = initializeApp({ projectId }, "admin");
+const db = getFirestore(adminApp);
+
+// Import the real tool code AFTER the app exists (functions only touch Firestore
+// when called, so import order vs. init is safe, but keep it explicit).
+const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, McpToolError } =
+  await import("../src/lib/mcp/data.ts");
+const { handleListSpaces } = await import("../src/lib/mcp/tool-logic.ts");
+const { runWithPrincipal } = await import("../src/lib/mcp/context.ts");
+
+const ALICE = "alice-uid";
+const BOB = "bob-uid";
+const CAROL = "carol-uid";
+const S1 = "space-1"; // alice + bob
+const S2 = "space-2"; // carol only
+
+let failures = 0;
+function check(name: string, cond: boolean) {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.error(`  ✗ ${name}`);
+  }
+}
+async function expectError(name: string, code: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    failures++;
+    console.error(`  ✗ ${name} (expected ${code}, but it resolved)`);
+  } catch (e) {
+    const actual = e instanceof McpToolError ? e.code : `${(e as Error).name}`;
+    check(`${name} → ${code}`, actual === code);
+  }
+}
+
+async function seed() {
+  await db.collection("publicProfiles").doc(ALICE).set({ displayName: "Alice" });
+  await db.collection("publicProfiles").doc(BOB).set({ displayName: "Bob" });
+  await db.collection("publicProfiles").doc(CAROL).set({ displayName: "Carol" });
+
+  await db.collection("spaces").doc(S1).set({
+    name: "Team", color: 40, members: [ALICE, BOB], createdBy: ALICE, createdAt: FieldValue.serverTimestamp(),
+  });
+  await db.collection("spaces").doc(S2).set({
+    name: "Carol", color: 200, members: [CAROL], createdBy: CAROL, createdAt: FieldValue.serverTimestamp(),
+  });
+
+  await db.collection("spaces").doc(S1).collection("todos").doc("t1").set({
+    spaceId: S1, title: "Existing", body: null, completed: false, waitingOn: null,
+    tags: [], mentions: [], createdBy: ALICE, createdAt: FieldValue.serverTimestamp(), order: 1,
+  });
+}
+
+async function run() {
+  await seed();
+
+  // --- requireMember / isolation ---
+  await expectError("non-member is rejected on a space", "unauthorized", () => requireMember(CAROL, S1));
+  await expectError("unknown space is not_found", "not_found", () => requireMember(ALICE, "nope"));
+  const space = await requireMember(ALICE, S1);
+  check("member resolves the space", space.id === S1 && space.members.includes(ALICE));
+
+  // --- list-spaces ---
+  const spaces = await listSpacesForUid(ALICE);
+  check("list-spaces returns only my spaces", spaces.length === 1 && spaces[0].id === S1);
+  check("list-spaces reports open-todo count", spaces[0].openTodoCount === 1);
+
+  // --- list-todos isolation ---
+  const todos = await listTodos(ALICE, S1, {});
+  check("list-todos returns the space's todos", todos.length === 1 && todos[0].title === "Existing");
+  await expectError("list-todos rejects non-members", "unauthorized", () => listTodos(CAROL, S1, {}));
+
+  // --- add-todo invariants ---
+  const created = await addTodo(ALICE, S1, { title: "Buy #milk @Bob", waitingOn: BOB });
+  const createdSnap = await db.collection("spaces").doc(S1).collection("todos").doc(created.id).get();
+  const cd = createdSnap.data()!;
+  check("add-todo sets createdBy to the caller", cd.createdBy === ALICE);
+  check("add-todo sets order = max+1", cd.order === 2);
+  check("add-todo derives #tags", Array.isArray(cd.tags) && cd.tags.includes("milk"));
+  check("add-todo resolves @mention to uid", Array.isArray(cd.mentions) && cd.mentions.includes(BOB));
+  check("add-todo keeps a member waitingOn", cd.waitingOn === BOB);
+  await expectError("add-todo rejects a non-member waitingOn", "invalid",
+    () => addTodo(ALICE, S1, { title: "x", waitingOn: CAROL }));
+
+  // --- complete-todo / set-waiting-on ---
+  const done = await completeTodo(ALICE, S1, created.id, true);
+  check("complete-todo sets completed", done.completed === true);
+  const cleared = await setWaitingOn(ALICE, S1, created.id, null);
+  check("set-waiting-on clears to null", cleared.waitingOn === null);
+  await expectError("set-waiting-on rejects a non-member", "invalid",
+    () => setWaitingOn(ALICE, S1, created.id, CAROL));
+
+  // --- principal gate (tool-logic): data tools require a user principal ---
+  await expectError("no principal → unauthorized", "unauthorized", () => handleListSpaces());
+  await expectError("shared principal → unauthorized", "unauthorized",
+    () => runWithPrincipal({ kind: "shared" }, () => handleListSpaces()));
+  const ok = await runWithPrincipal({ kind: "user", uid: ALICE }, () => handleListSpaces());
+  check("user principal → tool runs", !ok.isError && Array.isArray(ok.content));
+}
+
+run()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll MCP tool tests passed." : `\n${failures} check(s) failed.`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((e) => {
+    console.error("\nTest run crashed:", e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

`tests/mcp-tools.test.mts` exercises the **real** tool code (`src/lib/mcp/data.ts` + `tool-logic.ts`) against the Firestore emulator with the Admin SDK — the same path the live endpoint takes. Because the Admin SDK bypasses `firestore.rules`, these tests guard the membership isolation and field invariants the tools must enforce themselves.

Closes #122 · refs epic #124.

## Coverage — 19 checks, all passing locally
- `requireMember`: member ok, non-member → `unauthorized`, unknown space → `not_found`
- `list-spaces`: returns only my spaces + open-todo count; `list-todos` rejects non-members
- `add-todo`: `createdBy`=uid, `order`=max+1, `#tags` derived, `@mention` resolved to a uid (via publicProfiles, #76 parity), member `waitingOn` kept, **non-member `waitingOn` → `invalid`**
- `complete-todo` / `set-waiting-on` (clear to null + non-member rejection)
- principal gate: no principal / shared principal → `unauthorized`; user principal → runs

## How it tests the real TS code (no logic re-implementation)
The repo has no general TS test runner, and `data.ts` is TS + `server-only` + `@/` aliases. The suite runs via **`tsx`** with two tricks:
- `node --conditions=react-server` → the `server-only` guard resolves to an empty module (no throw).
- The test **pre-initializes the `admin`-named Firebase app** (emulator-bound) before the tools touch Firestore, so `admin.ts`'s `getAdminApp()` reuses it and never goes through `cert()` / `FIREBASE_SERVICE_ACCOUNT_KEY`.
- `tsx` transpiles the TS and resolves the `@/*` path alias from `tsconfig`.

The `.mts` extension keeps it out of `tsc`/`next build` (`**/*.ts` doesn't match `.mts`).

## Run
```
npm run test:mcp
# = firebase emulators:exec --only firestore --project demo-mcp \
#     "node --conditions=react-server --import tsx tests/mcp-tools.test.mts"
```
Needs a JDK + the firestore emulator (use `npx -y firebase-tools@13 …` if firebase isn't global). Adds `tsx` as a devDependency; CLAUDE.md updated.

## Notes
- Verified locally: **all 19 checks pass** against the emulator.
- Not run by Vercel (separate emulator command) — merges on build-green.
- Daily-tool (`add-daily`/`list-daily`) coverage lands with #121.

## Test Plan
- [x] `npm run test:mcp` — 19/19 pass against the emulator
- [x] `npm run build` / `tsc` / `lint` — clean (`.mts` excluded from the build)
- [ ] Vercel check green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)