### PR TITLE
MCP daily tools: list-daily & add-daily (#121)

### DIFF
--- a/src/app/api/mcp/sse/route.ts
+++ b/src/app/api/mcp/sse/route.ts
@@ -18,6 +18,8 @@ import {
     AddTodoParamsSchema,
     CompleteTodoParamsSchema,
     SetWaitingOnParamsSchema,
+    ListDailyParamsSchema,
+    AddDailyParamsSchema,
     ToolsListRequestSchema,
     type ToolDefinition, // For typing toolsArray
     ToolsCallRequestSchema
@@ -30,6 +32,8 @@ import {
     handleAddTodo,
     handleCompleteTodo,
     handleSetWaitingOn,
+    handleListDaily,
+    handleAddDaily,
     errorResult,
 } from '@/lib/mcp/tool-logic';
 
@@ -129,6 +133,30 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                     required: ['spaceId', 'todoId', 'userId'],
                 },
             },
+            {
+                name: 'list-daily',
+                description: 'Lists a space\'s short-lived "Heute" items for a date (default today).',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string' },
+                        date: { type: 'string', description: 'YYYY-MM-DD; defaults to today (UTC).' },
+                    },
+                    required: ['spaceId'],
+                },
+            },
+            {
+                name: 'add-daily',
+                description: 'Adds a short-lived "Heute" item dated today.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string' },
+                        text: { type: 'string', description: 'The item text.' },
+                    },
+                    required: ['spaceId', 'text'],
+                },
+            },
         ];
         const actualResultPayload = { tools: toolsArray };
         return { result: actualResultPayload }; 
@@ -161,6 +189,14 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                 case 'set-waiting-on': {
                     const params = SetWaitingOnParamsSchema.parse(toolArgs);
                     return await handleSetWaitingOn(params);
+                }
+                case 'list-daily': {
+                    const params = ListDailyParamsSchema.parse(toolArgs);
+                    return await handleListDaily(params);
+                }
+                case 'add-daily': {
+                    const params = AddDailyParamsSchema.parse(toolArgs);
+                    return await handleAddDaily(params);
                 }
                 default:
                     return errorResult(`Tool '${toolName}' not found.`);

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -58,6 +58,28 @@ export interface TodoView {
   order: number;
 }
 
+export interface DailyView {
+  id: string;
+  text: string;
+  completed: boolean;
+  date: string;
+  author: string;
+}
+
+// Strict YYYY-MM-DD, matching the daily `date` regex in firestore.rules.
+const DAILY_DATE_RE = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+
+// Today's date as YYYY-MM-DD in UTC. The web client uses the browser's local
+// date (firebaseUtils.todayString); server-side there is no user timezone, so
+// UTC is the deterministic choice (a daily added near midnight may land on the
+// caller's "yesterday/tomorrow" — acceptable for the tool).
+function todayUtc(): string {
+  const d = new Date();
+  const month = `${d.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getUTCDate()}`.padStart(2, "0");
+  return `${d.getUTCFullYear()}-${month}-${day}`;
+}
+
 // Admin Firestore handle, or a clear error when the service account is missing.
 // The feature degrades to a configuration error — never to something insecure.
 export function requireDb(): Firestore {
@@ -273,4 +295,57 @@ export async function setWaitingOn(
   if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
   await ref.update({ waitingOn: userId });
   return mapTodoView(await ref.get());
+}
+
+// --- Daily "Heute" items (issue #121) ---
+
+function mapDailyView(doc: FirebaseFirestore.DocumentSnapshot): DailyView {
+  const d = doc.data() ?? {};
+  return {
+    id: doc.id,
+    text: typeof d.text === "string" ? d.text : "",
+    completed: d.completed === true,
+    date: typeof d.date === "string" ? d.date : "",
+    author: typeof d.author === "string" ? d.author : "",
+  };
+}
+
+// Lists a space's daily items for a date (default: today UTC), oldest-first.
+export async function listDaily(uid: string, spaceId: string, date?: string): Promise<DailyView[]> {
+  await requireMember(uid, spaceId);
+  const day = date ?? todayUtc();
+  if (!DAILY_DATE_RE.test(day)) {
+    throw new McpToolError("invalid", "date must be YYYY-MM-DD.");
+  }
+  const db = requireDb();
+  const snap = await db
+    .collection("spaces")
+    .doc(spaceId)
+    .collection("daily")
+    .where("date", "==", day)
+    .get();
+
+  return snap.docs
+    .map((d) => ({ createdAt: d.data().createdAt?.toMillis?.() ?? 0, view: mapDailyView(d) }))
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map((r) => r.view);
+}
+
+// Adds a daily "Heute" item dated today (UTC). author=uid; mirrors the rules'
+// field shape (text/completed/spaceId/date).
+export async function addDaily(uid: string, spaceId: string, text: string): Promise<DailyView> {
+  await requireMember(uid, spaceId);
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) throw new McpToolError("invalid", "text is required.");
+
+  const db = requireDb();
+  const ref = await db.collection("spaces").doc(spaceId).collection("daily").add({
+    spaceId,
+    text: trimmed,
+    completed: false,
+    date: todayUtc(),
+    author: uid,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return mapDailyView(await ref.get());
 }

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -43,6 +43,14 @@ export const SetWaitingOnParamsSchema = MetaSchema.extend({
     todoId: z.string().min(1),
     userId: z.string().nullable(),
 });
+export const ListDailyParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    date: z.string().optional(),
+});
+export const AddDailyParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    text: z.string().min(1),
+});
 
 // Schemas for tools/list
 export const ToolsListParamsSchema = MetaSchema.extend({});

--- a/src/lib/mcp/tool-logic.ts
+++ b/src/lib/mcp/tool-logic.ts
@@ -8,6 +8,8 @@ import {
   addTodo,
   completeTodo,
   setWaitingOn,
+  listDaily,
+  addDaily,
 } from "./data";
 
 // Firestore-backed MCP tool handlers (issue #119). Each handler resolves the
@@ -99,4 +101,21 @@ export async function handleSetWaitingOn(args: {
   const uid = requireUserUid();
   enforceWriteRateLimit(uid);
   return jsonResult(await setWaitingOn(uid, args.spaceId, args.todoId, args.userId));
+}
+
+export async function handleListDaily(args: {
+  spaceId: string;
+  date?: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  return jsonResult(await listDaily(uid, args.spaceId, args.date));
+}
+
+export async function handleAddDaily(args: {
+  spaceId: string;
+  text: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await addDaily(uid, args.spaceId, args.text));
 }

--- a/tests/mcp-tools.test.mts
+++ b/tests/mcp-tools.test.mts
@@ -29,7 +29,7 @@ const db = getFirestore(adminApp);
 
 // Import the real tool code AFTER the app exists (functions only touch Firestore
 // when called, so import order vs. init is safe, but keep it explicit).
-const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, McpToolError } =
+const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, listDaily, addDaily, McpToolError } =
   await import("../src/lib/mcp/data.ts");
 const { handleListSpaces } = await import("../src/lib/mcp/tool-logic.ts");
 const { runWithPrincipal } = await import("../src/lib/mcp/context.ts");
@@ -115,6 +115,18 @@ async function run() {
   check("set-waiting-on clears to null", cleared.waitingOn === null);
   await expectError("set-waiting-on rejects a non-member", "invalid",
     () => setWaitingOn(ALICE, S1, created.id, CAROL));
+
+  // --- daily ("Heute") tools ---
+  const daily = await addDaily(ALICE, S1, "Quick note");
+  const dailySnap = await db.collection("spaces").doc(S1).collection("daily").doc(daily.id).get();
+  const dd = dailySnap.data()!;
+  check("add-daily sets author to the caller", dd.author === ALICE);
+  check("add-daily dates today (YYYY-MM-DD)", /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(dd.date));
+  check("add-daily starts not completed", dd.completed === false);
+  const listed = await listDaily(ALICE, S1, dd.date);
+  check("list-daily returns the day's items", listed.some((x) => x.id === daily.id));
+  await expectError("list-daily rejects a bad date", "invalid", () => listDaily(ALICE, S1, "2026-13-40"));
+  await expectError("add-daily rejects non-members", "unauthorized", () => addDaily(CAROL, S1, "x"));
 
   // --- principal gate (tool-logic): data tools require a user principal ---
   await expectError("no principal → unauthorized", "unauthorized", () => handleListSpaces());


### PR DESCRIPTION
## Summary

Member-gated daily "Heute" tools (Admin SDK), mirroring the daily field shape in `firestore.rules`. Also adds the deferred daily test coverage.

Closes #121 · refs epic #124.

## Tools
- **`list-daily`** `{ spaceId, date? }` — items for a date (default today, UTC), oldest-first; validates `date` against the rules' `YYYY-MM-DD` regex (bad date → `invalid`).
- **`add-daily`** `{ spaceId, text }` — `author`=uid, `date`=today (UTC), `completed`=false.

## Note on "today"
`todayUtc()` replaces the client's local-tz `todayString` server-side — there's no user timezone available to the endpoint, so UTC is the deterministic choice. A daily added near midnight may land on the caller's adjacent day; acceptable and documented.

## Tests
`tests/mcp-tools.test.mts` extended with daily checks (author, date regex, not-completed, list returns the day's items, bad date → `invalid`, non-member → `unauthorized`).

## Test Plan
- [x] `npm run test:mcp` — **25/25** pass against the emulator (19 prior + 6 daily)
- [x] `npm run build` / `tsc` / `lint` — clean
- [ ] Vercel check green before merge
- [ ] Manual: `add-daily` → appears in the Heute view; `list-daily` reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)