### PR TITLE
MCP comfort tools: delete-todo, whoami, list-members (#123)

### DIFF
--- a/src/app/api/mcp/sse/route.ts
+++ b/src/app/api/mcp/sse/route.ts
@@ -20,6 +20,8 @@ import {
     SetWaitingOnParamsSchema,
     ListDailyParamsSchema,
     AddDailyParamsSchema,
+    DeleteTodoParamsSchema,
+    ListMembersParamsSchema,
     ToolsListRequestSchema,
     type ToolDefinition, // For typing toolsArray
     ToolsCallRequestSchema
@@ -34,6 +36,9 @@ import {
     handleSetWaitingOn,
     handleListDaily,
     handleAddDaily,
+    handleDeleteTodo,
+    handleWhoami,
+    handleListMembers,
     errorResult,
 } from '@/lib/mcp/tool-logic';
 
@@ -157,6 +162,32 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                     required: ['spaceId', 'text'],
                 },
             },
+            {
+                name: 'delete-todo',
+                description: 'Deletes a todo from a space you are a member of.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        spaceId: { type: 'string' },
+                        todoId: { type: 'string' },
+                    },
+                    required: ['spaceId', 'todoId'],
+                },
+            },
+            {
+                name: 'whoami',
+                description: 'Returns the uid and display name of the personal API key owner.',
+                inputSchema: { type: 'object', properties: {} },
+            },
+            {
+                name: 'list-members',
+                description: 'Lists the members (uid + display name) of a space you belong to.',
+                inputSchema: {
+                    type: 'object',
+                    properties: { spaceId: { type: 'string' } },
+                    required: ['spaceId'],
+                },
+            },
         ];
         const actualResultPayload = { tools: toolsArray };
         return { result: actualResultPayload }; 
@@ -197,6 +228,16 @@ function createAndConfigureMcpServer(sessionId: string): McpServer {
                 case 'add-daily': {
                     const params = AddDailyParamsSchema.parse(toolArgs);
                     return await handleAddDaily(params);
+                }
+                case 'delete-todo': {
+                    const params = DeleteTodoParamsSchema.parse(toolArgs);
+                    return await handleDeleteTodo(params);
+                }
+                case 'whoami':
+                    return await handleWhoami();
+                case 'list-members': {
+                    const params = ListMembersParamsSchema.parse(toolArgs);
+                    return await handleListMembers(params);
                 }
                 default:
                     return errorResult(`Tool '${toolName}' not found.`);

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -297,6 +297,43 @@ export async function setWaitingOn(
   return mapTodoView(await ref.get());
 }
 
+export async function deleteTodo(
+  uid: string,
+  spaceId: string,
+  todoId: string
+): Promise<{ id: string; deleted: boolean }> {
+  await requireMember(uid, spaceId);
+  if (!todoId) throw new McpToolError("invalid", "todoId is required.");
+  const db = requireDb();
+  const ref = db.collection("spaces").doc(spaceId).collection("todos").doc(todoId);
+  const snap = await ref.get();
+  if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
+  await ref.delete();
+  return { id: todoId, deleted: true };
+}
+
+// --- Identity / members (issue #123) ---
+
+export interface MemberView {
+  uid: string;
+  displayName: string | null;
+}
+
+// The key owner's identity: uid + public display name.
+export async function whoami(uid: string): Promise<MemberView> {
+  if (!uid) throw new McpToolError("invalid", "Missing user.");
+  const db = requireDb();
+  const snap = await db.collection("publicProfiles").doc(uid).get();
+  return { uid, displayName: snap.exists ? ((snap.data()!.displayName as string | null) ?? null) : null };
+}
+
+// The members of a space (member-gated), with public display names — so a client
+// can resolve uids for set-waiting-on / add-todo waitingOn.
+export async function listMembers(uid: string, spaceId: string): Promise<MemberView[]> {
+  const space = await requireMember(uid, spaceId);
+  return loadMentionMembers(requireDb(), space.members);
+}
+
 // --- Daily "Heute" items (issue #121) ---
 
 function mapDailyView(doc: FirebaseFirestore.DocumentSnapshot): DailyView {

--- a/src/lib/mcp/schemas.ts
+++ b/src/lib/mcp/schemas.ts
@@ -52,6 +52,16 @@ export const AddDailyParamsSchema = MetaSchema.extend({
     text: z.string().min(1),
 });
 
+// Comfort tools (issue #123).
+export const DeleteTodoParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+    todoId: z.string().min(1),
+});
+export const WhoamiParamsSchema = MetaSchema.extend({});
+export const ListMembersParamsSchema = MetaSchema.extend({
+    spaceId: z.string().min(1),
+});
+
 // Schemas for tools/list
 export const ToolsListParamsSchema = MetaSchema.extend({});
 export const ToolDefinitionSchema = z.object({

--- a/src/lib/mcp/tool-logic.ts
+++ b/src/lib/mcp/tool-logic.ts
@@ -10,6 +10,9 @@ import {
   setWaitingOn,
   listDaily,
   addDaily,
+  deleteTodo,
+  whoami,
+  listMembers,
 } from "./data";
 
 // Firestore-backed MCP tool handlers (issue #119). Each handler resolves the
@@ -118,4 +121,23 @@ export async function handleAddDaily(args: {
   const uid = requireUserUid();
   enforceWriteRateLimit(uid);
   return jsonResult(await addDaily(uid, args.spaceId, args.text));
+}
+
+export async function handleDeleteTodo(args: {
+  spaceId: string;
+  todoId: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await deleteTodo(uid, args.spaceId, args.todoId));
+}
+
+export async function handleWhoami(): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  return jsonResult(await whoami(uid));
+}
+
+export async function handleListMembers(args: { spaceId: string }): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  return jsonResult(await listMembers(uid, args.spaceId));
 }

--- a/tests/mcp-tools.test.mts
+++ b/tests/mcp-tools.test.mts
@@ -29,7 +29,7 @@ const db = getFirestore(adminApp);
 
 // Import the real tool code AFTER the app exists (functions only touch Firestore
 // when called, so import order vs. init is safe, but keep it explicit).
-const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, listDaily, addDaily, McpToolError } =
+const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, listDaily, addDaily, deleteTodo, whoami, listMembers, McpToolError } =
   await import("../src/lib/mcp/data.ts");
 const { handleListSpaces } = await import("../src/lib/mcp/tool-logic.ts");
 const { runWithPrincipal } = await import("../src/lib/mcp/context.ts");
@@ -127,6 +127,23 @@ async function run() {
   check("list-daily returns the day's items", listed.some((x) => x.id === daily.id));
   await expectError("list-daily rejects a bad date", "invalid", () => listDaily(ALICE, S1, "2026-13-40"));
   await expectError("add-daily rejects non-members", "unauthorized", () => addDaily(CAROL, S1, "x"));
+
+  // --- comfort tools: delete-todo, whoami, list-members ---
+  const toDelete = await addTodo(ALICE, S1, { title: "Delete me" });
+  await expectError("delete-todo rejects non-members", "unauthorized", () => deleteTodo(CAROL, S1, toDelete.id));
+  const del = await deleteTodo(ALICE, S1, toDelete.id);
+  check("delete-todo reports deleted", del.deleted === true && del.id === toDelete.id);
+  const goneSnap = await db.collection("spaces").doc(S1).collection("todos").doc(toDelete.id).get();
+  check("delete-todo actually removes the doc", !goneSnap.exists);
+  await expectError("delete-todo on a missing todo → not_found", "not_found", () => deleteTodo(ALICE, S1, "nope"));
+
+  const me = await whoami(ALICE);
+  check("whoami returns uid + display name", me.uid === ALICE && me.displayName === "Alice");
+
+  const members = await listMembers(ALICE, S1);
+  check("list-members returns the space members with names",
+    members.length === 2 && members.some((m) => m.uid === BOB && m.displayName === "Bob"));
+  await expectError("list-members rejects non-members", "unauthorized", () => listMembers(CAROL, S1));
 
   // --- principal gate (tool-logic): data tools require a user principal ---
   await expectError("no principal → unauthorized", "unauthorized", () => handleListSpaces());


### PR DESCRIPTION
## Summary

Rounds out the MCP tool set with the #123 "Kann" tools. Completes epic #124.

Closes #123 · refs epic #124.

## Tools
- **`delete-todo`** `{ spaceId, todoId }` — member deletes a todo (rate-limited write; `not_found` if missing).
- **`whoami`** `{}` — the personal key owner's uid + public display name.
- **`list-members`** `{ spaceId }` — a space's members (uid + display name), so a client can resolve uids for `add-todo`/`set-waiting-on` `waitingOn`.

All member-gated; `whoami`/`list-members` are reads.

## Tests
`tests/mcp-tools.test.mts` extended: delete isolation + actual removal + `not_found`, `whoami` name, `list-members` + non-member rejection. **32/32** green against the emulator.

## Test Plan
- [x] `npm run test:mcp` — 32/32 pass
- [x] `npm run build` / `tsc` / `lint` — clean
- [ ] Vercel check green before merge

## Final MCP tool set (epic #124)
`list-spaces` · `list-todos` · `add-todo` · `complete-todo` · `set-waiting-on` · `list-daily` · `add-daily` · `delete-todo` · `whoami` · `list-members` — all Firestore-backed, member-gated, scoped to the personal API key's uid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)