### PR TITLE
Pin Node 22.x so firebase-admin/auth works on Vercel (#132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "template-2",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

`/api/mcp/sse` (and `/api/user/apiKey`) returned **500** on Vercel for every request. Function log:

```
ERR_REQUIRE_ESM: require() of ES Module jose/dist/webapi/index.js
  from jwks-rsa/src/utils.js   →   page: /api/mcp/sse
```

`firebase-admin/auth` pulls `jwks-rsa@4`, which `require()`s `jose@6` (ESM-only, `type: module`). `require()` of an ESM module is only supported from **Node 22.12**; Vercel ran an older default (no `engines` field), so the route crashed at module load. It works locally because that's Node 25.

Closes #132.

## Fix
`engines.node = "22.x"` → Vercel uses a runtime with `require(esm)` support. **No code/dependency change** — same `jose@6`, same `firebase-admin@14`; it's purely the runtime Node version, matching the local Node where everything works.

Fixes both affected routes (MCP **and** API-key generation, which the personal-key MCP flow needs).

## After merge
1. Vercel redeploys with Node 22.x.
2. ⚠️ **Confirm the Vercel project's Node.js Version** (Settings → General → Node.js Version) is **22.x** — a project-level pin can override `engines.node`.
3. Re-probe `POST /api/mcp/sse` (no auth) → should return **401**, not 500.

## Test Plan
- [x] `npm run build` — succeeds (engines change is config-only)
- [ ] Vercel check green before merge
- [ ] Post-deploy: `/api/mcp/sse` returns 401 (no auth) instead of 500
- [ ] Post-deploy: Settings → API Key → "Generate Key" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)