### PR TITLE
Bump engines.node to 24.x for reliable require(esm) on Vercel (#132)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

The 22.x bump didn't clear the `ERR_REQUIRE_ESM` crash on Vercel (`jose@6` is ESM-only and `require()`d by `jwks-rsa` via `firebase-admin/auth`). `require(esm)` is only default-on from **Node 22.12**, and Vercel's "22.x" may resolve to an earlier 22 minor.

**Node 24.x** has `require(esm)` enabled by default (matching local Node 25, where `require('jose')` works), so it's the reliable choice. No code/dependency change — purely the runtime Node version.

Refs #132. (`jose` can't be downgraded: `jwks-rsa@4` hard-requires `jose@^6`, which is ESM-only.)

## After merge — two things
1. ⚠️ Set the **Vercel project Node.js Version to 24.x** (Settings → General) so it matches `engines.node` (a project pin can override engines).
2. Redeploy → `POST /api/mcp/sse` (no auth) should return **401**, not 500; and Settings → API Key → "Generate Key" should work.

## Test Plan
- [x] `npm run build` — succeeds (config-only)
- [ ] Vercel check green before merge
- [ ] Post-deploy: `/api/mcp/sse` → 401 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)