### PR TITLE
Downgrade firebase-admin to 13 so jose loads via CJS on Vercel (#132)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "autoprefixer": "^10.4.18",
         "emoji-picker-react": "^4.12.2",
         "firebase": "^12.14.0",
-        "firebase-admin": "^14.0.0",
+        "firebase-admin": "^13.10.0",
         "framer-motion": "^11.3.31",
         "lucide-react": "^0.436.0",
         "next": "^15.5.19",
@@ -46,6 +46,9 @@
         "eslint": "8.57.0",
         "eslint-config-next": "^15.5.19",
         "tsx": "^4.22.4"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1224,20 +1227,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.6.0.tgz",
-      "integrity": "sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.6.tgz",
+      "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "fast-deep-equal": "^3.1.3",
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^5.0.1",
-        "protobufjs": "^7.5.3"
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -3006,6 +3009,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -5832,25 +5842,25 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-14.0.0.tgz",
-      "integrity": "sha512-U88/r6VWiBQ05+UlLaF1A1AN4Y3SAGQKcQWawzafEAnXVaCZ21+2KclMPdlIQAAF5pUtN+FkXCSQnJEpc6QDZA==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
+      "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
-        "@firebase/database-compat": "^2.1.4",
-        "@firebase/database-types": "^1.0.20",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
         "farmhash-modern": "^1.1.0",
         "fast-deep-equal": "^3.1.1",
-        "google-auth-library": "^10.6.2",
+        "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^4.0.1"
+        "jwks-rsa": "^3.1.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^8.6.0",
+        "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.19.0"
       }
     },
@@ -6356,26 +6366,27 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
-      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "^1.12.6",
-        "@grpc/proto-loader": "^0.8.0",
-        "duplexify": "^4.1.3",
-        "google-auth-library": "10.5.0",
-        "google-logging-utils": "1.1.3",
-        "node-fetch": "^3.3.2",
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "3.0.4",
-        "protobufjs": "^7.5.4",
-        "retry-request": "^8.0.2",
-        "rimraf": "^5.0.1"
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
     "node_modules/google-gax/node_modules/@grpc/grpc-js": {
@@ -6392,7 +6403,7 @@
         "node": ">=12.10.0"
       }
     },
-    "node_modules/google-gax/node_modules/@grpc/proto-loader": {
+    "node_modules/google-gax/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
       "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
@@ -6411,131 +6422,47 @@
         "node": ">=6"
       }
     },
-    "node_modules/google-gax/node_modules/gaxios": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
-      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
     "node_modules/google-gax/node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
-    "node_modules/google-gax/node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-gax/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/google-gax/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/google-gax/node_modules/retry-request": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
-      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "teeny-request": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-gax/node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/google-gax/node_modules/teeny-request": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
-      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "dependencies": {
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2",
-        "stream-events": "^1.0.5"
-      },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
     "node_modules/google-logging-utils": {
@@ -7449,19 +7376,28 @@
       }
     },
     "node_modules/jwks-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-4.0.1.tgz",
-      "integrity": "sha512-poXwUA8S4cP9P5N8tZS3xnUDJH8WmwSGfKK9gIaRPdjLHyJtd9iX/cngX9CUIe0Caof5JhK2EbN7N5lnnaf9NA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+      "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.4",
         "debug": "^4.3.4",
-        "jose": "^6.1.3",
+        "jose": "^4.15.4",
         "limiter": "^1.1.5",
-        "lru-memoizer": "^3.0.0"
+        "lru-memoizer": "^2.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >= 23.0.0"
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/jws": {
@@ -7659,22 +7595,25 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/lru-memoizer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
-      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
       "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "^11.0.1"
+        "lru-cache": "6.0.0"
       }
     },
     "node_modules/lru-memoizer/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "license": "BlueOak-1.0.0",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=10"
       }
     },
     "node_modules/lucide-react": {
@@ -8850,16 +8789,16 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
-      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "protobufjs": "^7.4.0"
+        "protobufjs": "^7.2.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/protobufjs": {
@@ -10852,6 +10791,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "autoprefixer": "^10.4.18",
     "emoji-picker-react": "^4.12.2",
     "firebase": "^12.14.0",
-    "firebase-admin": "^14.0.0",
+    "firebase-admin": "^13.10.0",
     "framer-motion": "^11.3.31",
     "lucide-react": "^0.436.0",
     "next": "^15.5.19",


### PR DESCRIPTION
## Root cause (finally pinned down via a diag route)

`/api/mcp/sse` and `/api/user/apiKey` 500 in prod because `firebase-admin@14` → `jwks-rsa@4` → `require()`s `jose@6`, which is **ESM-only**. The diag route (`/api/diag`) proved:

```json
{ "node": "v24.14.1", "firestore": "ok",
  "auth": "ERR_REQUIRE_ESM require() of ES Module jose … from jwks-rsa …" }
```

So even on **Node 24.14** (where `require(esm)` is default-on), the require still throws `ERR_REQUIRE_ESM` — **Vercel's serverless module loader doesn't honor native `require(esm)`**. The Node bumps (22→24) were a red herring. Only `firebase-admin/auth` fails; `firestore` loads fine.

## Fix
Downgrade **`firebase-admin` 14 → 13**: `firebase-admin@13.10.0` → `jwks-rsa@3.2.2` → `jose@4.15.9`, which ships a **CJS build** (`exports.require → dist/node/cjs`). `require('jose')` then resolves to CJS and works under any loader, regardless of Node version. API is unchanged (`verifyIdToken` / `getFirestore` / `FieldValue`).

Closes #132.

## Verified
- [x] `npx tsc --noEmit` + `npm run build` — clean
- [x] `npm run test:mcp` — **32/32** emulator checks pass on firebase-admin@13
- [ ] Vercel green before merge
- [ ] Post-deploy: `/api/mcp/sse` → 401 (not 500); `/api/diag` `auth: "ok"`

## ⚠️ Second blocker — needs YOU (env var)
The diag also showed **`hasServiceAccount: false`** — `FIREBASE_SERVICE_ACCOUNT_KEY` is **not set in Vercel production**. The Admin SDK can't initialize without it, so even after this fix the MCP data tools and key generation return 503. Please add it in **Vercel → Settings → Environment Variables** (Production): the single-line service-account JSON (`FIREBASE_SERVICE_ACCOUNT_KEY`). `MCP_AUTH_TOKEN` is optional (only for the shared-token path).

## Notes
- `engines.node` stays `24.x` (harmless).
- The temporary `/api/diag` route is removed in a follow-up once prod is confirmed healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)