### PR TITLE
docs: spec for OAuth on the MCP server (claude.ai connector)

### DIFF
--- a/docs/01-konzept-mcp-oauth-connector.md
+++ b/docs/01-konzept-mcp-oauth-connector.md
@@ -1,0 +1,63 @@
+# Konzept: OAuth für den aido-MCP-Server (Claude.ai Web-Connector)
+
+## 1. Zusammenfassung
+
+Der aido-MCP-Server (`/api/mcp/sse`) soll als **Custom Connector auf claude.ai (Web)** verbindbar werden. Das erfordert, dass der Server den **OAuth-2.1-/MCP-Authorization-Flow** unterstützt (Discovery-Metadaten, Authorization-Code-Flow mit PKCE, i. d. R. Dynamic Client Registration), statt wie heute nur einen statischen persönlichen API-Key als Bearer-Header zu akzeptieren. Der bestehende API-Key-Pfad (Claude Code / Desktop) bleibt parallel erhalten.
+
+## 2. Problemstellung
+
+- Claude Code und Claude Desktop können einen statischen `Authorization: Bearer aido_…`-Header mitschicken — das funktioniert bereits.
+- **claude.ai-Custom-Connectors** bieten dafür **kein Eingabefeld**: Sie verbinden einen remote MCP-Server per URL und authentifizieren über **OAuth** (MCP-Authorization-Spec, 2025-06-18) — oder gar nicht. Ohne Auth lehnen die Datentools mangels uid ab.
+- aido hat heute **keinen OAuth-Server**: `authenticateMcp` macht nur einen Hash-Lookup des persönlichen Keys → uid.
+
+## 3. Zielsetzung
+
+- aido lässt sich auf claude.ai als Custom Connector hinzufügen; der Nutzer durchläuft einen Login/Consent und ist danach mit **seiner** Identität (uid) verbunden.
+- Jeder Tool-Call ist wie bisher an die uid gebunden (nur eigene Spaces) — das bestehende `requireMember`/uid-Modell wird **wiederverwendet**, nur die Token-Quelle ändert sich.
+- **Koexistenz:** Persönlicher API-Key (Code/Desktop) **und** OAuth (Web) funktionieren gleichzeitig am selben Endpoint.
+- Messbar: Der „Add custom connector"-Flow auf claude.ai schließt erfolgreich ab, und ein Tool-Call (`list-spaces`) liefert die echten Spaces des angemeldeten Nutzers.
+
+## 4. Lösungsidee
+
+MCP-Authorization trennt zwei Rollen:
+- **Resource Server (RS)** = der MCP-Endpoint: validiert Access-Tokens, weist via `WWW-Authenticate` + `/.well-known/oauth-protected-resource` auf den Authorization Server hin. **Dafür bringt `mcp-handler` bereits Bausteine mit** (`withMcpAuth`, `protectedResourceHandler`, `generateProtectedResourceMetadata`).
+- **Authorization Server (AS)** = Login/Consent, Token-Endpoint, Metadaten, **Dynamic Client Registration (DCR)**. **Das liefert `mcp-handler` NICHT** — der AS muss von aido kommen.
+
+Der Kern der Entscheidung liegt also beim **AS**. Drei Wege (siehe Offene Fragen):
+- **(a) Eigener minimaler OAuth-AS in Next.js** — Authorization-/Token-/Registrierungs-Endpoints selbst implementieren, Login über die bestehende Firebase-Google-Anmeldung, Tokens selbst ausgeben (z. B. signierte JWTs oder opake Tokens in Firestore).
+- **(b) Firebase Auth / Google als Identitätsquelle** mit dünnem OAuth-Layer — die Nutzer-Authentifizierung macht Firebase (Google-Login, schon vorhanden), aido baut nur den OAuth-Wrapper (Endpoints/Consent/DCR) darum.
+- **(c) Externer IdP davor** (Auth0 / WorkOS / Stytch / Scalekit o. ä.) als fertiger AS inkl. DCR — aido ist nur RS und mappt das Token → uid.
+
+In allen Fällen: Access-Token → uid auflösen, dann in den **bestehenden** `runWithPrincipal({kind:'user',uid})`-Pfad einspeisen; der Rest (Tools, `requireMember`) bleibt unverändert.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Rolle |
+|---|---|---|
+| MCP-Auth-Guard | `src/lib/mcp/auth.ts` (`authenticateMcp`) | Zweiter Auth-Pfad: OAuth-Token → uid |
+| MCP-Route | `src/app/api/mcp/sse/route.ts` | `WWW-Authenticate`/RS-Metadaten; ggf. `withMcpAuth` |
+| OAuth-Metadaten | **neu:** `/.well-known/oauth-protected-resource`, ggf. `/.well-known/oauth-authorization-server` | Discovery |
+| OAuth-AS-Endpoints (bei a/b) | **neu:** `/authorize`, `/token`, `/register` (DCR) | Auth-Code-Flow, Token, Client-Registrierung |
+| Login/Consent-UI (bei a/b) | **neu:** Consent-Seite; nutzt bestehende `AuthContext`/Firebase-Login | Nutzer-Zustimmung |
+| Token-Speicher | Firestore (neue Collections) bzw. JWT-Signaturschlüssel | Codes/Tokens/Clients |
+| Identität | `src/lib/contexts/AuthContext.tsx`, Firebase Auth | Wer ist der Nutzer (uid) |
+| Bestehender Key-Pfad | `userApiKeys`, `src/lib/apiKeys.ts` | bleibt unverändert |
+
+## 6. Abgrenzung
+
+**Nicht** Teil dieser Anforderung:
+- Kein Ersatz/Abbau des persönlichen API-Key-Pfads (Code/Desktop) — der bleibt.
+- Keine neuen MCP-Tools, keine Änderung am Datenmodell der Spaces/Todos.
+- Kein allgemeiner „aido-OAuth-Provider für Drittapps" über den MCP-Use-Case hinaus (nur so weit, wie der Connector es braucht).
+- Keine Multi-Tenant-/Org-Verwaltung, keine Scopes jenseits eines einfachen Modells (sofern in den Offenen Fragen nicht anders entschieden).
+
+## 7. Entscheidungen (Review-Ergebnis)
+
+1. **Authorization-Server-Ansatz:** ✅ **(b) Firebase-basiert.** aido baut die OAuth-AS-Endpoints selbst, die **Nutzer-Authentifizierung** kommt aber aus der bestehenden Firebase-**Google**-Anmeldung. Kein Fremd-IdP.
+   > Wichtige Klarstellung: Firebase macht aido zum OAuth-**Client** (Konsument von Google). Für den Connector muss aido OAuth-**Provider** (Authorization Server für Claude) sein — die umgekehrte Rolle. Firebase liefert Login/Identität (uid), aber **nicht** die AS-Endpoints `/authorize`/`/token`/`/register`/Metadaten, mit denen Claude spricht. Genau die werden gebaut.
+2. **Dynamic Client Registration:** ✅ **Ja** (`/register`) — Claude registriert sich dynamisch; Client-Daten in Firestore.
+3. **Token-Format:** ✅ **Kurzlebiges signiertes JWT-Access-Token** (HS256, Signaturschlüssel aus Env; `sub`=uid, `exp`, `aud`, `scope`, `client_id`) — vom MCP-Endpoint per Signatur+`exp` validiert (kein Firestore-Lookup pro Request). Dazu **opakes Refresh-Token in Firestore** (widerrufbar, längere Laufzeit).
+4. **Login-Quelle für Consent:** ✅ Bestehende Firebase-**Google**-Anmeldung. Die Consent-Seite ist eine Client-Seite (nutzt `AuthContext`); sie holt das Firebase-ID-Token (`user.getIdToken()`), das ein Server-Endpoint per `verifyIdToken` → uid prüft, bevor ein Auth-Code ausgestellt wird.
+5. **Scope-Modell:** ✅ **Ein Scope zum Start** — `aido.tools` („volle Tool-Nutzung auf eigene Spaces"). Feinere Scopes (read/write) sind später additiv möglich. *(Default; im Review anpassbar.)*
+6. **Token→uid:** ✅ Das Access-Token (`sub`) trägt die uid; sie bleibt die **alleinige** Autorisierungsbasis (wie beim API-Key). `requireMember`/Tools unverändert.
+7. **Koexistenz:** ✅ Der persönliche **API-Key-Pfad bleibt** (Code/Desktop). `authenticateMcp` bekommt einen dritten Zweig: OAuth-JWT → uid, zusätzlich zu Shared-Token und API-Key.

--- a/docs/02-ist-analyse-mcp-oauth-connector.md
+++ b/docs/02-ist-analyse-mcp-oauth-connector.md
@@ -1,0 +1,63 @@
+# Ist-Analyse: OAuth-Anbindung des MCP-Servers
+
+## 1. Aktueller Zustand
+
+### 1.1 MCP-Auth (heute)
+- `src/lib/mcp/auth.ts` → `authenticateMcp(req)` akzeptiert `Authorization: Bearer <token>`:
+  1. **Shared Secret** `MCP_AUTH_TOKEN` → Principal `{kind:'shared'}` (keine uid).
+  2. **Persönlicher API-Key** `aido_…` → Hash-Lookup in `userApiKeys` → `{kind:'user', uid}` (uid = Doc-ID).
+- Liefert `{ok:true, principal}` oder `{ok:false, response}` (401/503). **Kein OAuth, keine Discovery, kein `WWW-Authenticate`.**
+- `src/app/api/mcp/sse/route.ts` (mcp-handler, stateless Streamable-HTTP) wrappt den Handler: `authenticateMcp` → `runWithPrincipal(principal, () => mcpHandler(req))`. Datentools verlangen `kind:'user'` (uid).
+
+### 1.2 Vorhandene OAuth-Bausteine
+- **`mcp-handler` (1.1.0)** exportiert **Resource-Server**-Helfer:
+  - `withMcpAuth(handler, verifyToken, opts)` — prüft das Bearer-Token via `verifyToken(req, bearer) → AuthInfo|undefined`; bei `required` → 401 mit `WWW-Authenticate`; hängt `req.auth` an.
+  - `protectedResourceHandler({authServerUrls, resourceUrl?})` — liefert `/.well-known/oauth-protected-resource` (RFC 9728).
+  - `generateProtectedResourceMetadata(...)`, `getPublicOrigin/Url`, `metadataCorsOptionsRequestHandler()`.
+  - **Liefert NICHT:** Authorization Server (kein `/authorize`, `/token`, `/register`, kein AS-Metadaten-Endpoint, keine Consent-UI, kein Token-Issuing).
+
+### 1.3 Identität / Firebase Auth
+- **Client:** `src/lib/contexts/AuthContext.tsx` — `onAuthStateChanged`, `signInWithGoogle` (Popup, `GoogleAuthProvider`), `user: User|null` (uid, displayName). Firebase-`User` hat `getIdToken()`.
+- **Server:** `src/lib/firebase/admin.ts` — `getAdminAuth().verifyIdToken(idToken)` → decoded (uid). Bereits in `/api/user/apiKey` genutzt.
+- Firebase ist ein **Client-seitiges** Login: die uid ist im Browser bekannt; serverseitig wird sie über ein **ID-Token** (verify) etabliert — **keine** server-lesbare Session-Cookie standardmäßig.
+
+### 1.4 Token-/Key-Speicher
+- `userApiKeys/{uid}` (Admin-only, `keyHash`/`keyPrefix`) — Vorlage für ein „nur-Hash"-Speichermuster.
+- `publicProfiles/{uid}` — Anzeigename (für Consent-UI „Angemeldet als …").
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/lib/mcp/auth.ts` | Bearer-Auth (shared/API-Key) | **3. Zweig:** OAuth-JWT → uid |
+| `src/app/api/mcp/sse/route.ts` | MCP-Route (mcp-handler) | `WWW-Authenticate`/RS-Metadaten-Verweis |
+| `src/lib/firebase/admin.ts` | `getAdminAuth().verifyIdToken` | Consent: ID-Token → uid |
+| `src/lib/contexts/AuthContext.tsx` | Firebase-Login (Google) | Consent-Seite |
+| `src/lib/apiKeys.ts` | Hash/Token-Helfer, `rateLimit` | Wiederverwendbar (Token-Hash, Limit) |
+| **neu** `/.well-known/*` Routen | Discovery-Metadaten | RS + AS Metadata |
+| **neu** `/api/oauth/{authorize,token,register}` | AS-Endpoints | Auth-Code-Flow + DCR |
+| **neu** Consent-Page | OAuth-Zustimmung | Firebase-Login wiederverwenden |
+| **neu** Firestore-Collections | `oauthClients`, `oauthCodes`, `oauthRefreshTokens` | Clients/Codes/Refresh |
+| `firestore.rules` | Regeln | neue Collections **admin-only** (kein Client-Zugriff) |
+
+## 3. Bestehende Abhängigkeiten
+
+- **Extern:** `mcp-handler`, `@modelcontextprotocol/sdk`, `firebase-admin` (verifyIdToken), `firebase` (Client-Login), `jose` (JWT signieren/prüfen — als Dep bereits vorhanden, ESM-import-sicher), `zod`.
+- **Intern:** MCP-Route → `auth.ts` → `admin.ts`/`apiKeys.ts`; Consent-Page → `AuthContext`/Firebase.
+- **Konfiguration:** `FIREBASE_SERVICE_ACCOUNT_KEY` (verifyIdToken + Admin-Firestore) — in Prod gesetzt; neu: `OAUTH_SIGNING_SECRET` (JWT-Signatur) + die öffentliche Basis-URL.
+
+## 4. Bekannte Einschränkungen
+
+- **Firebase ist kein OAuth-AS für Drittapps** — `/authorize`/`/token`/`/register`/Metadaten müssen selbst gebaut werden (das ist der Kernaufwand).
+- **Kein server-seitiger Login-State** — die Consent-Seite muss das Firebase-ID-Token client-seitig holen und serverseitig verifizieren (kein „Cookie liest uid").
+- **Admin-SDK umgeht Rules** — neue OAuth-Collections müssen in den Rules **komplett gesperrt** und nur über das Admin-SDK bedient werden (wie `userApiKeys`).
+- **Stateless Serverless** — Authorization-Codes/Refresh-Tokens müssen in Firestore liegen (kein In-Memory-State, der über Instanzen hält).
+- **`mcp-handler` deckt nur RS ab** — `withMcpAuth`/`protectedResourceHandler` helfen, aber der AS ist Eigenbau.
+
+## 5. Risiken bei Änderung
+
+- **OAuth-Sicherheit (höchstes Risiko):** PKCE (S256) zwingend prüfen, `redirect_uri` exakt gegen den registrierten Client matchen, `state` durchreichen, Auth-Codes einmalig + kurzlebig, Tokens kurzlebig + Refresh widerrufbar. Fehler hier = Account-Übernahme.
+- **Token→uid-Integrität:** Ein fälschbares/zu langlebiges Access-Token unterläuft das gesamte `requireMember`-Modell (Cross-Tenant). Signatur + `aud` + `exp` strikt prüfen.
+- **DCR-Missbrauch:** offener `/register` lädt zu Spam ein → Rate-Limit; nur die für den MCP-Flow nötigen Felder akzeptieren.
+- **Koexistenz/Regression:** der neue Auth-Zweig darf den bestehenden API-Key-/Shared-Token-Pfad nicht brechen (Reihenfolge/Token-Form-Erkennung sauber trennen).
+- **Discovery-Korrektheit:** falsche Metadaten-URLs (hinter Vercel-Proxy) → Claude findet den AS nicht. `getPublicOrigin`/`X-Forwarded-*` korrekt nutzen.

--- a/docs/03-anforderungsanalyse-mcp-oauth-connector.md
+++ b/docs/03-anforderungsanalyse-mcp-oauth-connector.md
@@ -1,0 +1,58 @@
+# Anforderungsanalyse: OAuth für den MCP-Connector
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | RS-Discovery | **Muss** | `GET /.well-known/oauth-protected-resource` liefert RS-Metadaten (verweist auf den aido-AS). Per `mcp-handler.protectedResourceHandler`. |
+| FA-02 | `WWW-Authenticate` | **Muss** | Unauthorisierte MCP-Requests antworten 401 mit `WWW-Authenticate: Bearer resource_metadata=…`, damit Claude die Discovery startet. |
+| FA-03 | AS-Metadaten | **Muss** | `GET /.well-known/oauth-authorization-server` liefert AS-Metadaten (authorization/token/registration_endpoint, `code_challenge_methods_supported:[S256]`, `grant_types`, `scopes`). |
+| FA-04 | Dynamic Client Registration | **Muss** | `POST /api/oauth/register` (RFC 7591): nimmt `redirect_uris`, gibt `client_id` (+ ggf. `client_secret`) zurück; speichert in `oauthClients`. Rate-limitiert. |
+| FA-05 | Authorization-Endpoint | **Muss** | `GET /api/oauth/authorize`: validiert `client_id`/`redirect_uri`/`response_type=code`/PKCE-`code_challenge`(S256)/`state`; rendert die **Consent-Seite**. |
+| FA-06 | Consent + Login | **Muss** | Consent-Seite nutzt die Firebase-Google-Anmeldung; zeigt „Angemeldet als <Name>"; „Erlauben" → ID-Token an den Server. |
+| FA-07 | Auth-Code ausstellen | **Muss** | Server verifiziert das ID-Token (`verifyIdToken`→uid), erstellt einen einmaligen, kurzlebigen Auth-Code (bindet uid, client_id, redirect_uri, code_challenge) in `oauthCodes`, 302 zurück an `redirect_uri?code=…&state=…`. |
+| FA-08 | Token-Endpoint (code) | **Muss** | `POST /api/oauth/token` `grant_type=authorization_code`: prüft Code (einmalig, nicht abgelaufen), PKCE-`code_verifier` gegen `code_challenge`, `redirect_uri`/`client_id`; gibt **Access-Token (JWT, `sub`=uid)** + **Refresh-Token** + `expires_in` zurück. |
+| FA-09 | Token-Endpoint (refresh) | **Soll** | `grant_type=refresh_token`: prüft Refresh-Token in `oauthRefreshTokens` (nicht widerrufen/abgelaufen) → neues Access-Token (+ rotiertes Refresh-Token). |
+| FA-10 | MCP akzeptiert OAuth-Token | **Muss** | `authenticateMcp` erkennt ein OAuth-JWT (Signatur+`aud`+`exp`+`scope`) und liefert `{kind:'user', uid}`. API-Key/Shared-Token-Pfade bleiben. |
+| FA-11 | Token-Revocation | **Soll** | `POST /api/oauth/revoke` (oder UI in Settings): Refresh-Token widerrufen; aktive Access-Tokens laufen kurz aus. |
+| FA-12 | Connector-fähige UI-Hilfe | **Kann** | In Settings die Connector-URL anzeigen + „verbundene Connectors/Tokens verwalten". |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | PKCE zwingend | Sicherheit | Nur `code_challenge_method=S256`; ohne gültigen `code_verifier` kein Token. |
+| NFA-02 | Strikte Redirect-/Client-Prüfung | Sicherheit | `redirect_uri` exakt gegen die beim Client registrierten matchen; `state` unverändert durchreichen. |
+| NFA-03 | Token-Härtung | Sicherheit | Access-Token kurzlebig (z. B. 1 h), `aud`/`iss`/`exp` geprüft; Auth-Codes einmalig + ≤60 s; Refresh-Tokens nur als Hash gespeichert, widerrufbar, rotiert. |
+| NFA-04 | Speicher admin-only | Sicherheit | `oauthClients`/`oauthCodes`/`oauthRefreshTokens` in `firestore.rules` komplett gesperrt (nur Admin-SDK). |
+| NFA-05 | Mandantentrennung unverändert | Sicherheit | Die uid aus dem Token ist die alleinige Autorisierung; `requireMember`/Tools bleiben. |
+| NFA-06 | Korrekte Discovery hinter Proxy | Robustheit | Metadaten-URLs aus `getPublicOrigin`/`X-Forwarded-*` (Vercel) ableiten, nicht aus `req.url`. |
+| NFA-07 | Rate-Limiting | Stabilität | `/register` und `/token` pro IP/Client begrenzt (analog `apiKeys.rateLimit`). |
+| NFA-08 | Keine Regression | Zuverlässigkeit | API-Key-/Shared-Token-Pfad und die 10 Tools funktionieren unverändert weiter. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] „Add custom connector" auf claude.ai mit der aido-URL führt durch Login/Consent und endet in einem **verbundenen** Connector.
+- [ ] Ein Tool-Call (`list-spaces`) über den Web-Connector liefert die **echten** Spaces des angemeldeten Nutzers.
+- [ ] Unauthorisierter MCP-Request → 401 mit `WWW-Authenticate` + funktionierender Discovery-Kette (`/.well-known/*`).
+- [ ] DCR (`/register`) liefert eine `client_id`; ein Flow ohne gültiges PKCE/`redirect_uri` wird abgewiesen.
+- [ ] Auth-Code ist einmalig und kurzlebig; ein zweiter Token-Tausch desselben Codes schlägt fehl.
+- [ ] Access-Token mit falscher Signatur/`aud` oder abgelaufen → MCP antwortet 401.
+- [ ] Der bestehende **API-Key**-Pfad (Claude Code) verbindet weiterhin.
+- [ ] Refresh-Token erneuert ein Access-Token; ein widerrufenes Refresh-Token wird abgelehnt.
+- [ ] Die OAuth-Collections sind per Rules für Clients **nicht** lesbar/schreibbar (Rules-Test).
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Baut auf der bestehenden MCP-Auth (#117) und dem mcp-handler-Transport (#140) auf.
+- Nutzt Firebase Auth (verifyIdToken) und das Admin-SDK (wie #21 API-Keys).
+- FA-10 (MCP akzeptiert Token) hängt an FA-08 (Token-Issuing); FA-05/06/07 bilden zusammen den Authorize-Flow.
+
+## 5. Priorisierung
+
+1. **Discovery + RS-Anschluss (Muss):** FA-01, FA-02, FA-03.
+2. **DCR (Muss):** FA-04.
+3. **Authorize-Flow (Muss):** FA-05, FA-06, FA-07.
+4. **Token (Muss/Soll):** FA-08, dann FA-09.
+5. **MCP-Integration (Muss):** FA-10 — schaltet den Connector scharf.
+6. **Lifecycle/Komfort (Soll/Kann):** FA-11, FA-12.

--- a/docs/04-spezifikation-mcp-oauth-connector.md
+++ b/docs/04-spezifikation-mcp-oauth-connector.md
@@ -1,0 +1,105 @@
+# Spezifikation: OAuth für den MCP-Connector (Firebase-basiert)
+
+## 1. Übersicht
+
+aido wird zum **OAuth-2.1-Authorization-Server für den eigenen MCP-Resource-Server**. Nutzer-Login kommt aus der bestehenden Firebase-Google-Anmeldung; aido baut die AS-Endpoints (Discovery, DCR, authorize, token), eine Consent-Seite und die Token-Validierung im MCP-Pfad. Access-Tokens sind kurzlebige, von aido signierte JWTs (`sub`=uid); Refresh-Tokens sind opake, in Firestore widerrufbare Werte. Der bestehende API-Key-Pfad bleibt.
+
+## 2. Technisches Design
+
+### 2.1 Architektur (Flow)
+
+```
+Claude (Web)                aido (Next.js)                         Firebase
+  │  1. GET MCP → 401 WWW-Authenticate (resource_metadata)
+  │  2. GET /.well-known/oauth-protected-resource  → AS-URL (aido)
+  │  3. GET /.well-known/oauth-authorization-server → endpoints
+  │  4. POST /api/oauth/register (DCR) → client_id           [oauthClients]
+  │  5. GET /api/oauth/authorize?…PKCE,state → Consent-Page
+  │        └─ Nutzer: Google-Login (Firebase) ──────────────▶ ID-Token
+  │        └─ "Erlauben" → POST ID-Token + req → verifyIdToken→uid
+  │                                   → Auth-Code (uid,…)     [oauthCodes]
+  │  ◀─ 302 redirect_uri?code&state
+  │  6. POST /api/oauth/token (code + code_verifier)
+  │        → JWT access_token(sub=uid) + refresh_token        [oauthRefreshTokens]
+  │  7. MCP-Calls mit Bearer <jwt> → authenticateMcp verifiziert → uid
+  ▼                                   → runWithPrincipal({user,uid}) → Tools
+```
+
+### 2.2 Datenmodell (neue Firestore-Collections, admin-only)
+
+- `oauthClients/{client_id}`: `redirect_uris[]`, `client_name?`, `token_endpoint_auth_method`, `createdAt`. (DCR)
+- `oauthCodes/{code}`: `uid`, `client_id`, `redirect_uri`, `code_challenge`, `scope`, `expiresAt` (≤60 s), `used:false`. (einmalig)
+- `oauthRefreshTokens/{tokenHash}`: `uid`, `client_id`, `scope`, `createdAt`, `expiresAt`, `revoked:false`. (Hash, rotiert)
+
+`firestore.rules`: alle drei `allow read, write: if false;` (nur Admin-SDK) — analog `userApiKeys`. Tests in `tests/firestore-rules.test.mjs` ergänzen.
+
+### 2.3 Schnittstellen
+
+| Endpoint | Methode | Zweck |
+|---|---|---|
+| `/.well-known/oauth-protected-resource` | GET | RS-Metadaten (mcp-handler `protectedResourceHandler`) |
+| `/.well-known/oauth-authorization-server` | GET | AS-Metadaten (authorize/token/register, S256, scopes) |
+| `/api/oauth/register` | POST | DCR (RFC 7591) → `client_id` |
+| `/api/oauth/authorize` | GET | Validierung + rendert Consent-Page |
+| `/api/oauth/authorize/confirm` | POST | ID-Token→uid, Auth-Code ausstellen, Redirect-Daten |
+| `/api/oauth/token` | POST | `authorization_code` & `refresh_token` grants |
+| `/api/oauth/revoke` | POST | Refresh-Token widerrufen *(Soll)* |
+
+**Token (JWT, HS256):** `iss`=Basis-URL, `aud`=RS-URL, `sub`=uid, `scope`, `client_id`, `exp` (~1 h), `iat`. Signatur mit `OAUTH_SIGNING_SECRET` via `jose` (bereits vorhanden, ESM-import-sicher).
+
+**`authenticateMcp` (erweitert):** Reihenfolge — Shared-Token → API-Key (`aido_…`) → sonst **OAuth-JWT**: `jose.jwtVerify(token, secret, {aud, iss})`; bei Erfolg `{kind:'user', uid: payload.sub}`.
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/oauth/*` (neu) | Token-Sign/Verify, Code/Refresh-Helfer, Client-Store (Admin) | **Groß** |
+| `/.well-known/*` (neu) | RS- + AS-Metadaten-Routen | Klein |
+| `/api/oauth/register` (neu) | DCR + Rate-Limit | Mittel |
+| `/api/oauth/authorize` (+ Consent-Page) | Validierung + Consent-UI (Firebase-Login) | **Groß** |
+| `/api/oauth/authorize/confirm` (neu) | verifyIdToken→uid, Code ausstellen | Mittel |
+| `/api/oauth/token` (neu) | code/refresh grants, PKCE | **Groß** |
+| `src/lib/mcp/auth.ts` | 3. Zweig: OAuth-JWT → uid | Klein |
+| `src/app/api/mcp/sse/route.ts` | 401 mit `WWW-Authenticate` | Klein |
+| `firestore.rules` (+ Tests) | 3 Collections sperren | Klein |
+| `.env.example` | `OAUTH_SIGNING_SECRET`, Basis-URL | Klein |
+| `tests/` | Flow-/Rules-Tests | Mittel |
+
+### 3.2 Reihenfolge der Implementierung
+
+1. **OAuth-Kernbibliothek** (`src/lib/oauth/`): JWT-Sign/Verify, PKCE-Prüfung, Code-/Refresh-Store (Admin-SDK), Client-Store. + Rules für die 3 Collections.
+2. **Discovery**: `/.well-known/oauth-protected-resource` + `/.well-known/oauth-authorization-server`; MCP-Route 401 → `WWW-Authenticate`.
+3. **DCR**: `/api/oauth/register` (+ Rate-Limit).
+4. **Authorize + Consent**: `/api/oauth/authorize` (Validierung), Consent-Page (Firebase-Login), `/api/oauth/authorize/confirm` (uid + Code).
+5. **Token**: `/api/oauth/token` (authorization_code, PKCE), dann refresh_token.
+6. **MCP-Integration**: `authenticateMcp` akzeptiert OAuth-JWT (FA-10) — schaltet scharf.
+7. **Lifecycle/Komfort**: Revocation + Settings-UI *(Soll/Kann)*.
+
+> Schritte 1–2 sind ein Fundament-Issue; 3/4/5/6 je ein eigenständiges, sessionweise abarbeitbares Issue.
+
+## 4. Testplan
+
+- **Rules-Suite (`tests/firestore-rules.test.mjs`):** `oauthClients/codes/refreshTokens` für Clients nicht les-/schreibbar.
+- **OAuth-Flow-Tests (neu, `tsx`/Emulator analog `test:mcp`):**
+  - DCR → client_id; `/authorize` lehnt falsche `redirect_uri`/fehlende PKCE ab.
+  - Code einmalig + abgelaufen → Token-Tausch scheitert; PKCE-Mismatch → Fehler.
+  - JWT: gültig → uid; falsche Signatur/`aud`/abgelaufen → abgelehnt.
+  - Refresh: gültig → neues Token; widerrufen → abgelehnt.
+  - `authenticateMcp`: OAuth-JWT → `{user,uid}`; API-Key/Shared weiterhin ok (keine Regression).
+- **Manuell (End-to-End):** claude.ai „Add custom connector" → Login/Consent → `list-spaces` liefert echte Spaces. Parallel: Claude Code mit API-Key weiterhin verbunden.
+
+## 5. Migration / Deployment
+
+- **Env (Vercel, Production):** `OAUTH_SIGNING_SECRET` (zufälliger 32-Byte-Wert), öffentliche Basis-URL falls nötig. `FIREBASE_SERVICE_ACCOUNT_KEY` ist gesetzt.
+- **Rules-Deploy:** `npx -y firebase-tools@13 deploy --only firestore:rules` nach App-Deploy.
+- **Kein Datenmodell-Bruch** an bestehenden Collections; rein additiv.
+- **Reihenfolge:** Backend (AS-Endpoints) vor dem Bewerben des Web-Connectors; der API-Key-Pfad bleibt durchgehend nutzbar.
+- **Voraussetzung claude.ai:** Custom Connectors sind plan-abhängig (Pro/Max/Team/Enterprise).
+
+## 6. Referenzen
+
+- [Konzept](01-konzept-mcp-oauth-connector.md) · [Ist-Analyse](02-ist-analyse-mcp-oauth-connector.md) · [Anforderungsanalyse](03-anforderungsanalyse-mcp-oauth-connector.md)
+- Specs: OAuth 2.1, RFC 7591 (DCR), RFC 9728 (Protected Resource Metadata), RFC 8414 (AS Metadata), MCP Authorization (2025-06-18)
+- Code: `src/lib/mcp/auth.ts`, `src/app/api/mcp/sse/route.ts`, `src/lib/firebase/admin.ts`, `src/lib/contexts/AuthContext.tsx`, `mcp-handler`


### PR DESCRIPTION
## Summary

Bestandsanalyse + requirement/spec to make the aido MCP server connectable as a **claude.ai custom connector** via OAuth 2.1 / the MCP Authorization flow — keeping the existing personal-API-key path (Claude Code/Desktop) intact.

Four review docs under `docs/` (`*-mcp-oauth-connector.md`): concept, current-state analysis, requirements, spec.

## Decision (from review)
**Firebase-based (option b):** aido becomes the OAuth Authorization Server for its own MCP Resource Server — it builds the AS endpoints (discovery, DCR, authorize, token) and **reuses the existing Firebase Google login** for consent. Access tokens are short-lived signed JWTs (`sub`=uid); refresh tokens are revocable Firestore entries. The API-key path stays.

## Key insight
Firebase makes aido an OAuth *client* (consumer of Google). The connector needs aido to be an OAuth *provider* (Authorization Server for Claude) — the opposite role. Firebase gives login/identity for free, but the AS endpoints Claude talks to don't exist in Firebase and must be built.

## Note
claude.ai custom connectors are plan-gated (Pro/Max/Team/Enterprise) — to confirm before implementation.

Docs-only — merges without waiting for CI. Implementation epic + issues follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)