### PR TITLE
OAuth core library: JWT, PKCE, admin stores + locked rules (#150)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,11 @@ MCP_AUTH_TOKEN=your_mcp_auth_token_here
 # Benoetigt fuer /api/user/apiKey (persoenliche API-Keys) und deren Nutzung
 # als MCP-Credential. Ohne diesen Wert antwortet die Key-Verwaltung mit 503.
 FIREBASE_SERVICE_ACCOUNT_KEY=
+
+# OAuth (MCP web connector, issue #150)
+# Signing secret for the OAuth access-token JWTs (HS256). aido is both the
+# Authorization and Resource Server, so one symmetric secret signs and verifies.
+# Use a long random value, e.g.: openssl rand -base64 48
+# Required for the OAuth connector flow (claude.ai). The personal-API-key path
+# (Claude Code/Desktop) does not need it.
+OAUTH_SIGNING_SECRET=

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,6 +39,19 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // OAuth Authorization Server state (issue #150): registered clients, one-time
+    // authorization codes and hashed refresh tokens. Managed exclusively through
+    // the Admin SDK (src/lib/oauth) — no client access whatsoever.
+    match /oauthClients/{clientId} {
+      allow read, write: if false;
+    }
+    match /oauthCodes/{code} {
+      allow read, write: if false;
+    }
+    match /oauthRefreshTokens/{tokenHash} {
+      allow read, write: if false;
+    }
+
     // Spaces (issue #40): the organizing unit that replaces "My Todos / Shared
     // with me". Membership grants full access to everything in the space.
     // Rights model: any member may read and update (rename, recolor, add/remove

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:rules": "firebase emulators:exec --only firestore,storage --project demo-rules-test \"node tests/firestore-rules.test.mjs && node tests/storage-rules.test.mjs\"",
     "test:migration": "firebase emulators:exec --only firestore --project demo-migration \"node tests/migration-admin.test.mjs\"",
     "test:mcp": "firebase emulators:exec --only firestore --project demo-mcp \"node --conditions=react-server --import tsx tests/mcp-tools.test.mts\"",
+    "test:oauth": "firebase emulators:exec --only firestore --project demo-oauth \"node --conditions=react-server --import tsx tests/oauth.test.mts\"",
     "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs"
   },
   "dependencies": {

--- a/src/lib/oauth/config.ts
+++ b/src/lib/oauth/config.ts
@@ -1,0 +1,27 @@
+// OAuth Authorization Server config (issue #150, epic #157). aido acts as the
+// AS for its own MCP Resource Server (/api/mcp/sse). Firebase provides the user
+// login; this module owns tokens, PKCE and the AS storage.
+
+export const OAUTH = {
+  collections: {
+    clients: "oauthClients",
+    codes: "oauthCodes",
+    refreshTokens: "oauthRefreshTokens",
+  },
+  /** Single starting scope: full tool access to the user's own spaces. */
+  scope: "aido.tools",
+  accessTokenTtlSec: 60 * 60, // 1 h
+  authCodeTtlSec: 60, // one-time, short-lived
+  refreshTokenTtlSec: 30 * 24 * 60 * 60, // 30 d
+  refreshTokenPrefix: "aidor_",
+} as const;
+
+/**
+ * The protected resource (the MCP endpoint) — used as the access token's
+ * `aud`. The `iss` is the public origin. Endpoints derive `origin` from the
+ * request (mcp-handler `getPublicOrigin`, proxy-aware); the MCP token check
+ * derives the same so `aud`/`iss` line up.
+ */
+export function resourceUrl(origin: string): string {
+  return `${origin.replace(/\/$/, "")}/api/mcp/sse`;
+}

--- a/src/lib/oauth/pkce.ts
+++ b/src/lib/oauth/pkce.ts
@@ -1,0 +1,12 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+// PKCE S256 (issue #150): the authorize step stores `code_challenge`; the token
+// step must present a `code_verifier` whose base64url(SHA-256) equals it. S256
+// only — `plain` is not accepted. Timing-safe comparison.
+export function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
+  if (!codeVerifier || !codeChallenge) return false;
+  const computed = createHash("sha256").update(codeVerifier).digest("base64url");
+  const a = Buffer.from(computed);
+  const b = Buffer.from(codeChallenge);
+  return a.length === b.length && timingSafeEqual(a, b);
+}

--- a/src/lib/oauth/store.ts
+++ b/src/lib/oauth/store.ts
@@ -1,0 +1,138 @@
+import "server-only";
+import { FieldValue } from "firebase-admin/firestore";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { getAdminDb } from "@/lib/firebase/admin";
+import { OAUTH } from "./config";
+
+// Admin-SDK storage for the OAuth Authorization Server (issue #150). These three
+// collections are denied to all clients in firestore.rules and are only ever
+// touched here. Refresh tokens are stored hashed (like userApiKeys); auth codes
+// are single-use and short-lived.
+
+function db() {
+  const d = getAdminDb();
+  if (!d) {
+    throw new Error("OAuth store requires the Admin SDK (FIREBASE_SERVICE_ACCOUNT_KEY).");
+  }
+  return d;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// --- Clients (Dynamic Client Registration) ---
+
+export interface OAuthClient {
+  clientId: string;
+  redirectUris: string[];
+  clientName: string | null;
+}
+
+export async function createClient(input: {
+  redirectUris: string[];
+  clientName?: string | null;
+}): Promise<OAuthClient> {
+  const clientId = randomUUID();
+  await db().collection(OAUTH.collections.clients).doc(clientId).set({
+    redirectUris: input.redirectUris,
+    clientName: input.clientName ?? null,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return { clientId, redirectUris: input.redirectUris, clientName: input.clientName ?? null };
+}
+
+export async function getClient(clientId: string): Promise<OAuthClient | null> {
+  if (!clientId) return null;
+  const snap = await db().collection(OAUTH.collections.clients).doc(clientId).get();
+  if (!snap.exists) return null;
+  const d = snap.data()!;
+  return {
+    clientId: snap.id,
+    redirectUris: Array.isArray(d.redirectUris) ? d.redirectUris : [],
+    clientName: typeof d.clientName === "string" ? d.clientName : null,
+  };
+}
+
+// --- Authorization codes (single-use, short-lived) ---
+
+export interface AuthCodeData {
+  uid: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  scope: string;
+}
+
+export async function createAuthCode(input: AuthCodeData): Promise<string> {
+  const code = randomBytes(32).toString("base64url");
+  await db().collection(OAUTH.collections.codes).doc(code).set({
+    ...input,
+    expiresAt: Date.now() + OAUTH.authCodeTtlSec * 1000,
+    used: false,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return code;
+}
+
+// Atomically consume a code: returns its data only if it exists, is unused and
+// unexpired — and marks it used in the same transaction (so a replay returns
+// null). Returns null otherwise.
+export async function consumeAuthCode(code: string): Promise<AuthCodeData | null> {
+  if (!code) return null;
+  const ref = db().collection(OAUTH.collections.codes).doc(code);
+  return db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) return null;
+    const d = snap.data()!;
+    if (d.used === true || typeof d.expiresAt !== "number" || d.expiresAt < Date.now()) {
+      return null;
+    }
+    tx.update(ref, { used: true });
+    return {
+      uid: d.uid,
+      clientId: d.clientId,
+      redirectUri: d.redirectUri,
+      codeChallenge: d.codeChallenge,
+      scope: d.scope,
+    };
+  });
+}
+
+// --- Refresh tokens (opaque, hashed, revocable) ---
+
+export interface RefreshTokenData {
+  uid: string;
+  clientId: string;
+  scope: string;
+}
+
+export async function createRefreshToken(input: RefreshTokenData): Promise<string> {
+  const token = OAUTH.refreshTokenPrefix + randomBytes(32).toString("base64url");
+  await db().collection(OAUTH.collections.refreshTokens).doc(sha256(token)).set({
+    ...input,
+    revoked: false,
+    expiresAt: Date.now() + OAUTH.refreshTokenTtlSec * 1000,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return token;
+}
+
+export async function consumeRefreshToken(token: string): Promise<RefreshTokenData | null> {
+  if (!token) return null;
+  const snap = await db().collection(OAUTH.collections.refreshTokens).doc(sha256(token)).get();
+  if (!snap.exists) return null;
+  const d = snap.data()!;
+  if (d.revoked === true || typeof d.expiresAt !== "number" || d.expiresAt < Date.now()) {
+    return null;
+  }
+  return { uid: d.uid, clientId: d.clientId, scope: d.scope };
+}
+
+export async function revokeRefreshToken(token: string): Promise<void> {
+  if (!token) return;
+  await db()
+    .collection(OAUTH.collections.refreshTokens)
+    .doc(sha256(token))
+    .set({ revoked: true }, { merge: true });
+}

--- a/src/lib/oauth/tokens.ts
+++ b/src/lib/oauth/tokens.ts
@@ -1,0 +1,59 @@
+import { SignJWT, jwtVerify } from "jose";
+import { OAUTH } from "./config";
+
+// Access tokens are short-lived JWTs signed by aido (HS256, OAUTH_SIGNING_SECRET)
+// — aido is both Authorization Server and Resource Server, so a symmetric secret
+// is enough. `sub` carries the uid, which is the sole authorization basis (issue
+// #150). jose is imported via ESM (no CJS require), so it loads on any runtime.
+
+function signingKey(): Uint8Array {
+  const secret = process.env.OAUTH_SIGNING_SECRET;
+  if (!secret) throw new Error("OAUTH_SIGNING_SECRET is not set.");
+  return new TextEncoder().encode(secret);
+}
+
+export async function signAccessToken(params: {
+  issuer: string;
+  audience: string;
+  uid: string;
+  scope: string;
+  clientId: string;
+  ttlSec?: number;
+}): Promise<{ accessToken: string; expiresIn: number }> {
+  const ttl = params.ttlSec ?? OAUTH.accessTokenTtlSec;
+  const accessToken = await new SignJWT({ scope: params.scope, client_id: params.clientId })
+    .setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
+    .setIssuer(params.issuer)
+    .setAudience(params.audience)
+    .setSubject(params.uid)
+    .setIssuedAt()
+    .setExpirationTime(`${ttl}s`)
+    .sign(signingKey());
+  return { accessToken, expiresIn: ttl };
+}
+
+export interface VerifiedAccessToken {
+  uid: string;
+  scope: string;
+  clientId: string;
+}
+
+// Verifies signature + iss/aud/exp. Throws (jose error) on any failure — callers
+// translate that into a 401.
+export async function verifyAccessToken(
+  token: string,
+  expected: { issuer: string; audience: string }
+): Promise<VerifiedAccessToken> {
+  const { payload } = await jwtVerify(token, signingKey(), {
+    issuer: expected.issuer,
+    audience: expected.audience,
+  });
+  if (typeof payload.sub !== "string" || !payload.sub) {
+    throw new Error("Access token has no subject (uid).");
+  }
+  return {
+    uid: payload.sub,
+    scope: typeof payload.scope === "string" ? payload.scope : "",
+    clientId: typeof payload.client_id === "string" ? payload.client_id : "",
+  };
+}

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -417,6 +417,20 @@ await check('owner may tag a legacy todo with migratedTo', assertSucceeds(
 await check('owner may set the migration flag on their user doc', assertSucceeds(
   setDoc(doc(db(ALICE), `users/${ALICE}`), { todosMigratedToSpacesAt: 1 }, { merge: true })));
 
+console.log('OAuth collections (admin-only, issue #150):');
+await check('user may not read oauthClients', assertFails(
+  getDoc(doc(db(ALICE), 'oauthClients/c1'))));
+await check('user may not write oauthClients', assertFails(
+  setDoc(doc(db(ALICE), 'oauthClients/c1'), { redirectUris: ['https://x'] })));
+await check('user may not read oauthCodes', assertFails(
+  getDoc(doc(db(ALICE), 'oauthCodes/code1'))));
+await check('user may not write oauthCodes', assertFails(
+  setDoc(doc(db(ALICE), 'oauthCodes/code1'), { uid: ALICE })));
+await check('user may not read oauthRefreshTokens', assertFails(
+  getDoc(doc(db(ALICE), 'oauthRefreshTokens/hash1'))));
+await check('user may not write oauthRefreshTokens', assertFails(
+  setDoc(doc(db(ALICE), 'oauthRefreshTokens/hash1'), { uid: ALICE })));
+
 await testEnv.cleanup();
 
 if (failures > 0) {

--- a/tests/oauth.test.mts
+++ b/tests/oauth.test.mts
@@ -1,0 +1,106 @@
+// Integration tests for the OAuth core library (issue #150, epic #157).
+// Exercises the REAL code (src/lib/oauth/*) against the Firestore emulator with
+// the Admin SDK — JWT sign/verify, PKCE-S256, and the client/code/refresh stores.
+//
+// Run via (needs a JDK + the firestore emulator):
+//   npx -y firebase-tools@13 emulators:exec --only firestore --project demo-oauth \
+//     "node --conditions=react-server --import tsx tests/oauth.test.mts"
+// (react-server condition neutralises the `server-only` guard; tsx resolves @/*.)
+
+import { initializeApp } from "firebase-admin/app";
+import { createHash, randomBytes } from "node:crypto";
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("FIRESTORE_EMULATOR_HOST is not set — run inside emulators:exec.");
+  process.exit(1);
+}
+
+// Token signing needs a secret; set a test one if the env didn't provide it.
+process.env.OAUTH_SIGNING_SECRET =
+  process.env.OAUTH_SIGNING_SECRET || "test-oauth-signing-secret-at-least-32-bytes!!";
+
+// Pre-init the app under the name admin.ts expects, so the store's getAdminDb()
+// reuses this emulator-bound app and never goes through cert().
+const projectId = process.env.GCLOUD_PROJECT || "demo-oauth";
+initializeApp({ projectId }, "admin");
+
+const { signAccessToken, verifyAccessToken } = await import("../src/lib/oauth/tokens.ts");
+const { verifyPkceS256 } = await import("../src/lib/oauth/pkce.ts");
+const store = await import("../src/lib/oauth/store.ts");
+
+let failures = 0;
+function check(name: string, cond: boolean) {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.error(`  ✗ ${name}`);
+  }
+}
+async function expectReject(name: string, fn: () => Promise<unknown>) {
+  try {
+    await fn();
+    failures++;
+    console.error(`  ✗ ${name} (expected rejection, resolved)`);
+  } catch {
+    console.log(`  ✓ ${name}`);
+  }
+}
+
+async function run() {
+  const iss = "https://aido.example";
+  const aud = "https://aido.example/api/mcp/sse";
+
+  // --- JWT access tokens ---
+  const { accessToken, expiresIn } = await signAccessToken({
+    issuer: iss, audience: aud, uid: "u1", scope: "aido.tools", clientId: "c1",
+  });
+  const v = await verifyAccessToken(accessToken, { issuer: iss, audience: aud });
+  check("jwt verify → uid/scope/client", v.uid === "u1" && v.scope === "aido.tools" && v.clientId === "c1");
+  check("jwt expiresIn is the TTL", expiresIn === 3600);
+  await expectReject("jwt wrong audience rejected", () => verifyAccessToken(accessToken, { issuer: iss, audience: "https://evil" }));
+  await expectReject("jwt wrong issuer rejected", () => verifyAccessToken(accessToken, { issuer: "https://evil", audience: aud }));
+  await expectReject("tampered jwt rejected", () => verifyAccessToken(accessToken + "x", { issuer: iss, audience: aud }));
+
+  // --- PKCE S256 ---
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  check("pkce S256 match", verifyPkceS256(verifier, challenge) === true);
+  check("pkce mismatch rejected", verifyPkceS256("not-the-verifier", challenge) === false);
+  check("pkce empty rejected", verifyPkceS256("", challenge) === false);
+
+  // --- Client store (DCR) ---
+  const client = await store.createClient({ redirectUris: ["https://claude.ai/cb"], clientName: "Claude" });
+  check("client has an id", typeof client.clientId === "string" && client.clientId.length > 0);
+  const got = await store.getClient(client.clientId);
+  check("client store roundtrip", got?.redirectUris[0] === "https://claude.ai/cb" && got?.clientName === "Claude");
+  check("unknown client → null", (await store.getClient("nope")) === null);
+
+  // --- Auth code: single-use, short-lived ---
+  const code = await store.createAuthCode({
+    uid: "u1", clientId: client.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: challenge, scope: "aido.tools",
+  });
+  const c1 = await store.consumeAuthCode(code);
+  check("auth code consume → data", c1?.uid === "u1" && c1?.codeChallenge === challenge);
+  const c2 = await store.consumeAuthCode(code);
+  check("auth code is single-use (replay → null)", c2 === null);
+  check("unknown auth code → null", (await store.consumeAuthCode("nope")) === null);
+
+  // --- Refresh token: hashed, revocable ---
+  const rt = await store.createRefreshToken({ uid: "u1", clientId: client.clientId, scope: "aido.tools" });
+  check("refresh token is opaque (aidor_ prefix)", rt.startsWith("aidor_"));
+  const r1 = await store.consumeRefreshToken(rt);
+  check("refresh consume → data", r1?.uid === "u1");
+  await store.revokeRefreshToken(rt);
+  const r2 = await store.consumeRefreshToken(rt);
+  check("revoked refresh → null", r2 === null);
+}
+
+run()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll OAuth core tests passed." : `\n${failures} check(s) failed.`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((e) => {
+    console.error("\nTest run crashed:", e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Foundation for the OAuth web-connector (epic #157): the security-critical primitives the AS endpoints (#151+) build on.

Closes #150.

## Changes
- **`src/lib/oauth/config.ts`** — collection names, TTLs, scope `aido.tools`, `resourceUrl(origin)` (token audience = the MCP endpoint).
- **`src/lib/oauth/tokens.ts`** — HS256 access-token JWTs via **`jose` (ESM import → loader-safe)**; `signAccessToken` / `verifyAccessToken` (`sub`=uid; `iss`/`aud`/`exp` enforced, throws on any mismatch).
- **`src/lib/oauth/pkce.ts`** — `verifyPkceS256` (timing-safe, S256 only).
- **`src/lib/oauth/store.ts`** — Admin-SDK stores: `oauthClients` (DCR), `oauthCodes` (**single-use, transactional consume**), `oauthRefreshTokens` (**hashed, revocable**).
- **`firestore.rules`** — the three OAuth collections denied to all clients (`allow read, write: if false`), admin-SDK-only like `userApiKeys`.
- **Tests** — `tests/oauth.test.mts` (`npm run test:oauth`, emulator, real code): 17 checks incl. wrong-`aud`/`iss`/tampered-JWT rejection, PKCE match/mismatch, single-use code replay → null, revoked refresh → null. Rules suite +6 OAuth-collection denial checks.
- **`.env.example`** — `OAUTH_SIGNING_SECRET`.

## Notes
- No callers yet — by design (foundation). `#151` (discovery) and onward consume it.
- **Rollout:** the `firestore.rules` change should be deployed (`npx -y firebase-tools@13 deploy --only firestore:rules`) before the OAuth endpoints (#152+) write those collections. `OAUTH_SIGNING_SECRET` must be set in Vercel before #154/#155.

## Test Plan
- [x] `npm run test:oauth` — 17/17 pass (emulator)
- [x] `npm run test:rules` — pass incl. 6 new OAuth-collection denials
- [x] `tsc` / `lint` / `build` — clean
- [ ] Vercel green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)