### PR TITLE
OAuth discovery metadata + MCP 401 WWW-Authenticate (#151)

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,29 @@
+import { getPublicOrigin, metadataCorsOptionsRequestHandler } from "mcp-handler";
+import { OAUTH } from "@/lib/oauth/config";
+
+// RFC 8414 Authorization Server Metadata (issue #151). aido is the AS for its
+// own MCP resource server. Public clients (Claude) use the authorization-code
+// flow with PKCE (S256) and register dynamically. The advertised endpoints land
+// in #152 (register), #153 (authorize) and #154 (token).
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request) {
+  const origin = getPublicOrigin(req).replace(/\/$/, "");
+  return Response.json(
+    {
+      issuer: origin,
+      authorization_endpoint: `${origin}/api/oauth/authorize`,
+      token_endpoint: `${origin}/api/oauth/token`,
+      registration_endpoint: `${origin}/api/oauth/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["none"],
+      scopes_supported: [OAUTH.scope],
+    },
+    { headers: { "Access-Control-Allow-Origin": "*" } }
+  );
+}
+
+export const OPTIONS = metadataCorsOptionsRequestHandler();

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,19 @@
+import { protectedResourceHandler, getPublicOrigin, metadataCorsOptionsRequestHandler } from "mcp-handler";
+import { resourceUrl } from "@/lib/oauth/config";
+
+// RFC 9728 Protected Resource Metadata (issue #151). Tells an MCP client which
+// Authorization Server protects /api/mcp/sse — here aido itself (the AS issuer
+// is the public origin). Built per request so the origin is correct behind the
+// Vercel proxy.
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request) {
+  const origin = getPublicOrigin(req);
+  return protectedResourceHandler({
+    authServerUrls: [origin],
+    resourceUrl: resourceUrl(origin),
+  })(req);
+}
+
+export const OPTIONS = metadataCorsOptionsRequestHandler();

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { FieldValue } from "firebase-admin/firestore";
+import { getPublicOrigin } from "mcp-handler";
 import { getAdminDb } from "@/lib/firebase/admin";
 import { API_KEYS_COLLECTION, hashApiKey, looksLikeApiKey } from "@/lib/apiKeys";
 
@@ -70,7 +71,20 @@ export async function authenticateMcp(req: NextRequest): Promise<McpAuthResult> 
     if (uid) return { ok: true, principal: { kind: "user", uid } };
   }
 
-  return { ok: false, response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  // 401 with a WWW-Authenticate that points at the protected-resource metadata
+  // (issue #151), so an OAuth-capable client (claude.ai connector) can discover
+  // the Authorization Server. API-key/shared-token clients ignore the header.
+  const resourceMetadataUrl = `${getPublicOrigin(req)}/.well-known/oauth-protected-resource`;
+  return {
+    ok: false,
+    response: NextResponse.json(
+      { error: "Unauthorized" },
+      {
+        status: 401,
+        headers: { "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"` },
+      }
+    ),
+  };
 }
 
 // Back-compat transport guard: returns null if authorized, else the error


### PR DESCRIPTION
## Summary

Starts the OAuth discovery chain so a claude.ai connector can find aido's Authorization Server. Closes #151 · refs epic #157.

## Changes
- **`/.well-known/oauth-protected-resource`** (RFC 9728) — via mcp-handler `protectedResourceHandler`, built per request (origin from `getPublicOrigin`, proxy-aware). Advertises aido as the AS.
- **`/.well-known/oauth-authorization-server`** (RFC 8414) — `issuer` + `authorization_endpoint`/`token_endpoint`/`registration_endpoint`, `code_challenge_methods_supported:[S256]`, `grant_types_supported:[authorization_code, refresh_token]`, `scopes_supported:[aido.tools]`. CORS headers + OPTIONS.
- **MCP route 401** now carries `WWW-Authenticate: Bearer resource_metadata="…"` (in `authenticateMcp`), so an OAuth client discovers the AS. API-key/shared-token clients ignore it.

## Notes
- Next.js 15 **serves the `.well-known` dot-folder routes** (confirmed in the build output as `ƒ` routes) — no rewrite needed.
- The advertised `/api/oauth/*` endpoints don't exist yet — they land in #152 (register), #153 (authorize), #154 (token). Discovery being in place first is correct.

## Verified locally (dev server)
- `/.well-known/oauth-protected-resource` → `{resource, authorization_servers:[origin]}`
- `/.well-known/oauth-authorization-server` → full AS metadata, correct URLs
- unauth MCP `POST` → **401** with `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`
- `tsc` / `lint` / `build` clean

## Test Plan
- [ ] Vercel green before merge
- [ ] Post-deploy: the three responses above with the prod origin
- [ ] (After #152–#155 + secret + rules deploy) end-to-end connector flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)