### PR TITLE
OAuth Dynamic Client Registration: /api/oauth/register (#152)

### DIFF
--- a/src/app/api/oauth/register/route.ts
+++ b/src/app/api/oauth/register/route.ts
@@ -1,0 +1,87 @@
+import { rateLimit } from "@/lib/apiKeys";
+import { createClient } from "@/lib/oauth/store";
+
+// Dynamic Client Registration (RFC 7591, issue #152). claude.ai registers
+// itself by POSTing its redirect_uris; we return a client_id. Public client
+// (PKCE), so no client_secret. Uses Web Request/Response (no next/server) so the
+// handler is testable in isolation.
+
+export const dynamic = "force-dynamic";
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status, headers: CORS });
+}
+
+function isValidRedirectUri(uri: unknown): uri is string {
+  if (typeof uri !== "string" || !uri) return false;
+  try {
+    const u = new URL(uri);
+    // http(s) only, no fragment (RFC 6749 §3.1.2).
+    return (u.protocol === "https:" || u.protocol === "http:") && u.hash === "";
+  } catch {
+    return false;
+  }
+}
+
+export async function POST(req: Request): Promise<Response> {
+  if (!rateLimit(`oauth:register:${clientIp(req)}`, { max: 20, windowMs: 60 * 60 * 1000 })) {
+    return err("rate_limited", "Too many registrations; try again later.", 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return err("invalid_client_metadata", "Invalid JSON body.", 400);
+  }
+
+  const b = (body ?? {}) as Record<string, unknown>;
+  const redirectUris = b.redirect_uris;
+  if (
+    !Array.isArray(redirectUris) ||
+    redirectUris.length === 0 ||
+    !redirectUris.every(isValidRedirectUri)
+  ) {
+    return err(
+      "invalid_redirect_uri",
+      "redirect_uris must be a non-empty array of http(s) URIs without a fragment.",
+      400
+    );
+  }
+  const clientName = typeof b.client_name === "string" ? b.client_name : null;
+
+  let client;
+  try {
+    client = await createClient({ redirectUris: redirectUris as string[], clientName });
+  } catch (e) {
+    console.error("[oauth/register] createClient failed", e);
+    return err("server_error", "Registration storage is unavailable.", 503);
+  }
+
+  return Response.json(
+    {
+      client_id: client.clientId,
+      redirect_uris: client.redirectUris,
+      ...(client.clientName ? { client_name: client.clientName } : {}),
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+    },
+    { status: 201, headers: CORS }
+  );
+}
+
+export function OPTIONS(): Response {
+  return new Response(null, { status: 204, headers: CORS });
+}

--- a/tests/oauth.test.mts
+++ b/tests/oauth.test.mts
@@ -27,6 +27,15 @@ initializeApp({ projectId }, "admin");
 const { signAccessToken, verifyAccessToken } = await import("../src/lib/oauth/tokens.ts");
 const { verifyPkceS256 } = await import("../src/lib/oauth/pkce.ts");
 const store = await import("../src/lib/oauth/store.ts");
+const { POST: registerPost } = await import("../src/app/api/oauth/register/route.ts");
+
+function registerReq(bodyObj: unknown, ip = "1.2.3.4"): Request {
+  return new Request("https://aido.example/api/oauth/register", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(bodyObj),
+  });
+}
 
 let failures = 0;
 function check(name: string, cond: boolean) {
@@ -84,6 +93,16 @@ async function run() {
   const c2 = await store.consumeAuthCode(code);
   check("auth code is single-use (replay → null)", c2 === null);
   check("unknown auth code → null", (await store.consumeAuthCode("nope")) === null);
+
+  // --- Dynamic Client Registration route (issue #152) ---
+  const okRes = await registerPost(registerReq({ redirect_uris: ["https://claude.ai/cb"], client_name: "Claude" }, "11.0.0.1"));
+  const okJson = (await okRes.json()) as { client_id?: string };
+  check("register → 201 + client_id", okRes.status === 201 && typeof okJson.client_id === "string");
+  const regClient = await store.getClient(okJson.client_id!);
+  check("register persisted the client", regClient?.redirectUris[0] === "https://claude.ai/cb" && regClient?.clientName === "Claude");
+  check("register empty redirect_uris → 400", (await registerPost(registerReq({ redirect_uris: [] }, "11.0.0.2"))).status === 400);
+  check("register invalid redirect_uri → 400", (await registerPost(registerReq({ redirect_uris: ["not-a-url"] }, "11.0.0.3"))).status === 400);
+  check("register fragment redirect_uri → 400", (await registerPost(registerReq({ redirect_uris: ["https://claude.ai/cb#x"] }, "11.0.0.4"))).status === 400);
 
   // --- Refresh token: hashed, revocable ---
   const rt = await store.createRefreshToken({ uid: "u1", clientId: client.clientId, scope: "aido.tools" });


### PR DESCRIPTION
## Summary

RFC 7591 Dynamic Client Registration so claude.ai can register itself and obtain a `client_id`. Closes #152 · refs epic #157.

## Changes
- **`POST /api/oauth/register`** — validates `redirect_uris` (non-empty array of http(s) URIs, no fragment) + optional `client_name`; stores via `oauth/store.createClient`; returns **201** with `client_id`, `token_endpoint_auth_method: "none"` (public client → PKCE), `grant_types`, `response_types`.
- Per-IP **rate limit** (`apiKeys.rateLimit`, 20/h). Admin-store failure → 503. CORS headers + `OPTIONS`.
- Web `Request`/`Response` (no `next/server`) → the handler is unit-testable.

## Tests
`oauth.test.mts` imports the **real route handler** and runs it against the emulator: valid → 201 + persisted client; empty / invalid / fragment `redirect_uri` → 400. Full suite green.

## Test Plan
- [x] `npm run test:oauth` — pass (incl. 5 DCR route checks)
- [x] `tsc` / `lint` / `build` — clean (`/api/oauth/register` route present)
- [ ] Vercel green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)