### PR TITLE
OAuth authorize endpoint + consent page + confirm (#153)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,9 @@
     "rules": "storage.rules"
   },
   "emulators": {
+    "auth": {
+      "port": 9099
+    },
     "firestore": {
       "port": 8181
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:rules": "firebase emulators:exec --only firestore,storage --project demo-rules-test \"node tests/firestore-rules.test.mjs && node tests/storage-rules.test.mjs\"",
     "test:migration": "firebase emulators:exec --only firestore --project demo-migration \"node tests/migration-admin.test.mjs\"",
     "test:mcp": "firebase emulators:exec --only firestore --project demo-mcp \"node --conditions=react-server --import tsx tests/mcp-tools.test.mts\"",
-    "test:oauth": "firebase emulators:exec --only firestore --project demo-oauth \"node --conditions=react-server --import tsx tests/oauth.test.mts\"",
+    "test:oauth": "firebase emulators:exec --only firestore,auth --project demo-oauth \"node --conditions=react-server --import tsx tests/oauth.test.mts\"",
     "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs"
   },
   "dependencies": {

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -13,7 +13,7 @@ export function GET(req: Request) {
   return Response.json(
     {
       issuer: origin,
-      authorization_endpoint: `${origin}/api/oauth/authorize`,
+      authorization_endpoint: `${origin}/oauth/authorize`,
       token_endpoint: `${origin}/api/oauth/token`,
       registration_endpoint: `${origin}/api/oauth/register`,
       response_types_supported: ["code"],

--- a/src/app/api/oauth/authorize/confirm/route.ts
+++ b/src/app/api/oauth/authorize/confirm/route.ts
@@ -1,0 +1,61 @@
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { getClient, createAuthCode } from "@/lib/oauth/store";
+import { OAUTH } from "@/lib/oauth/config";
+
+// Authorization confirm (issue #153): the consent page posts the user's Firebase
+// ID token plus the OAuth request params here. We verify the ID token → uid,
+// re-validate the client + redirect_uri, mint a one-time auth code, and hand the
+// page the final redirect (back to the client's redirect_uri with code + state).
+// Web Request/Response (no next/server) → testable in isolation.
+
+export const dynamic = "force-dynamic";
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return err("invalid_request", "Invalid JSON body.", 400);
+  }
+  const b = (body ?? {}) as Record<string, unknown>;
+  const idToken = str(b.idToken);
+  const clientId = str(b.clientId);
+  const redirectUri = str(b.redirectUri);
+  const codeChallenge = str(b.codeChallenge);
+  const state = str(b.state);
+  const scope = str(b.scope) || OAUTH.scope;
+
+  if (!idToken || !codeChallenge) {
+    return err("invalid_request", "Missing idToken or PKCE code_challenge.", 400);
+  }
+
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) return err("server_error", "Auth is not configured.", 503);
+
+  let uid: string;
+  try {
+    uid = (await adminAuth.verifyIdToken(idToken)).uid;
+  } catch {
+    return err("access_denied", "Invalid or expired Firebase ID token.", 401);
+  }
+
+  const client = await getClient(clientId).catch(() => null);
+  if (!client) return err("invalid_client", "Unknown client.", 400);
+  if (!client.redirectUris.includes(redirectUri)) {
+    return err("invalid_request", "redirect_uri is not registered for this client.", 400);
+  }
+
+  const code = await createAuthCode({ uid, clientId, redirectUri, codeChallenge, scope });
+
+  const sep = redirectUri.includes("?") ? "&" : "?";
+  const stateParam = state ? `&state=${encodeURIComponent(state)}` : "";
+  const redirectTo = `${redirectUri}${sep}code=${encodeURIComponent(code)}${stateParam}`;
+  return Response.json({ redirectTo });
+}

--- a/src/app/oauth/authorize/ConsentForm.tsx
+++ b/src/app/oauth/authorize/ConsentForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+// Consent step for the OAuth authorize flow (issue #153). The server page has
+// already validated client_id/redirect_uri/PKCE; here the user signs in with the
+// existing Firebase Google login and approves. "Allow" posts the Firebase ID
+// token + params to /api/oauth/authorize/confirm, which mints the auth code and
+// returns the redirect back to the client.
+export default function ConsentForm(props: {
+  clientName: string | null;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state: string;
+  scope: string;
+}) {
+  const { user, signInWithGoogle } = useAuth();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const appName = props.clientName || "Eine externe Anwendung";
+
+  async function allow() {
+    if (!user) return;
+    setBusy(true);
+    setError("");
+    try {
+      const idToken = await user.getIdToken();
+      const res = await fetch("/api/oauth/authorize/confirm", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          idToken,
+          clientId: props.clientId,
+          redirectUri: props.redirectUri,
+          codeChallenge: props.codeChallenge,
+          state: props.state,
+          scope: props.scope,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok && data.redirectTo) {
+        window.location.href = data.redirectTo;
+        return;
+      }
+      setError(data.error_description || "Autorisierung fehlgeschlagen.");
+      setBusy(false);
+    } catch {
+      setError("Autorisierung fehlgeschlagen.");
+      setBusy(false);
+    }
+  }
+
+  function deny() {
+    const sep = props.redirectUri.includes("?") ? "&" : "?";
+    const stateParam = props.state ? `&state=${encodeURIComponent(props.state)}` : "";
+    window.location.href = `${props.redirectUri}${sep}error=access_denied${stateParam}`;
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-bg text-text p-6">
+      <div className="w-full max-w-md rounded-2xl border border-border bg-bg-card p-6 shadow-soft">
+        <h1 className="text-2xl font-black mb-1">aido verbinden</h1>
+        <p className="text-text-dim mb-6">
+          <span className="font-semibold text-text">{appName}</span> möchte auf deine aido-Spaces
+          zugreifen (Todos lesen &amp; schreiben).
+        </p>
+
+        {!user ? (
+          <button
+            onClick={signInWithGoogle}
+            className="w-full rounded-full bg-accent px-4 py-2.5 font-extrabold text-white"
+          >
+            Mit Google anmelden
+          </button>
+        ) : (
+          <>
+            <p className="text-sm text-text-dim mb-4">
+              Angemeldet als{" "}
+              <span className="font-semibold text-text">{user.displayName || user.email}</span>
+            </p>
+            {error && <p className="text-sm text-danger mb-3">{error}</p>}
+            <div className="flex gap-2">
+              <button
+                onClick={allow}
+                disabled={busy}
+                className="flex-1 rounded-full bg-accent px-4 py-2.5 font-extrabold text-white disabled:opacity-50"
+              >
+                {busy ? "…" : "Erlauben"}
+              </button>
+              <button
+                onClick={deny}
+                disabled={busy}
+                className="flex-1 rounded-full border border-border px-4 py-2.5 font-semibold text-text-dim hover:text-text"
+              >
+                Ablehnen
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/oauth/authorize/page.tsx
+++ b/src/app/oauth/authorize/page.tsx
@@ -1,0 +1,65 @@
+import { getClient } from "@/lib/oauth/store";
+import { OAUTH } from "@/lib/oauth/config";
+import ConsentForm from "./ConsentForm";
+
+// OAuth authorization endpoint (issue #153) — a server-validated consent page.
+// Validates the request (client, redirect_uri, response_type, PKCE) server-side
+// before rendering, then hands the safe params to the client consent component.
+
+export const dynamic = "force-dynamic";
+
+function first(v: string | string[] | undefined): string {
+  return Array.isArray(v) ? v[0] ?? "" : v ?? "";
+}
+
+function AuthorizeError({ message }: { message: string }) {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-bg text-text p-6">
+      <div className="max-w-md text-center">
+        <h1 className="text-xl font-bold mb-2">aido — Verbindung nicht möglich</h1>
+        <p className="text-text-dim">{message}</p>
+      </div>
+    </main>
+  );
+}
+
+export default async function AuthorizePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const clientId = first(sp.client_id);
+  const redirectUri = first(sp.redirect_uri);
+  const responseType = first(sp.response_type);
+  const codeChallenge = first(sp.code_challenge);
+  const codeChallengeMethod = first(sp.code_challenge_method);
+  const state = first(sp.state);
+  const scope = first(sp.scope) || OAUTH.scope;
+
+  if (responseType !== "code") {
+    return <AuthorizeError message="Nicht unterstützter response_type (erwartet: code)." />;
+  }
+  if (codeChallengeMethod !== "S256" || !codeChallenge) {
+    return <AuthorizeError message="PKCE mit S256 ist erforderlich." />;
+  }
+
+  const client = await getClient(clientId).catch(() => null);
+  if (!client) {
+    return <AuthorizeError message="Unbekannter oder ungültiger Client." />;
+  }
+  if (!client.redirectUris.includes(redirectUri)) {
+    return <AuthorizeError message="Die redirect_uri ist für diesen Client nicht registriert." />;
+  }
+
+  return (
+    <ConsentForm
+      clientName={client.clientName}
+      clientId={clientId}
+      redirectUri={redirectUri}
+      codeChallenge={codeChallenge}
+      state={state}
+      scope={scope}
+    />
+  );
+}

--- a/tests/oauth.test.mts
+++ b/tests/oauth.test.mts
@@ -28,6 +28,26 @@ const { signAccessToken, verifyAccessToken } = await import("../src/lib/oauth/to
 const { verifyPkceS256 } = await import("../src/lib/oauth/pkce.ts");
 const store = await import("../src/lib/oauth/store.ts");
 const { POST: registerPost } = await import("../src/app/api/oauth/register/route.ts");
+const { POST: confirmPost } = await import("../src/app/api/oauth/authorize/confirm/route.ts");
+
+// Mint a real emulator Firebase ID token via the Auth emulator REST API
+// (accounts:signUp creates an anonymous user and returns an idToken).
+async function mintIdToken(): Promise<{ idToken: string; uid: string }> {
+  const host = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+  const res = await fetch(
+    `http://${host}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-key`,
+    { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ returnSecureToken: true }) }
+  );
+  const data = (await res.json()) as { idToken: string; localId: string };
+  return { idToken: data.idToken, uid: data.localId };
+}
+function confirmReq(bodyObj: unknown): Request {
+  return new Request("https://aido.example/api/oauth/authorize/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(bodyObj),
+  });
+}
 
 function registerReq(bodyObj: unknown, ip = "1.2.3.4"): Request {
   return new Request("https://aido.example/api/oauth/register", {
@@ -103,6 +123,21 @@ async function run() {
   check("register empty redirect_uris → 400", (await registerPost(registerReq({ redirect_uris: [] }, "11.0.0.2"))).status === 400);
   check("register invalid redirect_uri → 400", (await registerPost(registerReq({ redirect_uris: ["not-a-url"] }, "11.0.0.3"))).status === 400);
   check("register fragment redirect_uri → 400", (await registerPost(registerReq({ redirect_uris: ["https://claude.ai/cb#x"] }, "11.0.0.4"))).status === 400);
+
+  // --- Authorize confirm route (issue #153): ID token → uid → auth code ---
+  const acClient = await store.createClient({ redirectUris: ["https://claude.ai/cb"], clientName: "Claude" });
+  const { idToken, uid } = await mintIdToken();
+  const cres = await confirmPost(confirmReq({
+    idToken, clientId: acClient.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: challenge, state: "st-123", scope: "aido.tools",
+  }));
+  const cjson = (await cres.json()) as { redirectTo?: string };
+  check("confirm → 200 redirectTo with code+state", cres.status === 200 && /[?&]code=/.test(cjson.redirectTo ?? "") && /[?&]state=st-123/.test(cjson.redirectTo ?? ""));
+  const issuedCode = new URL(cjson.redirectTo!).searchParams.get("code");
+  const consumed = await store.consumeAuthCode(issuedCode!);
+  check("confirm code is bound to the real uid + challenge + client", consumed?.uid === uid && consumed?.codeChallenge === challenge && consumed?.clientId === acClient.clientId);
+  check("confirm invalid id token → 401", (await confirmPost(confirmReq({ idToken: "not-a-token", clientId: acClient.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: challenge }))).status === 401);
+  check("confirm unregistered redirect_uri → 400", (await confirmPost(confirmReq({ idToken, clientId: acClient.clientId, redirectUri: "https://evil.example/cb", codeChallenge: challenge }))).status === 400);
+  check("confirm missing PKCE → 400", (await confirmPost(confirmReq({ idToken, clientId: acClient.clientId, redirectUri: "https://claude.ai/cb" }))).status === 400);
 
   // --- Refresh token: hashed, revocable ---
   const rt = await store.createRefreshToken({ uid: "u1", clientId: client.clientId, scope: "aido.tools" });


### PR DESCRIPTION
## Summary

The interactive consent step of the OAuth flow — reusing the existing Firebase Google login. Closes #153 · refs epic #157.

## Changes
- **`/oauth/authorize`** (server-component page) — validates `client_id` / `redirect_uri` (against the registered client) / `response_type=code` / PKCE-S256 **server-side**, then renders `<ConsentForm>`. AS-metadata `authorization_endpoint` updated to this page URL.
- **`ConsentForm`** (client) — Firebase Google login via `AuthContext`; **Allow** posts the ID token + params to confirm; **Deny** redirects with `error=access_denied`.
- **`POST /api/oauth/authorize/confirm`** — `verifyIdToken` → uid, re-validates client + redirect_uri, mints a **one-time auth code**, returns the redirect back to the client (`code` + `state`).
- **`firebase.json`** — adds the auth emulator (9099) for the confirm test.

## Tests
`oauth.test.mts` mints a **real Firebase ID token via the Auth-emulator REST** and drives the confirm route: 200 + `redirectTo(code,state)`; code **bound to the real uid/challenge/client**; invalid token → 401; unregistered redirect → 400; missing PKCE → 400. `npm run test:oauth` now runs firestore+auth.

## Notes
- The token endpoint that consumes the code is **#154** (next).
- Consent UI uses the token theme; lives under the root layout (public, no auth guard) so the user can sign in there.

## Test Plan
- [x] `npm run test:oauth` — pass (incl. 5 confirm-flow checks via a real ID token)
- [x] `tsc` / `lint` / `build` — clean (all 3 routes present)
- [ ] Vercel green before merge
- [ ] Manual: `/oauth/authorize?...` with a registered client → Google login → Allow → redirect with code

🤖 Generated with [Claude Code](https://claude.com/claude-code)