### PR TITLE
OAuth token endpoint: code+PKCE → JWT, refresh rotation (#154)

### DIFF
--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,0 +1,110 @@
+import { rateLimit } from "@/lib/apiKeys";
+import { signAccessToken } from "@/lib/oauth/tokens";
+import { verifyPkceS256 } from "@/lib/oauth/pkce";
+import { OAUTH, resourceUrl, requestOrigin } from "@/lib/oauth/config";
+import {
+  consumeAuthCode,
+  createRefreshToken,
+  consumeRefreshToken,
+  revokeRefreshToken,
+} from "@/lib/oauth/store";
+
+// OAuth token endpoint (RFC 6749, issue #154). Exchanges an authorization code
+// (with PKCE) or a refresh token for a short-lived JWT access token (+ a rotated
+// refresh token). Form-encoded per spec. Web Request/Response → testable.
+
+export const dynamic = "force-dynamic";
+
+const CORS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status, headers: CORS });
+}
+
+async function issueTokens(
+  req: Request,
+  grant: { uid: string; clientId: string; scope: string }
+): Promise<Response> {
+  const origin = requestOrigin(req);
+  let accessToken: string;
+  let expiresIn: number;
+  try {
+    ({ accessToken, expiresIn } = await signAccessToken({
+      issuer: origin,
+      audience: resourceUrl(origin),
+      uid: grant.uid,
+      scope: grant.scope,
+      clientId: grant.clientId,
+    }));
+  } catch (e) {
+    console.error("[oauth/token] signing failed", e);
+    return err("server_error", "Token signing is not configured.", 503);
+  }
+  const refreshToken = await createRefreshToken(grant);
+  return Response.json(
+    {
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: expiresIn,
+      refresh_token: refreshToken,
+      scope: grant.scope,
+    },
+    { headers: { "Cache-Control": "no-store", ...CORS } }
+  );
+}
+
+export async function POST(req: Request): Promise<Response> {
+  if (!rateLimit(`oauth:token:${clientIp(req)}`, { max: 60, windowMs: 60 * 60 * 1000 })) {
+    return err("rate_limited", "Too many token requests; try again later.", 429);
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return err("invalid_request", "Expected application/x-www-form-urlencoded body.", 400);
+  }
+  const s = (k: string) => String(form.get(k) ?? "");
+  const grantType = s("grant_type");
+
+  if (grantType === "authorization_code") {
+    const code = s("code");
+    const codeVerifier = s("code_verifier");
+    const redirectUri = s("redirect_uri");
+    const clientId = s("client_id");
+    if (!code || !codeVerifier) return err("invalid_request", "Missing code or code_verifier.", 400);
+
+    const data = await consumeAuthCode(code);
+    if (!data) return err("invalid_grant", "Authorization code is invalid, used or expired.", 400);
+    if (data.clientId !== clientId) return err("invalid_grant", "client_id mismatch.", 400);
+    if (data.redirectUri !== redirectUri) return err("invalid_grant", "redirect_uri mismatch.", 400);
+    if (!verifyPkceS256(codeVerifier, data.codeChallenge)) {
+      return err("invalid_grant", "PKCE verification failed.", 400);
+    }
+    return issueTokens(req, { uid: data.uid, clientId: data.clientId, scope: data.scope });
+  }
+
+  if (grantType === "refresh_token") {
+    const refreshToken = s("refresh_token");
+    if (!refreshToken) return err("invalid_request", "Missing refresh_token.", 400);
+    const data = await consumeRefreshToken(refreshToken);
+    if (!data) return err("invalid_grant", "Refresh token is invalid, revoked or expired.", 400);
+    // Rotate: revoke the presented token, issue a fresh pair.
+    await revokeRefreshToken(refreshToken);
+    return issueTokens(req, { uid: data.uid, clientId: data.clientId, scope: data.scope || OAUTH.scope });
+  }
+
+  return err("unsupported_grant_type", `Unsupported grant_type: ${grantType}.`, 400);
+}
+
+export function OPTIONS(): Response {
+  return new Response(null, { status: 204, headers: CORS });
+}

--- a/src/lib/oauth/config.ts
+++ b/src/lib/oauth/config.ts
@@ -25,3 +25,17 @@ export const OAUTH = {
 export function resourceUrl(origin: string): string {
   return `${origin.replace(/\/$/, "")}/api/mcp/sse`;
 }
+
+/**
+ * Public origin of a request, honouring the Vercel proxy headers. Used by the
+ * token endpoint (to sign `iss`/`aud`) and the MCP token check (to verify them)
+ * so both compute the identical issuer/audience.
+ */
+export function requestOrigin(req: Request): string {
+  const url = new URL(req.url);
+  const host = (req.headers.get("x-forwarded-host") ?? url.host).split(",")[0].trim();
+  const proto = (req.headers.get("x-forwarded-proto") ?? url.protocol.replace(/:$/, ""))
+    .split(",")[0]
+    .trim();
+  return `${proto}://${host}`;
+}

--- a/tests/oauth.test.mts
+++ b/tests/oauth.test.mts
@@ -49,6 +49,15 @@ function confirmReq(bodyObj: unknown): Request {
   });
 }
 
+const { POST: tokenPost } = await import("../src/app/api/oauth/token/route.ts");
+function tokenReq(params: Record<string, string>): Request {
+  return new Request("https://aido.example/api/oauth/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded", "x-forwarded-for": "22.0.0.1" },
+    body: new URLSearchParams(params).toString(),
+  });
+}
+
 function registerReq(bodyObj: unknown, ip = "1.2.3.4"): Request {
   return new Request("https://aido.example/api/oauth/register", {
     method: "POST",
@@ -138,6 +147,28 @@ async function run() {
   check("confirm invalid id token → 401", (await confirmPost(confirmReq({ idToken: "not-a-token", clientId: acClient.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: challenge }))).status === 401);
   check("confirm unregistered redirect_uri → 400", (await confirmPost(confirmReq({ idToken, clientId: acClient.clientId, redirectUri: "https://evil.example/cb", codeChallenge: challenge }))).status === 400);
   check("confirm missing PKCE → 400", (await confirmPost(confirmReq({ idToken, clientId: acClient.clientId, redirectUri: "https://claude.ai/cb" }))).status === 400);
+
+  // --- Token endpoint (issue #154): code + PKCE → JWT + refresh; rotation ---
+  const tVerifier = randomBytes(32).toString("base64url");
+  const tChallenge = createHash("sha256").update(tVerifier).digest("base64url");
+  const tClient = await store.createClient({ redirectUris: ["https://claude.ai/cb"] });
+  const tCode = await store.createAuthCode({ uid: "tok-uid", clientId: tClient.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: tChallenge, scope: "aido.tools" });
+
+  const tokRes = await tokenPost(tokenReq({ grant_type: "authorization_code", code: tCode, code_verifier: tVerifier, redirect_uri: "https://claude.ai/cb", client_id: tClient.clientId }));
+  const tok = (await tokRes.json()) as { access_token?: string; refresh_token?: string; token_type?: string; expires_in?: number };
+  check("token: code+PKCE → access+refresh", tokRes.status === 200 && !!tok.access_token && !!tok.refresh_token && tok.token_type === "Bearer" && tok.expires_in === 3600);
+  const verifiedTok = await verifyAccessToken(tok.access_token!, { issuer: "https://aido.example", audience: "https://aido.example/api/mcp/sse" });
+  check("token: JWT sub = uid", verifiedTok.uid === "tok-uid" && verifiedTok.clientId === tClient.clientId);
+  check("token: code replay → 400", (await tokenPost(tokenReq({ grant_type: "authorization_code", code: tCode, code_verifier: tVerifier, redirect_uri: "https://claude.ai/cb", client_id: tClient.clientId }))).status === 400);
+
+  const tCode2 = await store.createAuthCode({ uid: "tok-uid", clientId: tClient.clientId, redirectUri: "https://claude.ai/cb", codeChallenge: tChallenge, scope: "aido.tools" });
+  check("token: wrong code_verifier → 400", (await tokenPost(tokenReq({ grant_type: "authorization_code", code: tCode2, code_verifier: "wrong-verifier", redirect_uri: "https://claude.ai/cb", client_id: tClient.clientId }))).status === 400);
+  check("token: unsupported grant → 400", (await tokenPost(tokenReq({ grant_type: "password" }))).status === 400);
+
+  const refRes = await tokenPost(tokenReq({ grant_type: "refresh_token", refresh_token: tok.refresh_token! }));
+  const ref = (await refRes.json()) as { access_token?: string; refresh_token?: string };
+  check("token: refresh → new access+refresh", refRes.status === 200 && !!ref.access_token && !!ref.refresh_token && ref.refresh_token !== tok.refresh_token);
+  check("token: rotated (old refresh) → 400", (await tokenPost(tokenReq({ grant_type: "refresh_token", refresh_token: tok.refresh_token! }))).status === 400);
 
   // --- Refresh token: hashed, revocable ---
   const rt = await store.createRefreshToken({ uid: "u1", clientId: client.clientId, scope: "aido.tools" });


### PR DESCRIPTION
## Summary

RFC 6749 token endpoint — the last flow piece before arming the connector. Closes #154 · refs epic #157.

## Changes
- **`POST /api/oauth/token`** (form-encoded):
  - `grant_type=authorization_code` — `consumeAuthCode` (single-use), verify `client_id`/`redirect_uri` and **PKCE-S256** `code_verifier` → short-lived **JWT access token** (`sub`=uid, `iss`/`aud` from `requestOrigin`) + **refresh token** + `expires_in`.
  - `grant_type=refresh_token` — consume + **rotate** (revoke old, issue a fresh pair).
- Per-IP rate limit; missing `OAUTH_SIGNING_SECRET` → 503; CORS + OPTIONS.
- **`config.requestOrigin(req)`** — shared so the token endpoint *signs* and the MCP check (#155) *verifies* the identical `iss`/`aud`.

## Tests
`oauth.test.mts` drives the real route: code+PKCE → access+refresh (**JWT verified `sub`=uid**); code replay → 400; wrong `code_verifier` → 400; unsupported grant → 400; refresh → rotated new pair; **old refresh after rotation → 400**.

## Next
**#155** wires `authenticateMcp` to accept the OAuth JWT → the claude.ai connector goes live (then set `OAUTH_SIGNING_SECRET` in Vercel + deploy the rules).

## Test Plan
- [x] `npm run test:oauth` — pass (incl. 7 token-endpoint checks)
- [x] `tsc` / `lint` / `build` — clean (`/api/oauth/token` present)
- [ ] Vercel green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)