### PR TITLE
authenticateMcp accepts OAuth access tokens — connector live (#155)

### DIFF
--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -4,6 +4,8 @@ import { FieldValue } from "firebase-admin/firestore";
 import { getPublicOrigin } from "mcp-handler";
 import { getAdminDb } from "@/lib/firebase/admin";
 import { API_KEYS_COLLECTION, hashApiKey, looksLikeApiKey } from "@/lib/apiKeys";
+import { verifyAccessToken } from "@/lib/oauth/tokens";
+import { requestOrigin, resourceUrl } from "@/lib/oauth/config";
 
 // Guards the MCP endpoint. Two accepted credentials:
 // 1. the shared secret MCP_AUTH_TOKEN (ops/back-compat) — carries NO user
@@ -49,6 +51,22 @@ async function resolvePersonalApiKey(provided: string): Promise<string | null> {
   return doc.id; // doc id === uid
 }
 
+// Verifies an OAuth access token (issue #155): a JWT signed by aido's token
+// endpoint. iss/aud are derived from the request origin — identical to how the
+// token endpoint signed them (config.requestOrigin), so they line up. Non-JWTs
+// (shared secret / personal key, handled earlier) and any verification failure
+// return null.
+async function resolveOAuthToken(token: string, req: NextRequest): Promise<string | null> {
+  if (!token.includes(".")) return null;
+  const origin = requestOrigin(req);
+  try {
+    const { uid } = await verifyAccessToken(token, { issuer: origin, audience: resourceUrl(origin) });
+    return uid;
+  } catch {
+    return null;
+  }
+}
+
 // Authenticates an MCP request and returns the principal (issue #117). Data
 // tools branch on `principal.kind`: only `user` exposes a uid to scope to.
 export async function authenticateMcp(req: NextRequest): Promise<McpAuthResult> {
@@ -69,6 +87,10 @@ export async function authenticateMcp(req: NextRequest): Promise<McpAuthResult> 
     if (matchesSharedSecret(provided)) return { ok: true, principal: { kind: "shared" } };
     const uid = await resolvePersonalApiKey(provided);
     if (uid) return { ok: true, principal: { kind: "user", uid } };
+    // OAuth access token (issue #155): a JWT from aido's token endpoint — this is
+    // how the claude.ai web connector authenticates.
+    const oauthUid = await resolveOAuthToken(provided, req);
+    if (oauthUid) return { ok: true, principal: { kind: "user", uid: oauthUid } };
   }
 
   // 401 with a WWW-Authenticate that points at the protected-resource metadata

--- a/tests/oauth.test.mts
+++ b/tests/oauth.test.mts
@@ -170,6 +170,19 @@ async function run() {
   check("token: refresh → new access+refresh", refRes.status === 200 && !!ref.access_token && !!ref.refresh_token && ref.refresh_token !== tok.refresh_token);
   check("token: rotated (old refresh) → 400", (await tokenPost(tokenReq({ grant_type: "refresh_token", refresh_token: tok.refresh_token! }))).status === 400);
 
+  // --- MCP integration (issue #155): authenticateMcp accepts the OAuth JWT ---
+  const { authenticateMcp } = await import("../src/lib/mcp/auth.ts");
+  const mcpReq = (auth?: string) =>
+    new Request("https://aido.example/api/mcp/sse", {
+      method: "POST",
+      headers: auth ? { authorization: auth } : {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  const okAuth = await authenticateMcp(mcpReq(`Bearer ${tok.access_token}`));
+  check("MCP: valid OAuth JWT → {user, uid}", okAuth.ok === true && okAuth.principal?.kind === "user" && okAuth.principal?.uid === "tok-uid");
+  check("MCP: garbage bearer → 401", (await authenticateMcp(mcpReq("Bearer not.a.jwt"))).ok === false);
+  check("MCP: no auth → 401", (await authenticateMcp(mcpReq())).ok === false);
+
   // --- Refresh token: hashed, revocable ---
   const rt = await store.createRefreshToken({ uid: "u1", clientId: client.clientId, scope: "aido.tools" });
   check("refresh token is opaque (aidor_ prefix)", rt.startsWith("aidor_"));


### PR DESCRIPTION
## Summary

The final functional piece — `authenticateMcp` now accepts an **OAuth access token**, so the full claude.ai connector flow works: discovery → DCR → consent → token → MCP. Closes #155 · refs epic #157.

## Changes
- **`auth.ts`** — third branch in `authenticateMcp`: after shared-token and personal-API-key, `resolveOAuthToken` verifies the bearer as a JWT (`verifyAccessToken` with `iss`/`aud` from **`config.requestOrigin`**, identical to how the token endpoint signed them). On success → `{kind:'user', uid}`.
- Shared-token and API-key paths **unchanged** (no regression); non-JWTs skipped; any verification failure falls through to the existing 401 + `WWW-Authenticate`.

## Tests
`oauth.test.mts` drives the **real `authenticateMcp`** with a **real token-endpoint JWT** → `{user, uid}`; garbage bearer → 401; no auth → 401. Full OAuth suite green (lib + DCR + confirm + token + MCP integration).

## ⚠️ Go-live (manual, after merge + deploy)
1. **Vercel → Settings → Environment Variables (Production):** set **`OAUTH_SIGNING_SECRET`** (e.g. `openssl rand -base64 48`), then redeploy.
2. **Deploy the rules** (locks the OAuth collections): `npx -y firebase-tools@13 deploy --only firestore:rules`.
3. On claude.ai: **Add custom connector** → `https://aido-phi.vercel.app/api/mcp/sse` → it should run the OAuth login/consent and connect.

The personal-API-key path (Claude Code/Desktop) keeps working throughout.

## Test Plan
- [x] `npm run test:oauth` — full suite incl. MCP+JWT integration
- [x] `tsc` / `lint` / `build` — clean
- [ ] Vercel green before merge
- [ ] Post go-live: claude.ai connector end-to-end → `list-spaces` returns real spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)