### PR TITLE
docs: bring README up to date (Spaces, real MCP tools, OAuth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,71 @@
 # Aido
 
-A collaborative todo app with rich-text editing, sharing, mentions and an MCP server — built on Next.js and Firebase.
+A collaborative, **Spaces-based** todo app — rich-text todos, a chat-style daily capture, a Kanban board, real-time collaboration, and an MCP server (API key **or** OAuth) so AI assistants can read and write your todos. Built on Next.js 15 and Firebase.
 
 Originally generated from [template-cursor-nextjs-firebase](https://github.com/martinvidec/template-cursor-nextjs-firebase).
 
 ## Features
 
+### Spaces — the organizing unit
+Everything lives in a **Space** (`spaces/{id}`) with members and an accent color. Any member can read and write everything in the space — full collaboration (this replaced the older "My Todos / Shared with me" split). Create, rename, recolor and delete spaces and invite members (search by display-name prefix or exact e-mail hash); only the creator may delete a space. Each space has three views:
+
+- **Heute** — chat-style quick capture of short-lived daily items (a separate `daily` collection; never clutters the list).
+- **Liste** — structured todos: a Tiptap composer (title + rich body), `@`-mentions, `#`-hashtag filtering, "waiting on \<member\>", interactive checklists, and a collapsible "Erledigt" (done) section.
+- **Board** — the same todos as a Kanban, grouped by **person** or **status**, with drag & drop on desktop and a "move" sheet on mobile.
+
+Responsive by design: a desktop shell (sidebar + scrolling column) and a dedicated mobile shell (header, space pills, bottom tabs, bottom sheets), switched purely via CSS. Live updates via Firestore snapshots. Legacy pre-redesign todos are migrated into spaces on login.
+
 ### Authentication
-- Sign in with Google (Firebase Auth popup flow)
-- Protected routes under `(protected)/` — todos, mentions, contacts, settings
-- User document (`users/{uid}`, owner-only) plus a PII-free public profile (`publicProfiles/{uid}`: display name, photo, e-mail hash) used for all cross-user lookups
+- Google sign-in (Firebase Auth). Owner-only user doc (`users/{uid}`, PII) plus a PII-free public profile (`publicProfiles/{uid}`: display name, photo, e-mail hash) used for **all** cross-user lookups — exact-match on the e-mail hash or display-name prefix, so the user base can't be enumerated.
 
-### Todos (`/todos`)
-- Rich-text editor (Tiptap) with toolbar: bold, italic, underline, strikethrough, headings, bullet/ordered lists, blockquote, code block, links, highlight, task lists, emoji picker, undo/redo
-- Create, edit, delete; checkbox to mark todos done
-- **@-Mentions**: type `@` to mention one of your contacts; mentioned users see the todo in their mentions feed
-- **#-Hashtags**: type `#` to tag todos; the list has a tag-based search/filter (all terms must match)
-- Live updates via Firestore snapshots; own and shared todos in separate sections
-
-### Sharing
-- Share a todo with other users (search by display-name prefix, or enter an exact e-mail address)
-- Shared users ("sharees") can read the todo and toggle `completed` — nothing else; enforced server-side by Firestore rules, not just in the UI
-- E-mail lookup works via SHA-256 hash exact-match, so the user base cannot be enumerated
-
-### Mentions feed (`/mentions`)
-- Lists all todos in which you are mentioned, with owner info from public profiles
+### Rich text & mentions
+- Tiptap editor with headings, lists, blockquote, code, hardened links, highlight, task lists and emoji. `@`-mentions resolve against your contacts; `#`-hashtags drive list filtering. Tags and mentions are derived from title/body on save.
 
 ### Contacts (`/contacts`)
-- Send, accept, reject and cancel contact requests
-- Inviting a not-yet-registered e-mail address creates an invite; a Cloud Function (`sendContactInviteEmail`) sends the invitation e-mail
-- Contacts feed the @-mention suggestions
+- Send / accept / reject / cancel contact requests. Inviting a not-yet-registered e-mail creates an invite and a Cloud Function (`sendContactInviteEmail`) sends the e-mail. Contacts feed the `@`-mention suggestions.
 
 ### Settings (`/settings`)
-- Profile (display name, e-mail, photo), language, timezone, e-mail/push notification toggles
-- Theme: light / dark / system (persisted per user)
-- **Personal API key**: generate / rotate / revoke a key (`aido_…`) for external integrations. The plaintext is shown exactly once; only a SHA-256 hash is stored (`userApiKeys/{uid}`, no client access). Requires `FIREBASE_SERVICE_ACCOUNT_KEY` on the server.
+- Profile (name, e-mail, photo), language, timezone, notification toggles; light / dark / system theme (oklch design tokens, persisted per user).
+- **Personal API key** (`aido_…`): generate / rotate / revoke for external integrations (e.g. Claude Code/Desktop). The plaintext is shown exactly once; only a SHA-256 hash is stored (`userApiKeys/{uid}`, admin-only). Requires `FIREBASE_SERVICE_ACCOUNT_KEY`.
 
 ### MCP server (`/api/mcp/sse`)
-- Model Context Protocol server with `streamable-http` (POST) and SSE (GET) transport, session management included
-- Tools: `list-todos`, `add-todo`
-- Auth: `Authorization: Bearer <token>` — either the shared `MCP_AUTH_TOKEN` or a personal API key; unauthenticated requests are rejected
-- Compatible with `@modelcontextprotocol/inspector`
+Model Context Protocol over **streamable HTTP**, stateless via [`mcp-handler`](https://www.npmjs.com/package/mcp-handler) (serverless-friendly — no in-memory session map). **10 Firestore-backed tools**, all member-gated and scoped to the caller's uid:
+
+`list-spaces` · `list-todos` · `add-todo` · `complete-todo` · `set-waiting-on` · `list-daily` · `add-daily` · `delete-todo` · `whoami` · `list-members`
+
+Three authentication methods on the same endpoint:
+- the shared `MCP_AUTH_TOKEN` (transport only — data tools require a user identity),
+- a **personal API key** (`aido_…`) → uid,
+- **OAuth 2.1** (for the claude.ai web connector — see below).
+
+Quickstart with Claude Code:
+```bash
+claude mcp add --transport http aido https://<your-app>/api/mcp/sse \
+  --header "Authorization: Bearer aido_<your-key>"
+```
+
+### OAuth (claude.ai connector)
+aido is its own **OAuth Authorization Server** for the MCP resource server, reusing the existing Google login for consent:
+- Discovery: `/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`
+- Dynamic Client Registration: `/api/oauth/register`
+- Authorize + consent page: `/oauth/authorize` (signs in with Firebase Google) → `/api/oauth/authorize/confirm`
+- Token: `/api/oauth/token` with PKCE (S256)
+
+Access tokens are short-lived signed JWTs (`sub` = uid); refresh tokens are revocable Firestore entries. Requires `OAUTH_SIGNING_SECRET`.
 
 ### Security
-- Firestore rules: owner-only user docs, field-validated todo updates (sharees restricted to `completed`), admin-only API-key hashes, deny-by-default Storage rules
-- Emulator-based rules test suite: `npm run test:rules` (Firestore + Storage)
-- Security headers on every route (CSP, `X-Frame-Options`, HSTS, `nosniff`, `Referrer-Policy`)
-- Tiptap link hardening: protocol allowlist (http/https/mailto), no `javascript:`/`data:` URLs, `openOnClick` disabled
-- Dependabot (weekly, root + `functions/`)
+- **Firestore rules are the authority**: space membership gates `todos`/`daily`; field-validated writes; owner-only user docs; admin-only API-key and OAuth collections; deny-by-default Storage.
+- The Admin SDK bypasses rules, so the MCP tools re-enforce membership and field invariants in code (mirrored by emulator tests).
+- Security headers on every route (CSP, `X-Frame-Options`, HSTS, `nosniff`, `Referrer-Policy`); Tiptap link hardening (http/https/mailto allowlist, no `javascript:`/`data:`, `openOnClick` off); Dependabot (root + `functions/`).
 
 ## Tech stack
 
-- **Next.js 15** (App Router) with React 19, TypeScript, TailwindCSS
-- **Firebase**: Auth, Firestore (client SDK v12), Security Rules; `firebase-admin` for server-side token verification and API-key storage
-- **Cloud Functions v2** (`functions/`, Node 22): contact invite e-mails
-- **Tiptap 2**: rich-text editing (mentions, hashtags, task lists, links)
-- **@modelcontextprotocol/sdk** + **Zod 4**: MCP server and schema validation
-- **Vercel**: hosting/deployment (auto-deploy on merge to `main`)
+- **Next.js 15** (App Router), React 19, TypeScript, **Tailwind** (oklch design tokens, light/dark via `data-theme`)
+- **Firebase**: Auth, Firestore (client SDK v12); **firebase-admin** (v13) for token verification, the Admin-SDK MCP/OAuth data path, and API-key/OAuth storage
+- **Cloud Functions v2** (`functions/`): contact-invite e-mails
+- **Tiptap 2** for rich-text editing
+- **@modelcontextprotocol/sdk** + **mcp-handler** (MCP transport) · **jose** (OAuth JWTs) · **Zod 4**
+- **Vercel** hosting (auto-deploy on merge to `main`); **Node 24.x** runtime (`engines`)
 
 ## Getting started
 
@@ -66,8 +75,9 @@ Originally generated from [template-cursor-nextjs-firebase](https://github.com/m
    ```
 2. Copy `.env.example` to `.env.local` and fill in:
    - `NEXT_PUBLIC_FIREBASE_*` — Firebase web app config
-   - `MCP_AUTH_TOKEN` — shared secret for the MCP endpoint (`openssl rand -hex 32`)
-   - `FIREBASE_SERVICE_ACCOUNT_KEY` — service-account JSON (single line); needed for personal API keys
+   - `FIREBASE_SERVICE_ACCOUNT_KEY` — service-account JSON (single line); needed for personal API keys and the MCP/OAuth data path
+   - `MCP_AUTH_TOKEN` — optional shared MCP secret (`openssl rand -hex 32`)
+   - `OAUTH_SIGNING_SECRET` — for the OAuth connector (`openssl rand -base64 48`)
 3. Run the dev server:
    ```bash
    npm run dev
@@ -80,29 +90,44 @@ Originally generated from [template-cursor-nextjs-firebase](https://github.com/m
 | `npm run dev` | Start the dev server |
 | `npm run build` / `npm run start` | Production build / serve |
 | `npm run lint` | ESLint (next lint) |
-| `npm run test:rules` | Firestore + Storage rules tests in the Firebase emulator (needs Java; `firebase-tools@13` if only Java 11 is available) |
+| `npm run test:rules` | Firestore + Storage security-rules tests (emulator) |
+| `npm run test:mcp` | MCP tool tests against the Firestore emulator (real tool code, via `tsx`) |
+| `npm run test:oauth` | OAuth flow tests against the Firestore + Auth emulators (via `tsx`) |
+| `npm run test:migration` | Legacy-todo → Spaces migration smoke test (emulator) |
+| `npm run migrate:legacy` | One-time admin migration of all users' legacy todos into spaces |
+
+> The `firebase` CLI isn't installed globally — run the emulator/deploy commands via `npx -y firebase-tools@13` (needs a JDK; v13 works with Java 11).
 
 ## Deployment
 
-- **App**: merges to `main` deploy automatically via Vercel
-- **Firestore rules**: `firebase deploy --only firestore:rules`
-- **Storage rules**: `firebase deploy --only storage` (once Storage is enabled in the Firebase console)
-- **Cloud Functions**: `cd functions && npm run deploy`
+- **App**: merges to `main` deploy automatically via Vercel.
+- **Firestore rules**: `npx -y firebase-tools@13 deploy --only firestore:rules`
+- **Storage rules**: `npx -y firebase-tools@13 deploy --only storage` (once Storage is enabled in the Firebase console)
+- **Cloud Functions**: `npx -y firebase-tools@13 deploy --only functions`
 
 ## Project structure
 
 ```
 src/
-  app/                  # Next.js App Router (login, (protected)/*, api/)
-  components/           # UI components (TodoList, Todo, ShareTodo, …)
+  app/
+    (protected)/{todos,contacts,settings}/   # authed pages (/todos = the Spaces shell)
+    oauth/authorize/                         # OAuth consent page
+    .well-known/                             # OAuth discovery metadata
+    api/
+      mcp/sse/                               # MCP endpoint (mcp-handler)
+      oauth/{register,token,authorize/confirm}/  # OAuth Authorization Server
+      user/apiKey/                           # personal API keys
+  components/
+    shell/                                   # Spaces UI: heute/, list/, board/ + mobile shell
   lib/
-    contexts/           # Auth, Theme, Error providers
-    firebase/           # client SDK init, admin SDK init, data helpers
-    hooks/              # useAuth, useError, useTiptapConfig
-    mcp/                # MCP server: auth guard, schemas, tool logic, sessions
-    tiptap/             # mention/hashtag extensions, link security
-functions/              # Cloud Functions (invite e-mails)
-tests/                  # emulator-based security-rules tests
-firestore.rules         # Firestore security rules
-storage.rules           # Storage security rules
+    contexts/   # Spaces, Todos, Daily, Auth, Theme, Toast, Error providers
+    firebase/   # client SDK init, admin SDK init, data helpers
+    mcp/        # auth guard, admin data layer, tool logic, request context
+    oauth/      # tokens (JWT), PKCE, admin stores, config
+    tiptap/     # mention/hashtag extensions, link security
+functions/      # Cloud Functions (invite e-mails)
+tests/          # emulator tests: rules, mcp, oauth, migration
+docs/           # design handoff + concept/spec documents
+firestore.rules # Firestore security rules (the authority)
+storage.rules   # Storage security rules
 ```


### PR DESCRIPTION
## Summary

The README was stale — it described the pre-redesign UI ("My Todos / Shared with me", a mentions feed) and the two **mock** MCP tools. Updated to reflect the current app:

- **Spaces** as the organizing unit (Heute / Liste / Board; desktop + mobile shells).
- **MCP server**: stateless streamable HTTP via `mcp-handler`; the **10** Firestore-backed, member-gated tools; **three auth methods** (shared token / personal API key / OAuth).
- **OAuth connector**: discovery, DCR, authorize + consent (Firebase login), token (PKCE), JWT access tokens.
- Tech stack (`mcp-handler`, `jose`, firebase-admin v13, Node 24), env (`OAUTH_SIGNING_SECRET`), scripts (`test:mcp`/`test:oauth`/`test:migration`/`migrate:legacy`), firebase CLI via `npx`, and the current project structure.

Docs-only — merges without waiting for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)