### PR TITLE
docs: OAuth Device Authorization Grant (RFC 8628) — concept + spec

### DIFF
--- a/docs/01-konzept-oauth-device-grant.md
+++ b/docs/01-konzept-oauth-device-grant.md
@@ -1,0 +1,134 @@
+# Konzept: OAuth 2.0 Device Authorization Grant (RFC 8628)
+
+## 1. Zusammenfassung
+
+aido soll den **OAuth 2.0 Device Authorization Grant** (RFC 8628) als zusätzlichen
+Grant-Type seines bestehenden Authorization Servers anbieten. Damit kann sich ein
+Client auf einem Gerät, das keine sichere Browser-Anmeldung durchführen soll
+(z.B. ein Arbeitsrechner hinter einem TLS-aufbrechenden Firmenproxy oder ein
+headless CLI), authentifizieren, indem **Login und Consent auf einem zweiten,
+vertrauenswürdigen Gerät** (Handy über Mobilfunk) erfolgen. Der ursprüngliche
+Client pollt nur den Token-Endpoint und erhält am Ende ein aido-Access-Token.
+
+## 2. Problemstellung
+
+Aido wird teils aus Umgebungen genutzt, in denen ein Unternehmensproxy mit
+eigenem Root-Zertifikat sämtlichen TLS-Verkehr als Man-in-the-Middle mitlesen
+kann. Dass der Proxy die **aido-Daten** mitliest, ist für den Nutzer akzeptabel.
+Nicht akzeptabel ist jedoch, die **Google-Anmeldung** (Firebase Auth) über diesen
+Kanal laufen zu lassen, weil dabei das Google-Passwort bzw. die Google-Session
+für den Proxy sichtbar würden — ein ungleich höherwertiges Geheimnis als eine
+einzelne aido-Session.
+
+Die heute vorhandenen Anmeldewege decken diesen Fall nicht sauber ab:
+
+- **Web-UI**: erfordert eine clientseitige Firebase-Session → Google-Login im
+  Arbeitsbrowser → Proxy sieht das Google-Credential.
+- **Personal API Key** (MCP): löst den Fall zwar (Key wird auf einem Trusted
+  Device erzeugt), ist aber ein langlebiges Bearer-Secret, das manuell kopiert
+  werden muss, keine Rotation kennt und außerhalb des OAuth-Standards liegt.
+
+Es fehlt ein **standardkonformer, entkoppelter Anmeldeweg**, bei dem das
+Google-Credential den unsicheren Kanal nie berührt.
+
+## 3. Zielsetzung
+
+- Ein Client auf einem unsicheren/eingeschränkten Gerät kann ein aido-OAuth-
+  Access-Token erhalten, **ohne dass das Google-Credential den Proxy passiert**
+  (Login + Consent ausschließlich auf dem Zweitgerät).
+- Vollständig RFC-8628-konform (Device Authorization Endpoint, `user_code`/
+  `device_code`, Polling am Token-Endpoint mit `authorization_pending`/
+  `slow_down`/`access_denied`/`expired_token`).
+- **Maximale Wiederverwendung** des bestehenden OAuth-Servers: gleiche
+  Token-Ausstellung (JWT + Refresh-Rotation), gleiche Consent-UI, gleicher
+  Admin-SDK-Store, gleiche `firestore.rules`-Disziplin.
+- Resultierende Tokens sind **aido-scoped, kurzlebig und widerrufbar** (gleiches
+  Sicherheitsprofil wie der Authorization-Code-Flow).
+- Optionaler Andockpunkt für **DPoP / sender-constrained Tokens** als spätere
+  Härtung (nicht Teil des Kerns).
+
+Messbar erreicht, wenn: ein CLI-/Device-Client am Arbeitsrechner per
+`device_code`-Grant ein gültiges MCP-Token erhält, während der Firmenproxy
+zu keinem Zeitpunkt das Google-Credential zu sehen bekommt.
+
+## 4. Lösungsidee
+
+Erweiterung des vorhandenen Authorization Servers um den Device-Flow:
+
+1. **Device Authorization Endpoint** (`POST /api/oauth/device_authorization`):
+   nimmt `client_id` (+ `scope`), erzeugt ein `device_code` (opak, lang) und ein
+   `user_code` (kurz, menschenlesbar), legt beide mit Status `pending` im
+   Admin-SDK-Store ab und liefert zusätzlich `verification_uri`,
+   `verification_uri_complete`, `expires_in`, `interval`.
+2. **Verifikationsseite** (`/device`): der Nutzer öffnet sie auf dem Zweitgerät
+   (Mobilfunk), meldet sich mit dem bestehenden Firebase-Google-Login an, gibt den
+   `user_code` ein und bestätigt im Consent. Auf „Erlauben" wird das `device_code`
+   serverseitig auf `approved` + `uid` gesetzt (über einen Confirm-Endpoint, der
+   das Firebase-ID-Token wie beim Authorization-Code-Flow verifiziert).
+3. **Token-Endpoint** (`POST /api/oauth/token`): neuer Zweig
+   `grant_type=urn:ietf:params:oauth:grant-type:device_code`. Pollt der Client,
+   wird je nach Status `authorization_pending` / `slow_down` / `access_denied` /
+   `expired_token` geantwortet — und nach Approve die **identische**
+   `issueTokens`-Ausgabe wie beim Authorization-Code-Flow (Access-JWT +
+   rotierender Refresh-Token), `device_code` wird single-use konsumiert.
+4. **Discovery/Rules**: `device_authorization_endpoint` + der neue Grant-Type
+   werden in der AS-Metadata (RFC 8414) ergänzt; die neue Collection
+   `oauthDeviceCodes` wird in `firestore.rules` wie die anderen OAuth-Collections
+   komplett gesperrt (`allow read, write: if false`).
+
+Der Login auf dem Zweitgerät (Mobilfunk) hält das Google-Credential vom Proxy
+fern; der unsichere Client sieht nur das finale, scoped Token.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Art der Betroffenheit |
+|---|---|---|
+| OAuth-Config | `src/lib/oauth/config.ts` | Erweitern: `oauthDeviceCodes`-Collection, Device-TTL, Poll-`interval`, `user_code`-Format |
+| OAuth-Store | `src/lib/oauth/store.ts` | Neu: `createDeviceCode`, Lookup per `user_code`, `approveDeviceCode`/`denyDeviceCode`, `pollDeviceCode`/`consumeDeviceCode` |
+| Device-Auth-Endpoint | `src/app/api/oauth/device_authorization/route.ts` (neu) | Neu: RFC 8628 §3.1/§3.2 |
+| Token-Endpoint | `src/app/api/oauth/token/route.ts` | Erweitern: `device_code`-Grant-Zweig inkl. Polling-Fehlercodes |
+| Verifikationsseite | `src/app/device/page.tsx` + Form-Komponente (neu) | Neu: `user_code`-Eingabe, Consent (Wiederverwendung der `ConsentForm`-Logik) |
+| Device-Confirm-Endpoint | `src/app/api/oauth/device/confirm/route.ts` (neu) | Neu: ID-Token → uid, `approveDeviceCode` |
+| AS-Metadata | `src/app/.well-known/oauth-authorization-server/route.ts` | Erweitern: `device_authorization_endpoint`, Grant-Type ergänzen |
+| Firestore-Rules | `firestore.rules` | Neu: `oauthDeviceCodes` sperren |
+| Tests | `tests/` | Neu: Device-Flow-Pfade (Happy Path, Polling-Zustände, Expiry, Replay) |
+
+Unverändert wiederverwendet: `src/lib/oauth/tokens.ts` (Token-Signatur),
+`issueTokens` im Token-Endpoint, die Firebase-ID-Token-Verifikation aus
+`authorize/confirm`, `src/lib/mcp/auth.ts` (akzeptiert das resultierende
+OAuth-Token bereits).
+
+## 6. Abgrenzung
+
+Nicht Teil dieser Anforderung:
+
+- **Web-UI-Login am Arbeitsrechner.** Der Device Grant liefert ein OAuth-Token
+  für den **MCP-Resource-Server** (`/api/mcp/sse`), keine clientseitige
+  Firebase-Session. Eine Anmeldung in der Web-UI ohne Google-über-Proxy wäre ein
+  separates Thema (Firebase-Custom-Token-Handoff) und ist hier ausdrücklich
+  ausgeklammert.
+- **DPoP / sender-constrained Tokens.** Nur als optionaler, klar getrennter
+  Folge-Schritt vorgesehen (schützt die Session zusätzlich gegen einen aktiven
+  MITM). Der Kern stellt weiterhin reine Bearer-Tokens aus.
+- **Neue Scopes / Berechtigungsmodell.** Es bleibt beim einzigen Scope
+  `aido.tools`.
+- **Ablösung** des Personal-API-Key- oder Authorization-Code-Flows. Der Device
+  Grant kommt additiv hinzu.
+
+## 7. Offene Fragen
+
+1. **Client-Registrierung für Device-Clients.** Die DCR (`/api/oauth/register`)
+   verlangt aktuell eine nicht-leere `redirect_uris`-Liste. Device-Clients haben
+   keine Redirect-URI. Vorschlag (Default-Annahme): `redirect_uris` optional
+   machen, wenn `grant_types` den Device-Code-Grant enthält — alternativ ein fest
+   konfigurierter First-Party-Public-Client für das aido-CLI. → Bitte bestätigen.
+2. **Pfad/`verification_uri`.** Vorschlag: kurzes, top-level `/device` (gut
+   tippbar) statt `/oauth/device`. `verification_uri_complete` =
+   `/device?user_code=…` (für QR). → ok?
+3. **`user_code`-Format.** Vorschlag: 8 Zeichen, gruppiert `WDJB-MJHT`, Alphabet
+   ohne mehrdeutige Zeichen (kein `0/O/1/I`). → ok?
+4. **Anzeige `user_code` ↔ Bestätigung.** Soll die `/device`-Seite den Client-
+   Namen (aus DCR) im Consent anzeigen, damit der Nutzer weiß, welches Gerät er
+   freigibt? (Empfohlen ja.)
+5. **DPoP jetzt mitdenken oder strikt später?** Annahme: später als eigenes
+   Issue; im Store/Token-Pfad nur die Erweiterbarkeit nicht verbauen.

--- a/docs/02-ist-analyse-oauth-device-grant.md
+++ b/docs/02-ist-analyse-oauth-device-grant.md
@@ -1,0 +1,89 @@
+# Ist-Analyse: OAuth 2.0 Device Authorization Grant (RFC 8628)
+
+## 1. Aktueller Zustand
+
+aido betreibt seit Epic #157 (Issues #150–#155) einen eigenen **OAuth 2.0
+Authorization Server**. aido ist gleichzeitig Authorization Server und Resource
+Server für seinen MCP-Endpoint (`/api/mcp/sse`). Implementiert sind heute:
+
+- **Dynamic Client Registration** (RFC 7591) — `POST /api/oauth/register`.
+- **Authorization Code Flow mit PKCE (S256)** — Consent-Seite `/oauth/authorize`
+  + `POST /api/oauth/authorize/confirm`.
+- **Token-Endpoint** — `POST /api/oauth/token` mit den Grants
+  `authorization_code` und `refresh_token` (mit Rotation).
+- **Discovery** — RFC 8414 (`/.well-known/oauth-authorization-server`) und
+  RFC 9728 (`/.well-known/oauth-protected-resource`).
+
+Der Nutzer-Login selbst läuft über **Firebase Auth (Google)**: die Consent-Seite
+meldet den Nutzer per Firebase an und schickt dessen **ID-Token** an den
+Confirm-Endpoint, der es mit dem Admin-SDK (`verifyIdToken`) zu einer `uid`
+auflöst. Die `uid` (`sub` im Access-JWT) ist die alleinige Autorisierungsbasis.
+
+Es gibt **keinen Device Authorization Grant**. Ein Client, der keinen Browser-
+Redirect-Flow durchführen kann/will (CLI, headless, oder bewusst kein
+Google-Login über einen MITM-Proxy), hat heute nur den Personal API Key als
+Ausweg.
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/lib/oauth/config.ts` | `OAUTH`-Konstanten (Collections, Scope `aido.tools`, TTLs, Refresh-Prefix `aidor_`), `resourceUrl()`, `requestOrigin()` | Wird um Device-Code-Collection, TTL, `interval`, `user_code`-Format erweitert |
+| `src/lib/oauth/store.ts` | Admin-SDK-Store: `createClient`/`getClient`, `createAuthCode`/`consumeAuthCode` (Transaktion, single-use), `createRefreshToken`/`consumeRefreshToken`/`revokeRefreshToken` (gehasht) | Vorbild + Erweiterung um Device-Code-Funktionen |
+| `src/lib/oauth/tokens.ts` | `signAccessToken`/`verifyAccessToken` (HS256/jose, `OAUTH_SIGNING_SECRET`, `at+jwt`, `sub`=uid, `iss`/`aud` aus Origin) | **Unverändert** wiederverwendet |
+| `src/lib/oauth/pkce.ts` | `verifyPkceS256` | Im Device-Flow nicht zwingend (kein Redirect); ggf. optional |
+| `src/app/api/oauth/token/route.ts` | Token-Endpoint; `issueTokens()`-Helper (Access-JWT + Refresh); Grant-Switch; `rateLimit`; CORS | **Zentral**: neuer `device_code`-Grant-Zweig; `issueTokens` wird wiederverwendet |
+| `src/app/api/oauth/authorize/confirm/route.ts` | Verifiziert Firebase-ID-Token → uid, validiert Client/redirect, mintet Auth-Code | Vorbild für den Device-Confirm-Endpoint (gleiche ID-Token-Verifikation) |
+| `src/app/oauth/authorize/page.tsx` + `ConsentForm.tsx` | Serverseitig validierte Consent-Seite; Firebase-Google-Login; postet ID-Token an Confirm | Vorbild/Wiederverwendung für die `/device`-Seite (Login + Consent-UI, Tokens via `bg-bg`, `bg-accent`, …) |
+| `src/app/.well-known/oauth-authorization-server/route.ts` | RFC-8414-Metadata: `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `grant_types_supported` | Erweitern: `device_authorization_endpoint`, Grant-Type ergänzen |
+| `src/app/api/oauth/register/route.ts` | DCR; verlangt nicht-leere `redirect_uris` (http/https, kein Fragment) | Ggf. anpassen: `redirect_uris` für Device-Clients optional |
+| `src/lib/mcp/auth.ts` | `authenticateMcp` akzeptiert Shared Secret, Personal API Key **und OAuth-Access-Token** (`resolveOAuthToken`) | **Unverändert** — akzeptiert das vom Device-Grant ausgestellte Token bereits |
+| `firestore.rules` | `oauthClients`/`oauthCodes`/`oauthRefreshTokens` jeweils `allow read, write: if false` | Erweitern: `oauthDeviceCodes` ebenso sperren |
+| `src/lib/apiKeys.ts` | `rateLimit(key, {max, windowMs})`, Hashing | `rateLimit` für den Device-Auth-Endpoint wiederverwenden |
+
+## 3. Bestehende Abhängigkeiten
+
+- **Intern:** Token-/Confirm-/Authorize-Routen → `src/lib/oauth/*`; OAuth-Store →
+  Admin SDK (`getAdminDb`); Confirm/Consent → Firebase Auth (`getAdminAuth` /
+  Client-SDK Google-Login); MCP-Auth → `verifyAccessToken`.
+- **Extern:** `jose` (JWT-Signatur, ESM), `firebase-admin` (Firestore-Store +
+  `verifyIdToken`), `mcp-handler` (`getPublicOrigin` für Discovery/Origin),
+  Firestore als persistenter Store für alle AS-Artefakte.
+- **Konfiguration:** `OAUTH_SIGNING_SECRET` (Pflicht für Token-Signatur),
+  `FIREBASE_SERVICE_ACCOUNT_KEY` (Admin SDK; ohne ihn 503).
+
+## 4. Bekannte Einschränkungen
+
+- **Serverless-Persistenz:** Anders als die MCP-Sessions (in-memory, nicht
+  durabel) liegt der OAuth-State bereits in Firestore — der Device-Code-Store muss
+  ebenfalls Firestore nutzen, damit Polling über mehrere Instanzen hinweg
+  funktioniert.
+- **DCR erzwingt `redirect_uris`:** der Register-Endpoint lehnt eine leere Liste
+  ab — für reine Device-Clients ist das anzupassen oder zu umgehen.
+- **Symmetrische Token-Signatur (HS256):** unverändert ausreichend, da aido AS und
+  RS zugleich ist. Für DPoP wäre kein Wechsel nötig (DPoP bindet über `cnf`/`jkt`,
+  nicht über den AT-Signaturalgorithmus).
+- **Rate-Limiting** ist in-memory pro Instanz (`rateLimit`) — gegen Polling-Abuse
+  ausreichend, aber nicht instanzübergreifend exakt. Das `interval`/`slow_down`
+  des Device-Flows ist die primäre Polling-Drossel.
+- **Java/Tooling:** Rules-Tests laufen nur über `firebase-tools@13` (Java 11),
+  siehe CLAUDE.md.
+
+## 5. Risiken bei Änderung
+
+- **Token-Endpoint** ist sicherheitskritisch und wird von Claude/MCP-Clients
+  produktiv genutzt. Der neue Grant-Zweig darf die bestehenden `authorization_code`/
+  `refresh_token`-Pfade nicht verändern (nur additiv); `issueTokens` bleibt
+  unangetastet.
+- **Polling-Missbrauch / DoS:** ohne korrektes `interval`+`slow_down`+`expires_in`
+  kann ein Client den Endpoint fluten. `expired_token` + single-use-Konsum des
+  `device_code` müssen sauber greifen.
+- **`user_code`-Rate/Entropie:** ein zu kurzer/schwacher `user_code` lädt zu
+  Brute-Force auf der `/device`-Seite ein → Eingabe-Rate-Limit + kurze TTL nötig.
+- **firestore.rules:** wird die neue Collection nicht gesperrt, wäre der
+  Device-Code-State clientseitig lesbar. Regel **und** Rules-Test gemeinsam
+  ergänzen (CLAUDE.md-Vorgabe).
+- **DCR-Lockerung:** `redirect_uris` optional zu machen, darf den
+  Authorization-Code-Flow (der sie zwingend braucht) nicht aufweichen.
+- **Discovery-Kompatibilität:** zusätzliche Felder/Grants in der AS-Metadata sind
+  additiv und für bestehende Clients unkritisch.

--- a/docs/03-anforderungsanalyse-oauth-device-grant.md
+++ b/docs/03-anforderungsanalyse-oauth-device-grant.md
@@ -1,0 +1,72 @@
+# Anforderungsanalyse: OAuth 2.0 Device Authorization Grant (RFC 8628)
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Device Authorization Endpoint | Muss | `POST /api/oauth/device_authorization` nimmt `client_id` (+ optional `scope`) und liefert `device_code`, `user_code`, `verification_uri`, `verification_uri_complete`, `expires_in`, `interval` (RFC 8628 §3.1/§3.2). |
+| FA-02 | Device-Code-Store | Muss | Neue Admin-SDK-Collection `oauthDeviceCodes`: persistiert `user_code`, `client_id`, `scope`, `status` (`pending`/`approved`/`denied`), `uid`, `interval`, `lastPolledAt`, `expiresAt`. Lookup per `device_code` **und** per `user_code`. |
+| FA-03 | Verifikationsseite `/device` | Muss | Nutzer öffnet `/device` (auf Trusted Device), meldet sich per Firebase-Google-Login an, gibt den `user_code` ein, sieht den Client-Namen und bestätigt/lehnt ab. `verification_uri_complete` füllt den Code vor. |
+| FA-04 | Device-Confirm-Endpoint | Muss | `POST /api/oauth/device/confirm`: verifiziert das Firebase-ID-Token → `uid`, schlägt den `user_code` nach, setzt den Datensatz auf `approved` + `uid` (bzw. `denied`). |
+| FA-05 | Token-Endpoint: Device-Grant | Muss | `grant_type=urn:ietf:params:oauth:grant-type:device_code` mit `device_code`+`client_id`. Antworten: `authorization_pending`, `slow_down`, `access_denied`, `expired_token` (RFC 8628 §3.5) und bei Erfolg Access-JWT + Refresh-Token via vorhandenem `issueTokens`. |
+| FA-06 | Single-use & Expiry | Muss | `device_code` wird bei erfolgreicher Ausgabe konsumiert (kein zweites Token); abgelaufene Codes → `expired_token`. |
+| FA-07 | Polling-Drossel | Muss | Pollt der Client schneller als `interval`, antwortet der Endpoint `slow_down`; `lastPolledAt` wird geführt. |
+| FA-08 | Discovery-Erweiterung | Muss | `/.well-known/oauth-authorization-server` weist `device_authorization_endpoint` aus und ergänzt `urn:ietf:params:oauth:grant-type:device_code` in `grant_types_supported`. |
+| FA-09 | firestore.rules | Muss | `oauthDeviceCodes` wird vollständig gesperrt (`allow read, write: if false`), analog der übrigen OAuth-Collections. |
+| FA-10 | DCR für Device-Clients | Soll | `/api/oauth/register` akzeptiert Clients ohne `redirect_uris`, sofern `grant_types` den Device-Code-Grant enthält (oder ein dedizierter First-Party-Client). |
+| FA-11 | Client-Identität im Consent | Soll | Die `/device`-Seite zeigt den registrierten `client_name`, damit der Nutzer weiß, welches Gerät er freigibt. |
+| FA-12 | DPoP-Bindung | Kann | Optionaler `dpop_jkt`/`cnf`-Pfad: Device-Client schickt einen DPoP-Proof, das ausgestellte Token wird sender-constrained. Eigenes Folge-Issue. |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Google-Credential bleibt off-proxy | Sicherheit | Login + Consent laufen ausschließlich auf der `/device`-Seite (Zweitgerät). Der pollende Client führt **keinen** Google-Login durch. |
+| NFA-02 | Bestehende Grants unverändert | Kompatibilität | `authorization_code`/`refresh_token`-Pfade und `issueTokens` bleiben funktional unverändert (nur additive Ergänzung). |
+| NFA-03 | Brute-Force-Schutz `user_code` | Sicherheit | Ausreichende Entropie (≥ ~8 Zeichen, ambig-freies Alphabet), kurze TTL, Eingabe-Rate-Limit auf der `/device`-Seite. |
+| NFA-04 | DoS-/Abuse-Schutz | Sicherheit/Stabilität | `rateLimit` auf `device_authorization`; Polling über `interval`/`slow_down`/`expires_in` begrenzt. |
+| NFA-05 | Token-Profil identisch | Sicherheit | Ausgestellte Tokens sind kurzlebig (1 h), refresh-rotiert (30 d), aido-scoped und über `revokeRefreshToken` widerrufbar — wie beim Code-Flow. |
+| NFA-06 | Persistenz serverless-tauglich | Zuverlässigkeit | Device-Code-State in Firestore, damit Polling über mehrere Instanzen funktioniert. |
+| NFA-07 | Testbarkeit | Wartbarkeit | Endpoints als Web `Request`/`Response` (kein `next/server`-Zwang) für isolierte Tests, analog der bestehenden OAuth-Routen. |
+| NFA-08 | Standardkonformität | Interoperabilität | Strikte Einhaltung von RFC 8628 (Feldnamen, Fehlercodes, HTTP-Status). |
+
+## 3. Akzeptanzkriterien
+
+- [ ] Ein Device-Client erhält über `device_authorization` ein `device_code` +
+      kurzes `user_code` + korrekte `verification_uri(_complete)`/`expires_in`/`interval`.
+- [ ] Vor Bestätigung liefert der Token-Endpoint `authorization_pending`; zu
+      schnelles Polling liefert `slow_down`.
+- [ ] Nach Login + Consent auf `/device` (Zweitgerät) liefert der Token-Endpoint
+      ein gültiges Access-JWT (`sub`=uid) **und** einen Refresh-Token.
+- [ ] Das ausgestellte Token wird vom MCP-Endpoint (`authenticateMcp`) als
+      `principal.kind === "user"` mit korrekter `uid` akzeptiert.
+- [ ] Ein bereits eingelöstes `device_code` liefert beim erneuten Polling kein
+      zweites Token; ein abgelaufenes liefert `expired_token`; ein abgelehntes
+      liefert `access_denied`.
+- [ ] Der `user_code` ist menschenlesbar, ambig-frei und vorausfüllbar via
+      `verification_uri_complete`.
+- [ ] `oauthDeviceCodes` ist clientseitig weder les- noch schreibbar (Rules-Test
+      grün).
+- [ ] Die AS-Metadata weist Endpoint + Grant-Type aus.
+- [ ] Während des gesamten Flows passiert der Google-Login nie über den Client-
+      (Proxy-)Kanal — verifiziert anhand des Ablaufs (Login nur auf `/device`).
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Baut auf dem bestehenden OAuth-AS (Epic #157, Issues #150–#155) auf;
+  insbesondere Token-Endpoint (#154), Confirm/Consent (#153), DCR (#152),
+  Discovery (#151), OAuth-Token-Akzeptanz im MCP (#155).
+- FA-10 (DCR-Lockerung) ist Voraussetzung dafür, dass ein reiner Device-Client
+  überhaupt eine `client_id` bekommt — alternativ ein fest hinterlegter
+  First-Party-Client.
+- FA-12 (DPoP) ist optional und unabhängig; setzt aber auf dem hier gebauten
+  Token-Ausgabepfad auf.
+
+## 5. Priorisierung
+
+1. **Muss (Kern-Flow):** FA-01, FA-02, FA-05, FA-06, FA-07 — der lauffähige
+   Device-Grant.
+2. **Muss (Sicherheit/Sichtbarkeit):** FA-09, FA-08, FA-03, FA-04 — Consent-
+   Oberfläche + Discovery + Rules.
+3. **Soll:** FA-10, FA-11 — saubere Client-Registrierung und Consent-Transparenz.
+4. **Kann/Später:** FA-12 (DPoP) — zusätzliche Härtung gegen aktiven MITM.

--- a/docs/04-spezifikation-oauth-device-grant.md
+++ b/docs/04-spezifikation-oauth-device-grant.md
@@ -1,0 +1,229 @@
+# Spezifikation: OAuth 2.0 Device Authorization Grant (RFC 8628)
+
+## 1. Übersicht
+
+Der bestehende aido-Authorization-Server (Epic #157) wird um den **Device
+Authorization Grant** erweitert. Ein Client auf einem unsicheren/eingeschränkten
+Gerät (Arbeitsrechner hinter MITM-Proxy, CLI, headless) erhält ein aido-Access-
+Token, indem Login + Consent auf einem **zweiten, vertrauenswürdigen Gerät**
+erfolgen. Es werden ein neuer Endpoint, ein neuer Store, eine Consent-Seite und
+ein neuer Token-Grant-Zweig ergänzt; Token-Ausstellung, Firebase-ID-Token-
+Verifikation und MCP-Token-Akzeptanz werden unverändert wiederverwendet.
+
+Vollständiger Ablauf (RFC 8628):
+
+```
+Client (Device, hinter Proxy)        aido AS              Zweitgerät (Mobilfunk, Trusted)
+  │ ① POST /api/oauth/device_authorization
+  │    client_id, scope
+  │ ─────────────────────────▶ erzeugt device_code + user_code (pending)
+  │ ② ◀── device_code, user_code, verification_uri(_complete),
+  │        expires_in, interval
+  │ ③ zeigt user_code + URL/QR an
+  │                                        ④ öffnet /device (KEIN Proxy)
+  │                                        ⑤ Firebase-Google-Login (sicher)
+  │                                        ⑥ user_code eingeben + Erlauben
+  │                            ◀──────────── POST /api/oauth/device/confirm
+  │                            setzt approved(uid)
+  │ ⑦ POST /api/oauth/token (Polling, grant_type=…device_code)
+  │ ◀── authorization_pending | slow_down …
+  │ ⑧ ◀── access_token (+ refresh_token)   nach Approve, device_code single-use
+```
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+Additive Erweiterung; keine Änderung an `authorization_code`/`refresh_token`.
+
+**Neue Endpoints**
+- `POST /api/oauth/device_authorization` — Device Authorization Endpoint.
+- `POST /api/oauth/device/confirm` — Approve/Deny vom Zweitgerät.
+- Seite `GET /device` — `user_code`-Eingabe + Login + Consent (Client-Komponente
+  analog `ConsentForm.tsx`).
+
+**Erweiterte Endpoints**
+- `POST /api/oauth/token` — neuer Grant-Zweig `device_code`.
+- `/.well-known/oauth-authorization-server` — Endpoint + Grant-Type ergänzt.
+- `POST /api/oauth/register` — `redirect_uris` für Device-Clients optional (FA-10).
+
+**Wiederverwendet (unverändert)**
+- `signAccessToken` / `issueTokens` (Access-JWT + Refresh-Rotation).
+- `verifyIdToken` (Firebase-ID-Token → uid), wie in `authorize/confirm`.
+- `src/lib/mcp/auth.ts` akzeptiert das Ergebnis-Token bereits (`resolveOAuthToken`).
+- `rateLimit` aus `src/lib/apiKeys.ts`.
+
+### 2.2 Datenmodell
+
+Neue Firestore-Collection **`oauthDeviceCodes`**, ausschließlich über den
+Admin-SDK-Store beschrieben. Doc-ID = SHA-256(`device_code`) (analog Refresh-
+Tokens — der `device_code` selbst wird nicht im Klartext persistiert). Der
+`user_code` wird als indiziertes Feld geführt (Lookup per Gleichheit).
+
+```
+oauthDeviceCodes/{sha256(device_code)}
+  userCode:     string   // kurzes, ambig-freies Code-Format, z.B. "WDJB-MJHT"
+  clientId:     string
+  scope:        string    // default OAUTH.scope ("aido.tools")
+  status:       "pending" | "approved" | "denied"
+  uid:          string | null   // gesetzt bei approve
+  interval:     number    // Sekunden (Default 5)
+  lastPolledAt: number    // ms epoch, für slow_down
+  expiresAt:    number    // ms epoch
+  createdAt:    serverTimestamp
+```
+
+`config.ts`-Ergänzung:
+
+```ts
+export const OAUTH = {
+  collections: {
+    clients: "oauthClients",
+    codes: "oauthCodes",
+    refreshTokens: "oauthRefreshTokens",
+    deviceCodes: "oauthDeviceCodes",          // neu
+  },
+  // … bestehend …
+  deviceCodeTtlSec: 10 * 60,                   // 10 min
+  devicePollIntervalSec: 5,                    // RFC 8628 Default
+  userCodeAlphabet: "BCDFGHJKLMNPQRSTVWXZ",    // ohne Vokale/0/O/1/I
+  userCodeLength: 8,                           // gruppiert "XXXX-XXXX"
+} as const;
+```
+
+### 2.3 Schnittstellen
+
+**① `POST /api/oauth/device_authorization`** (form-encoded, RFC 8628 §3.1/§3.2)
+
+Request: `client_id`, optional `scope`.
+Response `200`:
+```json
+{
+  "device_code": "GmRhmhc...DnyEys",
+  "user_code": "WDJB-MJHT",
+  "verification_uri": "https://<origin>/device",
+  "verification_uri_complete": "https://<origin>/device?user_code=WDJB-MJHT",
+  "expires_in": 600,
+  "interval": 5
+}
+```
+Fehler: `invalid_client` (unbekannte `client_id`), `rate_limited`.
+
+**④/⑥ `POST /api/oauth/device/confirm`** (JSON, intern von `/device`)
+
+Request: `{ idToken, userCode, action: "approve" | "deny" }`.
+Ablauf: `verifyIdToken(idToken)` → uid; `userCode` nachschlagen (existiert,
+nicht abgelaufen, `pending`); Status auf `approved`+uid bzw. `denied` setzen.
+Response `200`: `{ status: "approved" | "denied" }`.
+Fehler: `access_denied` (ID-Token ungültig), `invalid_request` (Code unbekannt/
+abgelaufen), `server_error` (Admin SDK fehlt).
+
+**⑦/⑧ `POST /api/oauth/token`** — neuer Zweig:
+```
+grant_type=urn:ietf:params:oauth:grant-type:device_code
+device_code=<…>
+client_id=<…>
+```
+Antwort-Matrix (HTTP 400 mit `error`, außer Erfolg):
+
+| Zustand | `error` |
+|---|---|
+| nicht existent / abgelaufen | `expired_token` |
+| zu schnell gepollt | `slow_down` |
+| `pending` | `authorization_pending` |
+| `denied` | `access_denied` |
+| `approved` | **200** Access-JWT + Refresh-Token (`issueTokens`), Code konsumiert |
+
+**Store-API (`src/lib/oauth/store.ts`, neu)**
+```ts
+createDeviceCode(input: { clientId; scope }):
+  Promise<{ deviceCode; userCode; expiresIn; interval }>
+approveDeviceCode(userCode: string, uid: string): Promise<boolean>   // false wenn unbekannt/abgelaufen/nicht pending
+denyDeviceCode(userCode: string): Promise<boolean>
+pollDeviceCode(deviceCode: string):
+  Promise<{ kind: "pending" | "slow_down" | "denied" | "expired" }
+         | { kind: "approved"; uid; clientId; scope }>
+// "approved" konsumiert den Code atomar (Transaktion), damit kein zweites Token entsteht.
+```
+
+**Discovery-Ergänzung**
+```jsonc
+{
+  "device_authorization_endpoint": "<origin>/api/oauth/device_authorization",
+  "grant_types_supported": [
+    "authorization_code", "refresh_token",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ]
+}
+```
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/oauth/config.ts` | `deviceCodes`-Collection, TTL, `interval`, `userCode`-Format | Klein |
+| `src/lib/oauth/store.ts` | `createDeviceCode`/`approveDeviceCode`/`denyDeviceCode`/`pollDeviceCode` (+ `user_code`-Generator, sha256-Doc-ID, atomarer Approve-Konsum) | Mittel |
+| `src/app/api/oauth/device_authorization/route.ts` | Neuer Endpoint (Client-Validierung, `rateLimit`, CORS, Origin) | Klein |
+| `src/app/api/oauth/token/route.ts` | `device_code`-Grant-Zweig (Polling-Matrix → `issueTokens`) | Mittel |
+| `src/app/api/oauth/device/confirm/route.ts` | Neuer Confirm-Endpoint (ID-Token → uid, approve/deny) | Klein |
+| `src/app/device/page.tsx` + Form-Komponente | `user_code`-Eingabe (vorausgefüllt via Query), Firebase-Login, Consent mit `client_name`, approve/deny | Mittel |
+| `src/app/.well-known/oauth-authorization-server/route.ts` | Endpoint + Grant-Type ergänzen | Klein |
+| `src/app/api/oauth/register/route.ts` | `redirect_uris` optional bei Device-Grant (FA-10) | Klein |
+| `firestore.rules` | `oauthDeviceCodes` sperren | Klein |
+| `tests/` | Device-Flow-Tests (Happy Path, Polling-Zustände, Expiry, Replay, Rules) | Mittel |
+
+### 3.2 Reihenfolge der Implementierung
+
+1. **Config + Store** (`config.ts`, `store.ts`) inkl. `user_code`-Generator und
+   atomarem Approve-Konsum — Fundament, isoliert testbar.
+2. **firestore.rules**: `oauthDeviceCodes` sperren (+ Rules-Test) — zusammen mit
+   dem Datenmodell (CLAUDE.md-Vorgabe).
+3. **Device Authorization Endpoint** (`device_authorization/route.ts`).
+4. **Token-Endpoint Device-Grant-Zweig** (`token/route.ts`).
+5. **Device-Confirm-Endpoint** (`device/confirm/route.ts`).
+6. **`/device`-Seite** (Eingabe + Login + Consent).
+7. **Discovery + DCR-Lockerung** (Metadata, `register`).
+8. **Tests** (MCP-Tool-Test-Setup als Vorbild) + manueller End-to-End-Durchlauf.
+9. **(Optional/später) DPoP** als eigenes Issue.
+
+## 4. Testplan
+
+**Automatisiert (emulatorbasiert, `tests/`, vgl. `npm run test:mcp`)**
+- `device_authorization` liefert wohlgeformte Response (Felder, TTL, `interval`).
+- Token-Polling: `authorization_pending` vor Approve; `slow_down` bei zu schnellem
+  Polling; `approved` → gültiges JWT (`sub`=uid) + Refresh-Token.
+- Single-use: zweites Polling nach Erfolg liefert kein Token.
+- Expiry: nach `deviceCodeTtlSec` → `expired_token`.
+- Deny: `denyDeviceCode` → `access_denied`.
+- `approveDeviceCode` mit unbekanntem/abgelaufenem `user_code` → `false`.
+- Ausgestelltes Token wird von `authenticateMcp` als `user`/korrekte uid akzeptiert.
+
+**Rules (`tests/firestore-rules.test.mjs`)**
+- `oauthDeviceCodes` ist für authentifizierte Clients weder les- noch schreibbar.
+
+**Manuell (End-to-End)**
+- Device-Client (z.B. `curl`/CLI) startet Flow → `user_code`; Approve auf
+  `/device` im zweiten Browser/Handy → Client erhält Token; Google-Login passiert
+  nur auf `/device`.
+
+## 5. Migration / Deployment
+
+- **Keine Datenmigration** — additive Collection + Endpoints.
+- Reihenfolge: App zuerst (Vercel-Auto-Deploy auf `main`), **danach**
+  `firestore.rules` deployen (`npx -y firebase-tools@13 deploy --only
+  firestore:rules`) — die neue Sperrregel ist additiv und für die bestehende App
+  unkritisch.
+- **Env:** keine neuen Variablen; `OAUTH_SIGNING_SECRET` + Admin SDK wie bisher.
+- Discovery-Änderung ist abwärtskompatibel (zusätzliche Felder/Grants).
+
+## 6. Referenzen
+
+- [Konzeptdokument](01-konzept-oauth-device-grant.md)
+- [Ist-Analyse](02-ist-analyse-oauth-device-grant.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-oauth-device-grant.md)
+- RFC 8628 — OAuth 2.0 Device Authorization Grant
+- RFC 8414 — Authorization Server Metadata; RFC 7591 — Dynamic Client Registration
+- RFC 9449 — DPoP (für die optionale Härtung, FA-12)
+- Bestehender AS: Epic #157, Issues #150–#155


### PR DESCRIPTION
Concept-analysis-spec documents for adding the **OAuth 2.0 Device Authorization Grant** (RFC 8628) to aido's existing Authorization Server.

## Motivation
aido is sometimes used from an environment with a TLS-intercepting corporate proxy. Reading aido data through that proxy is acceptable, but the **Google (Firebase) login must not** — it would expose the high-value Google credential. The Device Grant lets the work machine obtain a token by polling, while **login + consent happen on a trusted second device** (phone on cellular).

## Documents (`docs/`)
- `01-konzept-oauth-device-grant.md`
- `02-ist-analyse-oauth-device-grant.md`
- `03-anforderungsanalyse-oauth-device-grant.md`
- `04-spezifikation-oauth-device-grant.md`

Builds additively on the existing AS (epic #157, #150–#155): reuses `issueTokens`, Firebase `verifyIdToken`, and the existing MCP OAuth-token acceptance. Adds `device_authorization`/`device/confirm` endpoints, a `/device` consent page, a `device_code` grant branch on the token endpoint, the `oauthDeviceCodes` store, rules + discovery.

Docs-only — implementation tracked in the follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)