### PR TITLE
docs: web login via device flow (Firebase custom token)

### DIFF
--- a/docs/01-konzept-web-device-login.md
+++ b/docs/01-konzept-web-device-login.md
@@ -1,0 +1,123 @@
+# Konzept: Web-Login per Device-Flow (Zweitgerät-Anmeldung)
+
+## 1. Zusammenfassung
+
+aido soll eine **Anmeldung der Web-UI über ein zweites, vertrauenswürdiges Gerät**
+anbieten — angelehnt an den OAuth 2.0 Device Authorization Grant (RFC 8628). Der
+Arbeitsrechner zeigt einen kurzen Code (+ QR), die eigentliche Anmeldung (Google/
+Firebase) und Bestätigung erfolgen auf dem Handy (Mobilfunk). Der Arbeitsrechner
+pollt und erhält am Ende ein **Firebase Custom Token**, das er per
+`signInWithCustomToken` zu einer **vollwertigen Web-Session** macht.
+
+> Verwandt mit, aber getrennt von Epic #175 (OAuth-Device-Grant für MCP): dort ist
+> das Abschlussartefakt ein OAuth-Access-JWT für den MCP-Resource-Server. Hier ist
+> es ein **Firebase Custom Token** für die **Web-UI-Session**. Beide nutzen dasselbe
+> Device-Flow-Muster und könnten den Code-Store später teilen.
+
+## 2. Problemstellung
+
+Aido wird teils aus Umgebungen mit TLS-aufbrechendem Firmenproxy genutzt. Dass
+der Proxy die aido-Daten mitliest, ist akzeptabel — die **Google-Anmeldung**
+(Firebase Auth) darf aber **nicht** über diesen Kanal laufen, weil sonst das
+hochwertige Google-Credential für den Proxy sichtbar würde.
+
+Die Web-UI authentifiziert sich heute ausschließlich über den **clientseitigen
+Firebase-Google-Login** im Browser. Am Arbeitsrechner würde dieser Login direkt
+durch den Proxy gehen. Der in Epic #175 entworfene Device-Grant löst das nur für
+**MCP/programmatischen** Zugriff — sein Token ist **keine Firebase-Session** und
+loggt die Web-UI nicht ein.
+
+Es fehlt ein Anmeldeweg, der eine **Firebase-Web-Session** etabliert, ohne dass
+das Google-Credential den unsicheren Kanal berührt.
+
+## 3. Zielsetzung
+
+- Der Nutzer kann sich in der aido-Web-UI am Arbeitsrechner anmelden, **ohne dass
+  der Google-Login den Proxy passiert** (Login + Consent nur auf dem Zweitgerät).
+- Ergebnis ist eine **echte Firebase-Web-Session** (wie nach normalem Google-Login)
+  — der Nutzer landet eingeloggt auf `/todos`.
+- Device-Flow-UX nach RFC-8628-Muster (kurzes `user_code`, QR, Polling mit
+  `authorization_pending`/`slow_down`/`expired_token`).
+- **Maximale Wiederverwendung**: Admin-SDK + `verifyIdToken` (wie OAuth-Confirm),
+  Consent-UI-Muster (`ConsentForm`), `firestore.rules`-Disziplin, vorhandener
+  Firebase-Client.
+- Resultierende Session ist **aido-scoped und widerrufbar**
+  (`revokeRefreshTokens`).
+
+Messbar erreicht, wenn: der Arbeitsrechner nach Approve auf dem Handy in der
+Web-UI eingeloggt ist und zu keinem Zeitpunkt ein Google-Login über den
+Proxy-Kanal stattfand.
+
+## 4. Lösungsidee
+
+Ein Device-Flow, dessen Abschlussartefakt ein Firebase Custom Token ist:
+
+1. **Start** (`POST /api/auth/device/start`): die unangemeldete Web-UI am
+   Arbeitsrechner fordert einen Code an. Server erzeugt `device_code` (opak) +
+   `user_code` (kurz), legt sie mit Status `pending` im Admin-SDK-Store ab und
+   liefert `verification_uri`, `verification_uri_complete`, `expires_in`,
+   `interval`.
+2. **Anzeige**: die Web-UI zeigt `user_code` + URL und einen **QR-Code**
+   (`verification_uri_complete`) zum Scannen mit dem Handy.
+3. **Consent auf dem Zweitgerät** (`/device`): der Nutzer öffnet die Seite am
+   Handy (Mobilfunk), meldet sich mit dem bestehenden Firebase-Google-Login an,
+   gibt/scannt den `user_code` und bestätigt. „Erlauben" postet das Firebase-ID-
+   Token an `POST /api/auth/device/confirm`, das es zu einer `uid` verifiziert und
+   den Datensatz auf `approved` + `uid` setzt.
+4. **Polling** (`POST /api/auth/device/poll`): die Web-UI pollt mit dem
+   `device_code`. Vor Bestätigung `authorization_pending`/`slow_down`; nach
+   Approve mintet der Server `getAdminAuth().createCustomToken(uid)` und liefert
+   `{ firebaseCustomToken }` (Code wird single-use konsumiert).
+5. **Session**: die Web-UI ruft `signInWithCustomToken(auth, token)` → Firebase-
+   Web-Session steht → Redirect nach `/todos`.
+
+Der Google-Login passiert ausschließlich auf dem Handy (Mobilfunk); der
+Arbeitsrechner sieht nur das Custom Token bzw. die daraus entstehende Session.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Art der Betroffenheit |
+|---|---|---|
+| Device-Login-Store | `src/lib/auth/deviceLogin.ts` (neu) | Neu: Code-Erzeugung, approve/deny, poll (atomarer Single-use-Konsum), `user_code`-Format, TTL/Interval. Collection `deviceLoginCodes` |
+| Start-Endpoint | `src/app/api/auth/device/start/route.ts` (neu) | Neu: Code anfordern (+ `rateLimit`) |
+| Confirm-Endpoint | `src/app/api/auth/device/confirm/route.ts` (neu) | Neu: ID-Token → uid, approve/deny |
+| Poll-Endpoint | `src/app/api/auth/device/poll/route.ts` (neu) | Neu: Polling-Matrix → `createCustomToken` bei Approve |
+| Consent-Seite (Handy) | `src/app/device/page.tsx` + Form (neu) | Neu: `user_code`-Eingabe, Google-Login, Approve/Deny (Muster: `ConsentForm.tsx`) |
+| Login-UI (Arbeitsrechner) | `src/app/login/*` | Erweitern: Panel „Anmelden über Zweitgerät" (Start + Code/QR + Polling + `signInWithCustomToken`) |
+| Firebase-Client | `src/lib/firebase/firebase.ts` / `useAuth` | Wiederverwendet: `signInWithCustomToken` |
+| Admin SDK | `src/lib/firebase/admin.ts` | Wiederverwendet: `getAdminAuth().verifyIdToken` + `createCustomToken` |
+| Firestore-Rules | `firestore.rules` | Neu: `deviceLoginCodes` sperren |
+| Tests | `tests/` | Neu: Device-Login-Flow (Happy Path, Polling, Expiry, Deny, Single-use, Rules) |
+
+## 6. Abgrenzung
+
+Nicht Teil dieser Anforderung:
+
+- **MCP-/OAuth-Token.** Das Abschlussartefakt ist eine Firebase-Web-Session, kein
+  OAuth-Access-Token für den MCP-Resource-Server (das ist Epic #175). Beide Flows
+  bleiben getrennt; eine spätere Vereinheitlichung des Code-Stores ist optional.
+- **DPoP / sender-constrained Tokens.** Firebase-Sessions lassen sich nicht per
+  DPoP an einen Client-Schlüssel binden → für diesen Flow **nicht anwendbar**
+  (siehe Offene Fragen / Risiko). Der Schutz beschränkt sich darauf, das
+  Google-Credential vom Proxy fernzuhalten; die resultierende Session bleibt ein
+  Bearer-Artefakt (akzeptiertes Residual, widerrufbar).
+- **Ablösung des normalen Google-Logins.** Der Device-Login kommt additiv als
+  zweiter Anmeldeweg hinzu.
+
+## 7. Offene Fragen
+
+1. **Custom-Token-Residual.** Der Proxy sieht das Custom Token in der Poll-Antwort
+   und könnte es innerhalb seiner ~1 h Gültigkeit selbst gegen eine Session
+   tauschen (Google-Credential bleibt sicher; Schaden = eine aido-Web-Session,
+   widerrufbar). **Entscheidung getroffen:** akzeptieren + optionales
+   Härtungs-Issue (kurze TTL, Single-use, sofortiger Exchange, Session-Revoke-/
+   Rate-Limit-Tooling).
+2. **`verification_uri`.** Vorschlag: top-level `/device` (gut tippbar),
+   `verification_uri_complete` = `/device?user_code=…` (für QR). → ok?
+3. **`user_code`-Format.** Vorschlag: 8 Zeichen, gruppiert `WDJB-MJHT`, Alphabet
+   ohne mehrdeutige Zeichen. → ok?
+4. **QR-Anzeige.** Eigene kleine QR-Erzeugung (z.B. `qrcode`-Lib) oder zunächst nur
+   URL + Code anzeigen? (Empfohlen: QR, deutlich bessere UX.)
+5. **Store-Sharing mit #175.** Eigener `deviceLoginCodes`-Store (entkoppelt, nicht
+   durch #166 blockiert) — spätere Vereinheitlichung mit dem OAuth-Device-Store
+   optional. → so ok?

--- a/docs/02-ist-analyse-web-device-login.md
+++ b/docs/02-ist-analyse-web-device-login.md
@@ -1,0 +1,78 @@
+# Ist-Analyse: Web-Login per Device-Flow (Zweitgerät-Anmeldung)
+
+## 1. Aktueller Zustand
+
+Die Web-UI authentifiziert sich ausschließlich über **Firebase Auth (Google)** im
+Browser. `AuthProvider` (`src/lib/contexts/AuthContext.tsx`) hört auf
+`onAuthStateChanged`, legt lazy `users/{uid}` an, upsertet `publicProfiles/{uid}`
+und migriert Legacy-Todos. `(protected)/layout.tsx` leitet Unangemeldete per
+Client-Redirect um; der eigentliche Schutz sind die Firestore-Rules. Der Login
+selbst läuft über `signInWithGoogle` (Client-SDK) — am Arbeitsrechner also direkt
+durch den Proxy.
+
+Es existiert **kein** Weg, eine Firebase-Web-Session ohne diesen direkten
+Google-Login zu etablieren. Server-seitig ist das Admin SDK vorhanden und wird
+bereits genutzt (`verifyIdToken` im OAuth-Confirm), aber `createCustomToken` wird
+nirgends verwendet, und `signInWithCustomToken` wird clientseitig nicht genutzt.
+
+Verwandt: Epic #175 (OAuth-Device-Grant) führt einen Device-Flow ein, dessen
+Ergebnis jedoch ein OAuth-JWT für MCP ist — keine Web-Session.
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/lib/firebase/admin.ts` | Admin-SDK-Init; `getAdminAuth()` (nullbar ohne Service-Account → 503) | **Zentral**: `createCustomToken(uid)` + `verifyIdToken` |
+| `src/lib/firebase/firebase.ts` | Client-SDK (`auth`, `db`) | **Zentral**: `signInWithCustomToken(auth, token)` |
+| `src/lib/contexts/AuthContext.tsx` / `useAuth` | Auth-State, `signInWithGoogle`, lazy User-/Profil-Anlage | Wiederverwendet (Session-Folgeprozesse greifen automatisch); ggf. Helper für Custom-Token-Login |
+| `src/app/login/*` | Login-Seite (Google-Button) | Erweitern: Panel „Anmelden über Zweitgerät" |
+| `src/app/oauth/authorize/ConsentForm.tsx` | Consent-Muster: Firebase-Login + ID-Token an Confirm-Endpoint posten; Design-Tokens | Vorbild/Muster für die `/device`-Consent-Seite |
+| `src/app/api/oauth/authorize/confirm/route.ts` | `verifyIdToken(idToken) → uid`, Client/redirect-Validierung | Vorbild für den Device-Confirm-Endpoint (gleiche ID-Token-Verifikation) |
+| `src/lib/apiKeys.ts` | `rateLimit(key, {max, windowMs})` | Wiederverwendet für Start-/Confirm-/Poll-Endpoints |
+| `firestore.rules` | OAuth-Collections `allow read, write: if false` | Muster: `deviceLoginCodes` ebenso sperren |
+| `src/lib/oauth/store.ts` | Admin-SDK-Store mit single-use-Codes (Transaktion), gehashten Tokens | **Vorbild** für den Device-Login-Store (sha256-Doc-ID, atomarer Konsum) |
+| `tests/mcp-tools.test.mts` / `tests/firestore-rules.test.mjs` | Emulator-Tests (tsx bzw. node) | Vorbild für die neuen Tests |
+
+## 3. Bestehende Abhängigkeiten
+
+- **Intern:** Web-UI → Firebase-Client (`auth`); neue Endpoints → Admin SDK
+  (`getAdminAuth`); Confirm → `verifyIdToken`; Poll → `createCustomToken`;
+  Folge-State (User-/Profil-Anlage) → `AuthProvider`.
+- **Extern:** `firebase` (Client-SDK: `signInWithCustomToken`), `firebase-admin`
+  (`verifyIdToken`, `createCustomToken`, Firestore-Store), ggf. QR-Lib für die
+  Code-Anzeige.
+- **Konfiguration:** `FIREBASE_SERVICE_ACCOUNT_KEY` (Admin SDK; ohne ihn 503;
+  `createCustomToken` braucht den Service-Account). `NEXT_PUBLIC_FIREBASE_*` für
+  den Client.
+
+## 4. Bekannte Einschränkungen
+
+- **`createCustomToken` braucht den Service-Account** (privater Schlüssel zum
+  Signieren). Fehlt `FIREBASE_SERVICE_ACCOUNT_KEY`, muss der Poll-Endpoint sauber
+  503/`server_error` liefern (wie die OAuth-Routen).
+- **Custom-Token-Gültigkeit ist fix ~1 h** (Firebase) und nicht verkürzbar; das
+  Token ist bis dahin mehrfach einlösbar. Begrenzung erfolgt über kurze
+  `device_code`-TTL, Single-use-Konsum des Codes und sofortigen Exchange.
+- **Firebase-Sessions sind nicht DPoP-fähig** — anders als der MCP-OAuth-Pfad
+  (#175/#174) gibt es hier keine sender-constrained-Option.
+- **Serverless-Persistenz:** der Device-Login-State muss in Firestore liegen, damit
+  Polling über mehrere Instanzen funktioniert (in-memory reicht nicht).
+- **Rate-Limiting** ist in-memory pro Instanz; Polling wird primär über
+  `interval`/`slow_down`/`expires_in` gedrosselt.
+
+## 5. Risiken bei Änderung
+
+- **Session-Bootstrap ist sicherheitskritisch:** ein fehlerhafter Poll-/Confirm-
+  Pfad könnte Custom Tokens an Unbefugte ausgeben. `verifyIdToken` (Confirm) und
+  Single-use-Konsum (Poll) müssen strikt greifen.
+- **Custom-Token-Residual:** der Proxy sieht das Token; akzeptiert, aber
+  Härtung (kurze TTL, Revoke-Tooling) einplanen.
+- **Brute-Force auf `user_code`:** kurze TTL + ausreichende Entropie +
+  Eingabe-Rate-Limit auf Confirm/`/device` nötig.
+- **`firestore.rules`:** neue Collection muss gesperrt werden — Regel **und** Test
+  gemeinsam (CLAUDE.md-Vorgabe), sonst wäre der State clientseitig lesbar.
+- **Login-UI-Änderung:** der bestehende Google-Login darf unverändert
+  funktionieren; das Device-Panel kommt additiv hinzu.
+- **AuthProvider-Folgeprozesse:** nach `signInWithCustomToken` müssen User-/
+  Profil-Anlage und Migration genauso laufen wie nach Google-Login (sie hängen an
+  `onAuthStateChanged`, also automatisch — verifizieren).

--- a/docs/03-anforderungsanalyse-web-device-login.md
+++ b/docs/03-anforderungsanalyse-web-device-login.md
@@ -1,0 +1,58 @@
+# Anforderungsanalyse: Web-Login per Device-Flow (Zweitgerät-Anmeldung)
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Device-Login-Store | Muss | Admin-SDK-Collection `deviceLoginCodes`: `userCode`, `status` (`pending`/`approved`/`denied`), `uid`, `interval`, `lastPolledAt`, `expiresAt`; Doc-ID = `sha256(device_code)`. Lookup per `device_code` **und** per `user_code`; atomarer Single-use-Konsum bei Approve. |
+| FA-02 | Start-Endpoint | Muss | `POST /api/auth/device/start` erzeugt `device_code`+`user_code` (pending) und liefert `verification_uri`, `verification_uri_complete`, `expires_in`, `interval`. |
+| FA-03 | Confirm-Endpoint (Zweitgerät) | Muss | `POST /api/auth/device/confirm`: `verifyIdToken(idToken) → uid`, `user_code` nachschlagen, Status `approved`+uid bzw. `denied`. |
+| FA-04 | Poll-Endpoint → Custom Token | Muss | `POST /api/auth/device/poll` mit `device_code`. Antworten: `authorization_pending`, `slow_down`, `expired_token`, `access_denied`; bei Approve `getAdminAuth().createCustomToken(uid)` → `{ firebaseCustomToken }`, Code single-use konsumiert. |
+| FA-05 | Consent-Seite `/device` | Muss | Auf dem Handy: `user_code`-Eingabe (vorausgefüllt via `verification_uri_complete`), Firebase-Google-Login, Approve/Deny → Confirm-Endpoint. |
+| FA-06 | Login-UI am Arbeitsrechner | Muss | Panel „Anmelden über Zweitgerät" in `src/app/login`: Start aufrufen, `user_code` + URL + **QR** anzeigen, pollen, bei Erfolg `signInWithCustomToken(auth, token)` → Redirect `/todos`. |
+| FA-07 | Polling-Drossel & Expiry | Muss | `slow_down` bei zu schnellem Polling (`lastPolledAt`); abgelaufener Code → `expired_token`; Erfolg single-use. |
+| FA-08 | firestore.rules | Muss | `deviceLoginCodes` vollständig sperren (`allow read, write: if false`) + Rules-Test. |
+| FA-09 | QR-Code | Soll | `verification_uri_complete` als scanbarer QR-Code in der Login-UI. |
+| FA-10 | Session-Folgeprozesse | Soll | Nach `signInWithCustomToken` laufen User-/Profil-Anlage + Legacy-Migration wie nach Google-Login (über `AuthProvider`/`onAuthStateChanged`) — verifizieren. |
+| FA-11 | Härtung & Revoke (optional) | Kann | Kurze TTL, Eingabe-Rate-Limit auf `user_code`, Tooling/Doku zum Session-Revoke (`revokeRefreshTokens(uid)`). |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Google-Credential bleibt off-proxy | Sicherheit | Login + Consent laufen ausschließlich auf `/device` (Zweitgerät); der Arbeitsrechner führt **keinen** Google-Login durch. |
+| NFA-02 | Echte Firebase-Session | Funktion | Ergebnis ist eine reguläre Firebase-Session (ID- + Refresh-Token im Browser), identisch zum Google-Login-Ergebnis. |
+| NFA-03 | Custom-Token-Exposition minimieren | Sicherheit | Kurze `device_code`-TTL, Single-use-Konsum, sofortiger Exchange; Session über `revokeRefreshTokens` widerrufbar. (DPoP nicht anwendbar.) |
+| NFA-04 | Brute-Force-Schutz `user_code` | Sicherheit | Ausreichende Entropie (≥ ~8 Zeichen, ambig-frei), kurze TTL, Eingabe-Rate-Limit. |
+| NFA-05 | DoS-/Abuse-Schutz | Stabilität | `rateLimit` auf Start/Confirm/Poll; Polling über `interval`/`slow_down`/`expires_in` begrenzt. |
+| NFA-06 | Persistenz serverless-tauglich | Zuverlässigkeit | Device-Login-State in Firestore (instanzübergreifendes Polling). |
+| NFA-07 | Testbarkeit | Wartbarkeit | Endpoints als Web `Request`/`Response`; Emulator-Tests analog `test:mcp`/`test:rules`. |
+| NFA-08 | Bestehender Login unverändert | Kompatibilität | Der normale Google-Login bleibt funktional unverändert; Device-Login ist additiv. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] `start` liefert `device_code` + kurzes `user_code` + `verification_uri(_complete)`/`expires_in`/`interval`.
+- [ ] Vor Bestätigung liefert `poll` `authorization_pending`; zu schnelles Polling `slow_down`.
+- [ ] Nach Login + Approve auf `/device` (Zweitgerät) liefert `poll` ein `firebaseCustomToken`.
+- [ ] `signInWithCustomToken` etabliert eine Firebase-Session; der Nutzer landet eingeloggt auf `/todos`.
+- [ ] User-Doc/`publicProfile`/Migration laufen nach Custom-Token-Login wie nach Google-Login.
+- [ ] Ein bereits eingelöster `device_code` liefert kein zweites Token; abgelaufen → `expired_token`; abgelehnt → `access_denied`.
+- [ ] `user_code` ist menschenlesbar/ambig-frei und via `verification_uri_complete` vorausfüllbar; QR ist scanbar.
+- [ ] `deviceLoginCodes` ist clientseitig weder les- noch schreibbar (Rules-Test grün).
+- [ ] Während des gesamten Flows findet **kein** Google-Login über den Arbeitsrechner-(Proxy-)Kanal statt.
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Nutzt Admin SDK + Firebase-Client (vorhanden) und das Consent-/`verifyIdToken`-
+  Muster aus dem OAuth-Confirm (#153).
+- **Verwandt mit Epic #175** (OAuth-Device-Grant für MCP): gleiches Device-Flow-
+  Muster, anderes Abschlussartefakt. Bewusst **entkoppelt** (eigener Store), damit
+  keine Blockade durch #166; spätere Store-Vereinheitlichung optional.
+- FA-09 (QR) kann eine kleine zusätzliche Dependency erfordern.
+
+## 5. Priorisierung
+
+1. **Muss (Kern):** FA-01, FA-02, FA-03, FA-04, FA-07 — lauffähiger Flow bis Custom Token.
+2. **Muss (UI/Sicherheit):** FA-05, FA-06, FA-08 — Consent-Seite, Login-UI, Rules.
+3. **Soll:** FA-09 (QR), FA-10 (Folgeprozesse verifizieren).
+4. **Kann:** FA-11 (Härtung/Revoke-Tooling).

--- a/docs/04-spezifikation-web-device-login.md
+++ b/docs/04-spezifikation-web-device-login.md
@@ -1,0 +1,201 @@
+# Spezifikation: Web-Login per Device-Flow (Zweitgerät-Anmeldung)
+
+## 1. Übersicht
+
+Neuer, additiver Anmeldeweg für die aido-Web-UI: ein Device-Flow nach
+RFC-8628-Muster, dessen Abschlussartefakt ein **Firebase Custom Token** ist. Der
+Arbeitsrechner zeigt Code + QR und pollt; Login und Consent erfolgen auf einem
+Zweitgerät (Handy/Mobilfunk). Nach Approve erhält der Arbeitsrechner ein Custom
+Token und etabliert per `signInWithCustomToken` eine vollwertige Firebase-Session.
+
+```
+Arbeitsrechner (Web-UI, hinter Proxy)     aido-Server          Handy (Mobilfunk, Trusted)
+  │ ① POST /api/auth/device/start
+  │ ─────────────────────────▶ erzeugt device_code + user_code (pending)
+  │ ② ◀── device_code, user_code, verification_uri(_complete), expires_in, interval
+  │ ③ zeigt user_code + QR an
+  │                                        ④ öffnet /device (KEIN Proxy)
+  │                                        ⑤ Firebase-Google-Login (sicher)
+  │                                        ⑥ user_code + Erlauben
+  │                            ◀──────────── POST /api/auth/device/confirm {idToken,userCode}
+  │                            verifyIdToken→uid, setzt approved(uid)
+  │ ⑦ POST /api/auth/device/poll {device_code}   (alle `interval` s)
+  │ ◀── authorization_pending | slow_down …
+  │ ⑧ ◀── { firebaseCustomToken }   nach Approve (createCustomToken), single-use
+  │ ⑨ signInWithCustomToken(auth, token) → Firebase-Session → Redirect /todos
+```
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+Rein additiv; bestehender Google-Login unverändert.
+
+**Neue Endpoints**
+- `POST /api/auth/device/start` — Code anfordern.
+- `POST /api/auth/device/confirm` — Approve/Deny vom Zweitgerät (verifyIdToken).
+- `POST /api/auth/device/poll` — Polling → Firebase Custom Token bei Approve.
+
+**Neue/erweiterte UI**
+- `GET /device` — Consent-Seite (Handy), Muster `ConsentForm.tsx`.
+- `src/app/login/*` — Panel „Anmelden über Zweitgerät" (Start, Code/QR, Polling,
+  `signInWithCustomToken`).
+
+**Wiederverwendet**
+- `getAdminAuth().verifyIdToken` (Confirm) — wie OAuth-Confirm (#153).
+- `getAdminAuth().createCustomToken(uid)` (Poll) — neu genutzt, Admin SDK vorhanden.
+- `signInWithCustomToken` (Client), `AuthProvider`-Folgeprozesse.
+- `rateLimit` (`src/lib/apiKeys.ts`), `firestore.rules`-Sperrmuster.
+
+### 2.2 Datenmodell
+
+Neue Firestore-Collection **`deviceLoginCodes`** (nur Admin SDK). Doc-ID =
+`sha256(device_code)` (Klartext-Code nicht persistiert); `userCode` als indiziertes
+Feld für den Confirm-Lookup.
+
+```
+deviceLoginCodes/{sha256(device_code)}
+  userCode:     string    // "WDJB-MJHT", ambig-freies Alphabet
+  status:       "pending" | "approved" | "denied"
+  uid:          string | null
+  interval:     number     // s, Default 5
+  lastPolledAt: number     // ms epoch, für slow_down
+  expiresAt:    number      // ms epoch
+  createdAt:    serverTimestamp
+```
+
+Konfiguration (`src/lib/auth/deviceLogin.ts`):
+
+```ts
+const DEVICE_LOGIN = {
+  collection: "deviceLoginCodes",
+  ttlSec: 5 * 60,                            // kurz halten (Residual!)
+  pollIntervalSec: 5,
+  userCodeAlphabet: "BCDFGHJKLMNPQRSTVWXZ",  // ohne Vokale/0/O/1/I
+  userCodeLength: 8,                          // gruppiert "XXXX-XXXX"
+} as const;
+```
+
+### 2.3 Schnittstellen
+
+**① `POST /api/auth/device/start`** (JSON)
+Response `200`:
+```json
+{
+  "device_code": "GmRhmhc...DnyEys",
+  "user_code": "WDJB-MJHT",
+  "verification_uri": "https://<origin>/device",
+  "verification_uri_complete": "https://<origin>/device?user_code=WDJB-MJHT",
+  "expires_in": 300,
+  "interval": 5
+}
+```
+
+**④/⑥ `POST /api/auth/device/confirm`** (JSON, von `/device`)
+Request: `{ idToken, userCode, action: "approve" | "deny" }`.
+Ablauf: `verifyIdToken(idToken) → uid`; `userCode` nachschlagen (vorhanden, nicht
+abgelaufen, `pending`); `approveDeviceLogin(userCode, uid)` bzw.
+`denyDeviceLogin(userCode)`.
+Response `{ status }`; Fehler: `access_denied` (ID-Token ungültig),
+`invalid_request` (Code unbekannt/abgelaufen), `server_error` (Admin SDK fehlt).
+
+**⑦/⑧ `POST /api/auth/device/poll`** (JSON)
+Request: `{ device_code }`. Antwortmatrix:
+
+| Zustand | Antwort |
+|---|---|
+| nicht existent / abgelaufen | `{ error: "expired_token" }` |
+| zu schnell gepollt | `{ error: "slow_down" }` |
+| `pending` | `{ error: "authorization_pending" }` |
+| `denied` | `{ error: "access_denied" }` |
+| `approved` | **200** `{ firebaseCustomToken }` (Code konsumiert) |
+
+**Store-API (`src/lib/auth/deviceLogin.ts`)**
+```ts
+createDeviceLogin(): Promise<{ deviceCode; userCode; expiresIn; interval }>
+approveDeviceLogin(userCode: string, uid: string): Promise<boolean>
+denyDeviceLogin(userCode: string): Promise<boolean>
+pollDeviceLogin(deviceCode: string):
+  Promise<{ kind: "pending" | "slow_down" | "denied" | "expired" }
+         | { kind: "approved"; uid }>
+// "approved" konsumiert den Code atomar (Transaktion).
+```
+
+**⑨ Client (Login-UI)**
+```ts
+import { signInWithCustomToken } from "firebase/auth";
+await signInWithCustomToken(auth, firebaseCustomToken); // → Session → router.push("/todos")
+```
+
+### 2.4 Sicherheits-Residual (bewusst akzeptiert)
+
+- **Google-Credential**: nie über den Proxy (Login nur auf `/device`).
+- **Custom Token / Session**: der Proxy sieht das Token in ⑧ und die Folge-
+  Session; er könnte ~1 h lang selbst eine Session daraus ziehen. Schaden =
+  **eine aido-Web-Session** (nicht der Google-Account), **widerrufbar** via
+  `revokeRefreshTokens(uid)`. Minimierung: kurze `ttlSec`, Single-use, sofortiger
+  Exchange. **DPoP ist für Firebase-Sessions nicht anwendbar** (anders als der
+  MCP-Pfad #174).
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/auth/deviceLogin.ts` | Store + Config (create/approve/deny/poll, `user_code`-Generator, atomarer Konsum) | Mittel |
+| `firestore.rules` (+ Test) | `deviceLoginCodes` sperren | Klein |
+| `src/app/api/auth/device/start/route.ts` | Start-Endpoint (+ `rateLimit`) | Klein |
+| `src/app/api/auth/device/confirm/route.ts` | Confirm-Endpoint (ID-Token → uid) | Klein |
+| `src/app/api/auth/device/poll/route.ts` | Poll-Endpoint (Matrix → `createCustomToken`) | Mittel |
+| `src/app/device/page.tsx` + Form | Consent-Seite (Handy) | Mittel |
+| `src/app/login/*` | Device-Login-Panel (Start/QR/Poll/`signInWithCustomToken`) | Mittel |
+| `tests/` | Device-Login-Flow-Tests | Mittel |
+| (optional) Härtung | TTL/Rate-Limit/Revoke-Doku | Klein |
+
+### 3.2 Reihenfolge der Implementierung
+
+1. **Store + Config** (`src/lib/auth/deviceLogin.ts`) — Fundament, isoliert testbar.
+2. **firestore.rules** + Rules-Test (mit dem Datenmodell, CLAUDE.md-Vorgabe).
+3. **Start-Endpoint**.
+4. **Confirm-Endpoint**.
+5. **Poll-Endpoint** (inkl. `createCustomToken`).
+6. **`/device`-Consent-Seite** (Handy).
+7. **Login-UI-Panel** am Arbeitsrechner (inkl. QR + `signInWithCustomToken`).
+8. **Tests** (E2E) + manueller Durchlauf (Folgeprozesse FA-10 prüfen).
+9. **(Optional)** Härtung & Revoke-Tooling.
+
+## 4. Testplan
+
+**Automatisiert (Emulator, `tests/`)**
+- `start` liefert wohlgeformte Response (Felder, TTL, `interval`).
+- `poll`: `authorization_pending` vor Approve; `slow_down` bei zu schnellem Polling.
+- `confirm(approve)` → `poll` liefert `firebaseCustomToken`; Single-use (zweites
+  `poll` kein Token); `expired_token` nach TTL; `deny` → `access_denied`.
+- `approveDeviceLogin` mit unbekanntem/abgelaufenem `user_code` → `false`.
+
+**Rules (`tests/firestore-rules.test.mjs`)**
+- `deviceLoginCodes` für Clients weder les- noch schreibbar.
+
+**Manuell (E2E)**
+- Login-UI am Arbeitsrechner → QR scannen → Approve am Handy → Arbeitsrechner ist
+  eingeloggt auf `/todos`; User-Doc/Profil/Migration laufen; Google-Login nur auf
+  `/device`. Session-Revoke testen (`revokeRefreshTokens`).
+
+## 5. Migration / Deployment
+
+- **Keine Datenmigration** — additive Collection + Endpoints + UI.
+- Reihenfolge: App zuerst (Vercel-Auto-Deploy), **danach** `firestore.rules`
+  deployen (`npx -y firebase-tools@13 deploy --only firestore:rules`) — additive
+  Sperrregel.
+- **Env:** keine neuen Variablen; `FIREBASE_SERVICE_ACCOUNT_KEY` ist Pflicht
+  (`createCustomToken` + `verifyIdToken`).
+
+## 6. Referenzen
+
+- [Konzeptdokument](01-konzept-web-device-login.md)
+- [Ist-Analyse](02-ist-analyse-web-device-login.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-web-device-login.md)
+- RFC 8628 — OAuth 2.0 Device Authorization Grant (UX-Muster)
+- Firebase Auth — `createCustomToken` / `signInWithCustomToken`
+- Verwandt: Epic #175 (OAuth-Device-Grant für MCP), `docs/04-spezifikation-oauth-device-grant.md`


### PR DESCRIPTION
Concept-analysis-spec documents for a **web-UI login via a device flow** — modelled on RFC 8628 but completing with a **Firebase custom token** (→ `signInWithCustomToken` → real web session), so the work machine can log into the aido web UI without the **Google login crossing the corporate MITM proxy** (login + consent happen on a trusted second device).

Additive to — not replacing — the MCP-scoped OAuth device grant (epic #175). Same device-flow UX, different completion artifact. DPoP is **not** applicable to Firebase sessions; the residual (proxy can ride the resulting aido session ~1h, revocable) is accepted, mitigated by short TTL + single-use + revoke tooling.

## Documents (`docs/`)
- `01-konzept-web-device-login.md`
- `02-ist-analyse-web-device-login.md`
- `03-anforderungsanalyse-web-device-login.md`
- `04-spezifikation-web-device-login.md`

New surface: `/api/auth/device/{start,confirm,poll}`, `/device` consent page, a device-login panel on the login page, and the `deviceLoginCodes` store + rules. Reuses Admin SDK `verifyIdToken`/`createCustomToken` and the existing consent pattern.

Docs-only — implementation tracked in the follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)