### PR TITLE
feat(device-login): store + config (deviceLoginCodes) — #177

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:migration": "firebase emulators:exec --only firestore --project demo-migration \"node tests/migration-admin.test.mjs\"",
     "test:mcp": "firebase emulators:exec --only firestore --project demo-mcp \"node --conditions=react-server --import tsx tests/mcp-tools.test.mts\"",
     "test:oauth": "firebase emulators:exec --only firestore,auth --project demo-oauth \"node --conditions=react-server --import tsx tests/oauth.test.mts\"",
+    "test:device-login": "firebase emulators:exec --only firestore,auth --project demo-device-login \"node --conditions=react-server --import tsx tests/device-login.test.mts\"",
     "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs"
   },
   "dependencies": {

--- a/src/lib/auth/deviceLogin.ts
+++ b/src/lib/auth/deviceLogin.ts
@@ -1,0 +1,150 @@
+import "server-only";
+import { FieldValue } from "firebase-admin/firestore";
+import { createHash, randomBytes, randomInt } from "node:crypto";
+import { getAdminDb } from "@/lib/firebase/admin";
+
+// Device-login store (issue #177, epic #186). Backs a web-UI login over a second
+// device, modelled on RFC 8628: the work machine starts a flow and polls; the
+// user approves on a trusted device. The completion artifact is a Firebase custom
+// token (minted by the poll route), so the Google login never crosses the work
+// (proxy) channel.
+//
+// The `deviceLoginCodes` collection is denied to all clients in firestore.rules
+// and is only ever touched here (Admin SDK). The doc id is sha256(device_code) —
+// the opaque code is never stored in the clear (like oauthRefreshTokens). The
+// short `user_code` is an indexed field for the approve/deny lookup.
+
+export const DEVICE_LOGIN = {
+  collection: "deviceLoginCodes",
+  ttlSec: 5 * 60, // keep short — the custom-token residual is bounded by this
+  pollIntervalSec: 5, // RFC 8628 default
+  userCodeAlphabet: "BCDFGHJKLMNPQRSTVWXZ", // no vowels, no 0/O/1/I — unambiguous
+  userCodeLength: 8, // displayed grouped as "XXXX-XXXX"
+} as const;
+
+function db() {
+  const d = getAdminDb();
+  if (!d) {
+    throw new Error("Device-login store requires the Admin SDK (FIREBASE_SERVICE_ACCOUNT_KEY).");
+  }
+  return d;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// A fresh, unambiguous user code (canonical form: uppercase, no separator).
+function generateUserCode(): string {
+  const a = DEVICE_LOGIN.userCodeAlphabet;
+  let out = "";
+  for (let i = 0; i < DEVICE_LOGIN.userCodeLength; i++) out += a[randomInt(a.length)];
+  return out;
+}
+
+/** Display form of a canonical user code, e.g. "WDJBMJHT" → "WDJB-MJHT". */
+export function formatUserCode(code: string): string {
+  const mid = Math.ceil(code.length / 2);
+  return `${code.slice(0, mid)}-${code.slice(mid)}`;
+}
+
+/** Canonicalise user input (strip separators/whitespace, uppercase) for lookup. */
+export function normalizeUserCode(input: string): string {
+  return (input || "").toUpperCase().replace(/[\s-]/g, "");
+}
+
+export interface DeviceLoginStart {
+  deviceCode: string;
+  userCode: string; // display form ("XXXX-XXXX")
+  expiresIn: number;
+  interval: number;
+}
+
+export async function createDeviceLogin(): Promise<DeviceLoginStart> {
+  const deviceCode = randomBytes(32).toString("base64url");
+  const userCode = generateUserCode();
+  await db().collection(DEVICE_LOGIN.collection).doc(sha256(deviceCode)).set({
+    userCode,
+    status: "pending",
+    uid: null,
+    interval: DEVICE_LOGIN.pollIntervalSec,
+    lastPolledAt: 0,
+    expiresAt: Date.now() + DEVICE_LOGIN.ttlSec * 1000,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return {
+    deviceCode,
+    userCode: formatUserCode(userCode),
+    expiresIn: DEVICE_LOGIN.ttlSec,
+    interval: DEVICE_LOGIN.pollIntervalSec,
+  };
+}
+
+// Set a pending code's status. Atomic: only succeeds if the code exists, is
+// unexpired and still pending. Returns false otherwise (unknown/expired/decided).
+async function decideDeviceLogin(
+  userCode: string,
+  update: { status: "approved"; uid: string } | { status: "denied" }
+): Promise<boolean> {
+  const canonical = normalizeUserCode(userCode);
+  if (!canonical) return false;
+  const d = db();
+  const q = d.collection(DEVICE_LOGIN.collection).where("userCode", "==", canonical).limit(1);
+  return d.runTransaction(async (tx) => {
+    const snap = await tx.get(q);
+    if (snap.empty) return false;
+    const doc = snap.docs[0];
+    const data = doc.data();
+    if (data.status !== "pending" || typeof data.expiresAt !== "number" || data.expiresAt < Date.now()) {
+      return false;
+    }
+    tx.update(doc.ref, update);
+    return true;
+  });
+}
+
+export function approveDeviceLogin(userCode: string, uid: string): Promise<boolean> {
+  if (!uid) return Promise.resolve(false);
+  return decideDeviceLogin(userCode, { status: "approved", uid });
+}
+
+export function denyDeviceLogin(userCode: string): Promise<boolean> {
+  return decideDeviceLogin(userCode, { status: "denied" });
+}
+
+export type DeviceLoginPoll =
+  | { kind: "pending" | "slow_down" | "denied" | "expired" }
+  | { kind: "approved"; uid: string };
+
+// Poll a device code. Returns the current state; `approved` is single-use — it
+// consumes (deletes) the code in the same transaction so a replay yields
+// `expired`. `slow_down` is only signalled while still pending (a variant of
+// authorization_pending per RFC 8628 §3.5); once approved the token is delivered
+// regardless of poll cadence.
+export async function pollDeviceLogin(deviceCode: string): Promise<DeviceLoginPoll> {
+  if (!deviceCode) return { kind: "expired" };
+  const ref = db().collection(DEVICE_LOGIN.collection).doc(sha256(deviceCode));
+  return db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) return { kind: "expired" } as const;
+    const d = snap.data()!;
+    const now = Date.now();
+    if (typeof d.expiresAt !== "number" || d.expiresAt < now) {
+      tx.delete(ref);
+      return { kind: "expired" } as const;
+    }
+    if (d.status === "approved" && typeof d.uid === "string") {
+      tx.delete(ref); // single-use
+      return { kind: "approved", uid: d.uid } as const;
+    }
+    if (d.status === "denied") return { kind: "denied" } as const;
+    // pending: enforce the polling interval
+    const interval = typeof d.interval === "number" ? d.interval : DEVICE_LOGIN.pollIntervalSec;
+    const last = typeof d.lastPolledAt === "number" ? d.lastPolledAt : 0;
+    if (last > 0 && now - last < interval * 1000) {
+      return { kind: "slow_down" } as const;
+    }
+    tx.update(ref, { lastPolledAt: now });
+    return { kind: "pending" } as const;
+  });
+}

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -1,0 +1,104 @@
+// Integration tests for the device-login store (issue #177, epic #186).
+// Exercises the REAL code (src/lib/auth/deviceLogin.ts) against the Firestore
+// emulator with the Admin SDK — create / poll (pending, slow_down, approved,
+// single-use, expired) / approve / deny.
+//
+// Run via (needs a JDK + the firestore emulator):
+//   npx -y firebase-tools@13 emulators:exec --only firestore --project demo-device-login \
+//     "node --conditions=react-server --import tsx tests/device-login.test.mts"
+// (react-server condition neutralises the `server-only` guard; tsx resolves @/*.)
+
+import { initializeApp } from "firebase-admin/app";
+import { createHash } from "node:crypto";
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("FIRESTORE_EMULATOR_HOST is not set — run inside emulators:exec.");
+  process.exit(1);
+}
+
+// Pre-init the app under the name admin.ts expects, so getAdminDb() reuses this
+// emulator-bound app and never goes through cert().
+const projectId = process.env.GCLOUD_PROJECT || "demo-device-login";
+initializeApp({ projectId }, "admin");
+
+const store = await import("../src/lib/auth/deviceLogin.ts");
+const { getAdminDb } = await import("../src/lib/firebase/admin.ts");
+
+const sha256 = (v: string) => createHash("sha256").update(v).digest("hex");
+
+let failures = 0;
+function check(name: string, cond: boolean) {
+  if (cond) console.log(`  ✓ ${name}`);
+  else {
+    failures++;
+    console.error(`  ✗ ${name}`);
+  }
+}
+
+async function run() {
+  // --- create: shape + display formatting ---
+  const started = await store.createDeviceLogin();
+  check(
+    "create → deviceCode + formatted userCode + ttl/interval",
+    typeof started.deviceCode === "string" &&
+      started.deviceCode.length > 0 &&
+      /^[A-Z]{4}-[A-Z]{4}$/.test(started.userCode) &&
+      started.expiresIn === store.DEVICE_LOGIN.ttlSec &&
+      started.interval === store.DEVICE_LOGIN.pollIntervalSec
+  );
+
+  // --- poll: pending, then slow_down on a too-fast second poll ---
+  const p1 = await store.pollDeviceLogin(started.deviceCode);
+  check("poll #1 → pending", p1.kind === "pending");
+  const p2 = await store.pollDeviceLogin(started.deviceCode);
+  check("poll #2 (too fast) → slow_down", p2.kind === "slow_down");
+
+  // --- approve via the hyphenated display form (normalize), then approved+uid ---
+  const approved = await store.approveDeviceLogin(started.userCode, "uid-123");
+  check("approveDeviceLogin (display form) → true", approved === true);
+  const p3 = await store.pollDeviceLogin(started.deviceCode);
+  check("poll after approve → approved + uid (interval ignored once approved)", p3.kind === "approved" && (p3 as { uid: string }).uid === "uid-123");
+
+  // --- single-use: a second poll after consumption → expired ---
+  const p4 = await store.pollDeviceLogin(started.deviceCode);
+  check("poll after consume → expired (single-use)", p4.kind === "expired");
+
+  // --- approving an already-decided/consumed code → false ---
+  check("approve consumed code → false", (await store.approveDeviceLogin(started.userCode, "uid-x")) === false);
+
+  // --- unknowns ---
+  check("poll unknown deviceCode → expired", (await store.pollDeviceLogin("does-not-exist")).kind === "expired");
+  check("approve unknown userCode → false", (await store.approveDeviceLogin("ZZZZ-ZZZZ", "uid-y")) === false);
+  check("approve empty uid → false", (await store.approveDeviceLogin(started.userCode, "")) === false);
+
+  // --- deny flow ---
+  const d = await store.createDeviceLogin();
+  check("deny → true", (await store.denyDeviceLogin(d.userCode)) === true);
+  check("poll after deny → denied", (await store.pollDeviceLogin(d.deviceCode)).kind === "denied");
+  check("approve after deny → false", (await store.approveDeviceLogin(d.userCode, "uid-z")) === false);
+
+  // --- TTL expiry: backdate expiresAt directly, then poll → expired + cleaned up ---
+  const e = await store.createDeviceLogin();
+  const ref = getAdminDb()!.collection(store.DEVICE_LOGIN.collection).doc(sha256(e.deviceCode));
+  await ref.update({ expiresAt: Date.now() - 1000 });
+  check("poll expired code → expired", (await store.pollDeviceLogin(e.deviceCode)).kind === "expired");
+  check("expired code is deleted", !(await ref.get()).exists);
+
+  // --- approving an expired code → false ---
+  const e2 = await store.createDeviceLogin();
+  await getAdminDb()!
+    .collection(store.DEVICE_LOGIN.collection)
+    .doc(sha256(e2.deviceCode))
+    .update({ expiresAt: Date.now() - 1000 });
+  check("approve expired code → false", (await store.approveDeviceLogin(e2.userCode, "uid-e")) === false);
+}
+
+run()
+  .then(() => {
+    console.log(failures === 0 ? "\nAll device-login store tests passed." : `\n${failures} check(s) failed.`);
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch((e) => {
+    console.error("\nTest run crashed:", e);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #177. Foundation for **web-UI login over a second device** (epic #186) — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md).

Adds `src/lib/auth/deviceLogin.ts`, the Admin-SDK store for the `deviceLoginCodes` collection, mirroring the conventions of `src/lib/oauth/store.ts`:

- **`createDeviceLogin()`** → opaque `device_code` (doc id = `sha256(device_code)`, never stored in the clear) + short unambiguous `user_code` (alphabet without vowels/`0`/`O`/`1`/`I`), returned in display form `XXXX-XXXX`, plus `expiresIn`/`interval`.
- **`approveDeviceLogin` / `denyDeviceLogin`** — atomic (transaction), only succeed on a *pending, unexpired* code; input is normalized so the hyphenated display form is accepted.
- **`pollDeviceLogin`** — `pending` / `slow_down` (only while pending, a variant of `authorization_pending` per RFC 8628 §3.5) / `denied` / `approved` (single-use, consumed in the same transaction) / `expired` (also deletes the doc).
- Config (`DEVICE_LOGIN`): 5-min TTL (bounds the custom-token residual), 5-s poll interval, user-code format.

### Tests
`tests/device-login.test.mts` (+ `npm run test:device-login`) runs the **real** store against the Firestore emulator — create shape, pending→slow_down, approve→approved+uid, single-use consumption, deny, unknown/empty inputs, and TTL expiry+cleanup. All 16 checks green locally. `npx tsc --noEmit` and `npm run lint` clean.

### Not in this PR (follow-ups in #186)
firestore.rules deny (#178), endpoints (#179/#180/#181), `/device` page (#182), login panel (#183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)