### PR TITLE
feat(device-login): deny deviceLoginCodes in firestore.rules — #178

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -52,6 +52,13 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // Device-login state (issue #178, epic #186): pending/approved device codes
+    // for web-UI login over a second device. Managed exclusively through the
+    // Admin SDK (src/lib/auth/deviceLogin) — no client access whatsoever.
+    match /deviceLoginCodes/{deviceCodeHash} {
+      allow read, write: if false;
+    }
+
     // Spaces (issue #40): the organizing unit that replaces "My Todos / Shared
     // with me". Membership grants full access to everything in the space.
     // Rights model: any member may read and update (rename, recolor, add/remove

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -431,6 +431,15 @@ await check('user may not read oauthRefreshTokens', assertFails(
 await check('user may not write oauthRefreshTokens', assertFails(
   setDoc(doc(db(ALICE), 'oauthRefreshTokens/hash1'), { uid: ALICE })));
 
+console.log('Device-login collection (admin-only, issue #178):');
+await check('user may not read deviceLoginCodes', assertFails(
+  getDoc(doc(db(ALICE), 'deviceLoginCodes/dc1'))));
+await check('user may not write deviceLoginCodes', assertFails(
+  setDoc(doc(db(ALICE), 'deviceLoginCodes/dc1'), { uid: ALICE, status: 'approved' })));
+await check('user may not query deviceLoginCodes', assertFails(
+  getDocs(query(collection(db(ALICE), 'deviceLoginCodes'),
+    where('userCode', '==', 'WDJBMJHT')))));
+
 await testEnv.cleanup();
 
 if (failures > 0) {


### PR DESCRIPTION
Closes #178. Part of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md).

Locks down the `deviceLoginCodes` collection used by the device-login store (#177): **no client access**, like the OAuth AS collections — it is only ever touched by the Admin SDK (`src/lib/auth/deviceLogin.ts`).

- `firestore.rules`: `match /deviceLoginCodes/{deviceCodeHash} { allow read, write: if false; }`
- `tests/firestore-rules.test.mjs`: a signed-in user may not **read**, **write**, or **query** (by `user_code`) the collection.

Rule + test in the same PR (CLAUDE.md). `npm run test:rules` green locally (all rules + storage tests pass).

> Deploy note: the rule is additive (denies a not-yet-used collection), so it's safe to deploy anytime; per CLAUDE.md, `firestore:rules` is deployed after the app. The collection only goes live with the endpoints (#179–#181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)