### PR TITLE
feat(device-login): start endpoint /api/auth/device/start — #179

### DIFF
--- a/src/app/api/auth/device/start/route.ts
+++ b/src/app/api/auth/device/start/route.ts
@@ -1,0 +1,50 @@
+import { rateLimit } from "@/lib/apiKeys";
+import { createDeviceLogin } from "@/lib/auth/deviceLogin";
+import { requestOrigin } from "@/lib/oauth/config";
+
+// Device-login start endpoint (issue #179, epic #186). The unauthenticated web UI
+// on the work machine calls this to begin a second-device login (RFC 8628-style):
+// it returns a short user_code + a verification URL/QR target. The actual Google
+// login + consent happen on a trusted device via /device; the work machine then
+// polls /api/auth/device/poll. Same-origin only (no CORS) — this is aido's own UI.
+
+export const dynamic = "force-dynamic";
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  if (!rateLimit(`device-login:start:${clientIp(req)}`, { max: 30, windowMs: 60 * 60 * 1000 })) {
+    return err("rate_limited", "Too many device-login requests; try again later.", 429);
+  }
+
+  let started;
+  try {
+    started = await createDeviceLogin();
+  } catch (e) {
+    console.error("[auth/device/start] createDeviceLogin failed", e);
+    return err("server_error", "Device-login storage is unavailable.", 503);
+  }
+
+  const origin = requestOrigin(req);
+  const verificationUri = `${origin}/device`;
+  const verificationUriComplete = `${verificationUri}?user_code=${encodeURIComponent(started.userCode)}`;
+
+  return Response.json(
+    {
+      device_code: started.deviceCode,
+      user_code: started.userCode,
+      verification_uri: verificationUri,
+      verification_uri_complete: verificationUriComplete,
+      expires_in: started.expiresIn,
+      interval: started.interval,
+    },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -23,8 +23,16 @@ initializeApp({ projectId }, "admin");
 
 const store = await import("../src/lib/auth/deviceLogin.ts");
 const { getAdminDb } = await import("../src/lib/firebase/admin.ts");
+const { POST: startPost } = await import("../src/app/api/auth/device/start/route.ts");
 
 const sha256 = (v: string) => createHash("sha256").update(v).digest("hex");
+
+function startReq(ip = "5.0.0.1"): Request {
+  return new Request("https://aido.example/api/auth/device/start", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip, "x-forwarded-host": "aido.example", "x-forwarded-proto": "https" },
+  });
+}
 
 let failures = 0;
 function check(name: string, cond: boolean) {
@@ -91,6 +99,37 @@ async function run() {
     .doc(sha256(e2.deviceCode))
     .update({ expiresAt: Date.now() - 1000 });
   check("approve expired code → false", (await store.approveDeviceLogin(e2.userCode, "uid-e")) === false);
+
+  // --- start endpoint (issue #179): shape + verification URIs, then rate limit ---
+  const sRes = await startPost(startReq("5.0.0.1"));
+  const s = (await sRes.json()) as {
+    device_code?: string; user_code?: string;
+    verification_uri?: string; verification_uri_complete?: string;
+    expires_in?: number; interval?: number;
+  };
+  check(
+    "start → 200 with device_code + formatted user_code + ttl/interval",
+    sRes.status === 200 &&
+      typeof s.device_code === "string" && s.device_code!.length > 0 &&
+      /^[A-Z]{4}-[A-Z]{4}$/.test(s.user_code ?? "") &&
+      s.expires_in === store.DEVICE_LOGIN.ttlSec &&
+      s.interval === store.DEVICE_LOGIN.pollIntervalSec
+  );
+  check(
+    "start → verification_uri(_complete) honour the forwarded origin + user_code",
+    s.verification_uri === "https://aido.example/device" &&
+      s.verification_uri_complete === `https://aido.example/device?user_code=${encodeURIComponent(s.user_code!)}`
+  );
+  // the started code is real: poll it → pending
+  check("start → device_code is pollable (pending)", (await store.pollDeviceLogin(s.device_code!)).kind === "pending");
+
+  // rate limit: a fresh IP, 30 allowed then 429 (max 30 / window)
+  let limited = false;
+  for (let i = 0; i < 32; i++) {
+    const r = await startPost(startReq("5.9.9.9"));
+    if (r.status === 429) { limited = true; break; }
+  }
+  check("start → rate-limited after the per-IP cap", limited);
 }
 
 run()


### PR DESCRIPTION
Closes #179. Part of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md). Builds on the store from #177.

`POST /api/auth/device/start` — the unauthenticated work-machine UI begins a second-device login:

- Returns `device_code`, short `user_code` (display `XXXX-XXXX`), `verification_uri` (`<origin>/device`), `verification_uri_complete` (`?user_code=…`), `expires_in`, `interval`.
- Origin is proxy-aware (`requestOrigin`, honours `x-forwarded-host/proto`).
- **Same-origin only** (no CORS) — this is aido's own UI, not an external client.
- Per-IP **rate limit**; degrades to **503** when the Admin SDK is unconfigured.

### Tests
`tests/device-login.test.mts` extended: response shape, verification URIs honour the forwarded origin + `user_code`, the issued code is pollable (`pending`), and the per-IP rate limit trips. `npm run test:device-login` all green; `tsc`/`lint` clean.

### Follow-ups (epic #186)
Confirm endpoint #180, poll endpoint #181, `/device` page #182, login panel #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)