### PR TITLE
feat(device-login): confirm endpoint /api/auth/device/confirm — #180

### DIFF
--- a/src/app/api/auth/device/confirm/route.ts
+++ b/src/app/api/auth/device/confirm/route.ts
@@ -1,0 +1,63 @@
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { rateLimit } from "@/lib/apiKeys";
+import { approveDeviceLogin, denyDeviceLogin } from "@/lib/auth/deviceLogin";
+
+// Device-login confirm endpoint (issue #180, epic #186). Called from the /device
+// consent page on the trusted second device: the user is signed in with the
+// existing Firebase Google login and posts their ID token + the user_code shown
+// on the work machine. We verify the ID token → uid (like the OAuth confirm) and
+// approve/deny the pending device-login code. The work machine's poller then
+// receives a Firebase custom token (issue #181). Same-origin only (no CORS).
+
+export const dynamic = "force-dynamic";
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  // Rate-limit per IP to blunt user_code guessing (codes are short-lived + high
+  // entropy, so this is defence in depth).
+  if (!rateLimit(`device-login:confirm:${clientIp(req)}`, { max: 60, windowMs: 60 * 60 * 1000 })) {
+    return err("rate_limited", "Too many confirmation attempts; try again later.", 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return err("invalid_request", "Invalid JSON body.", 400);
+  }
+  const b = (body ?? {}) as Record<string, unknown>;
+  const idToken = str(b.idToken);
+  const userCode = str(b.userCode);
+  const action = str(b.action);
+
+  if (!idToken || !userCode) return err("invalid_request", "Missing idToken or userCode.", 400);
+  if (action !== "approve" && action !== "deny") {
+    return err("invalid_request", "action must be 'approve' or 'deny'.", 400);
+  }
+
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) return err("server_error", "Auth is not configured.", 503);
+
+  let uid: string;
+  try {
+    uid = (await adminAuth.verifyIdToken(idToken)).uid;
+  } catch {
+    return err("access_denied", "Invalid or expired Firebase ID token.", 401);
+  }
+
+  const ok = action === "approve" ? await approveDeviceLogin(userCode, uid) : await denyDeviceLogin(userCode);
+  if (!ok) {
+    return err("invalid_request", "Unknown, expired or already-decided user_code.", 400);
+  }
+  return Response.json({ status: action === "approve" ? "approved" : "denied" });
+}

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -24,6 +24,7 @@ initializeApp({ projectId }, "admin");
 const store = await import("../src/lib/auth/deviceLogin.ts");
 const { getAdminDb } = await import("../src/lib/firebase/admin.ts");
 const { POST: startPost } = await import("../src/app/api/auth/device/start/route.ts");
+const { POST: confirmPost } = await import("../src/app/api/auth/device/confirm/route.ts");
 
 const sha256 = (v: string) => createHash("sha256").update(v).digest("hex");
 
@@ -32,6 +33,25 @@ function startReq(ip = "5.0.0.1"): Request {
     method: "POST",
     headers: { "content-type": "application/json", "x-forwarded-for": ip, "x-forwarded-host": "aido.example", "x-forwarded-proto": "https" },
   });
+}
+
+function confirmReq(bodyObj: unknown, ip = "6.0.0.1"): Request {
+  return new Request("https://aido.example/api/auth/device/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(bodyObj),
+  });
+}
+
+// Mint a real emulator Firebase ID token via the Auth emulator REST API.
+async function mintIdToken(): Promise<{ idToken: string; uid: string }> {
+  const host = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+  const res = await fetch(
+    `http://${host}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-key`,
+    { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ returnSecureToken: true }) }
+  );
+  const data = (await res.json()) as { idToken: string; localId: string };
+  return { idToken: data.idToken, uid: data.localId };
 }
 
 let failures = 0;
@@ -130,6 +150,28 @@ async function run() {
     if (r.status === 429) { limited = true; break; }
   }
   check("start → rate-limited after the per-IP cap", limited);
+
+  // --- confirm endpoint (issue #180): approve binds the real uid; poll → approved ---
+  const ca = await store.createDeviceLogin();
+  const { idToken, uid } = await mintIdToken();
+  const caRes = await confirmPost(confirmReq({ idToken, userCode: ca.userCode, action: "approve" }));
+  const caJson = (await caRes.json()) as { status?: string };
+  check("confirm approve → 200 {status: approved}", caRes.status === 200 && caJson.status === "approved");
+  const caPoll = await store.pollDeviceLogin(ca.deviceCode);
+  check("confirm approve binds the real uid", caPoll.kind === "approved" && (caPoll as { uid: string }).uid === uid);
+
+  // deny
+  const cd = await store.createDeviceLogin();
+  const cdRes = await confirmPost(confirmReq({ idToken, userCode: cd.userCode, action: "deny" }));
+  check("confirm deny → 200 {status: denied}", cdRes.status === 200 && ((await cdRes.json()) as { status?: string }).status === "denied");
+  check("confirm deny → poll denied", (await store.pollDeviceLogin(cd.deviceCode)).kind === "denied");
+
+  // error cases
+  const cerr = await store.createDeviceLogin();
+  check("confirm invalid id token → 401", (await confirmPost(confirmReq({ idToken: "not-a-token", userCode: cerr.userCode, action: "approve" }))).status === 401);
+  check("confirm unknown user_code → 400", (await confirmPost(confirmReq({ idToken, userCode: "ZZZZ-ZZZZ", action: "approve" }))).status === 400);
+  check("confirm missing fields → 400", (await confirmPost(confirmReq({ idToken, action: "approve" }))).status === 400);
+  check("confirm bad action → 400", (await confirmPost(confirmReq({ idToken, userCode: cerr.userCode, action: "frobnicate" }))).status === 400);
 }
 
 run()


### PR DESCRIPTION
Closes #180. Part of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md). Builds on the store (#177).

`POST /api/auth/device/confirm` — called from the `/device` consent page on the **trusted second device**:

- Verifies the **Firebase ID token → uid** (`getAdminAuth().verifyIdToken`, same as the OAuth confirm).
- `action: "approve"` → `approveDeviceLogin(userCode, uid)`; `"deny"` → `denyDeviceLogin(userCode)`.
- Errors: **401** `access_denied` (bad/expired ID token), **400** `invalid_request` (unknown/expired/already-decided code, or malformed input), **503** `server_error` (Admin SDK unconfigured). Per-IP rate limit as defence-in-depth against `user_code` guessing.

### Tests
`tests/device-login.test.mts` extended (Auth emulator via `mintIdToken`): approve binds the **real uid** (verified via poll), deny → denied, invalid token → 401, unknown `user_code` → 400, missing/bad input → 400. `npm run test:device-login` all green; `tsc`/`lint` clean.

### Follow-ups (epic #186)
Poll endpoint #181 (→ Firebase custom token), `/device` page #182, login panel #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)