### PR TITLE
feat(device-login): poll endpoint → Firebase custom token — #181

### DIFF
--- a/src/app/api/auth/device/poll/route.ts
+++ b/src/app/api/auth/device/poll/route.ts
@@ -1,0 +1,77 @@
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { rateLimit } from "@/lib/apiKeys";
+import { pollDeviceLogin } from "@/lib/auth/deviceLogin";
+
+// Device-login poll endpoint (issue #181, epic #186). The work-machine UI polls
+// this with its device_code. Until the user approves on the trusted device it
+// gets authorization_pending / slow_down (RFC 8628 §3.5 error codes); once
+// approved it receives a Firebase custom token, which the UI hands to
+// signInWithCustomToken to establish a real web session — so the Google login
+// never crosses the work (proxy) channel. The approved code is single-use
+// (consumed by pollDeviceLogin). Same-origin only (no CORS).
+
+export const dynamic = "force-dynamic";
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+function err(error: string, status: number): Response {
+  return Response.json({ error }, { status, headers: { "Cache-Control": "no-store" } });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  // Generous per-IP cap: a flow polls ~once per `interval` for up to the TTL.
+  if (!rateLimit(`device-login:poll:${clientIp(req)}`, { max: 300, windowMs: 60 * 60 * 1000 })) {
+    return err("slow_down", 429);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return err("invalid_request", 400);
+  }
+  const deviceCode = str((body as Record<string, unknown> | null)?.device_code);
+  if (!deviceCode) return err("invalid_request", 400);
+
+  // Check Auth availability before polling, so a misconfigured server doesn't
+  // consume an approved code it then can't turn into a token.
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) return err("server_error", 503);
+
+  let result;
+  try {
+    result = await pollDeviceLogin(deviceCode);
+  } catch (e) {
+    console.error("[auth/device/poll] poll failed", e);
+    return err("server_error", 503);
+  }
+
+  switch (result.kind) {
+    case "pending":
+      return err("authorization_pending", 400);
+    case "slow_down":
+      return err("slow_down", 400);
+    case "denied":
+      return err("access_denied", 400);
+    case "expired":
+      return err("expired_token", 400);
+    case "approved": {
+      let customToken: string;
+      try {
+        customToken = await adminAuth.createCustomToken(result.uid);
+      } catch (e) {
+        console.error("[auth/device/poll] createCustomToken failed", e);
+        return err("server_error", 503);
+      }
+      return Response.json(
+        { firebaseCustomToken: customToken },
+        { headers: { "Cache-Control": "no-store" } }
+      );
+    }
+  }
+}

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -25,8 +25,31 @@ const store = await import("../src/lib/auth/deviceLogin.ts");
 const { getAdminDb } = await import("../src/lib/firebase/admin.ts");
 const { POST: startPost } = await import("../src/app/api/auth/device/start/route.ts");
 const { POST: confirmPost } = await import("../src/app/api/auth/device/confirm/route.ts");
+const { POST: pollPost } = await import("../src/app/api/auth/device/poll/route.ts");
+const { getAdminAuth } = await import("../src/lib/firebase/admin.ts");
 
 const sha256 = (v: string) => createHash("sha256").update(v).digest("hex");
+
+function pollReq(deviceCode: unknown, ip = "7.0.0.1"): Request {
+  return new Request("https://aido.example/api/auth/device/poll", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify({ device_code: deviceCode }),
+  });
+}
+
+// Exchange a custom token for an ID token via the Auth emulator REST API,
+// proving the token actually establishes a session.
+async function exchangeCustomToken(customToken: string): Promise<string | null> {
+  const host = process.env.FIREBASE_AUTH_EMULATOR_HOST;
+  const res = await fetch(
+    `http://${host}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake-key`,
+    { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ token: customToken, returnSecureToken: true }) }
+  );
+  if (!res.ok) return null;
+  const data = (await res.json()) as { idToken?: string };
+  return data.idToken ?? null;
+}
 
 function startReq(ip = "5.0.0.1"): Request {
   return new Request("https://aido.example/api/auth/device/start", {
@@ -172,6 +195,31 @@ async function run() {
   check("confirm unknown user_code → 400", (await confirmPost(confirmReq({ idToken, userCode: "ZZZZ-ZZZZ", action: "approve" }))).status === 400);
   check("confirm missing fields → 400", (await confirmPost(confirmReq({ idToken, action: "approve" }))).status === 400);
   check("confirm bad action → 400", (await confirmPost(confirmReq({ idToken, userCode: cerr.userCode, action: "frobnicate" }))).status === 400);
+
+  // --- poll endpoint (issue #181): RFC error codes, then custom token on approve ---
+  const pf = await store.createDeviceLogin();
+  const pPending = await pollPost(pollReq(pf.deviceCode));
+  check("poll pending → 400 authorization_pending", pPending.status === 400 && ((await pPending.json()) as { error?: string }).error === "authorization_pending");
+  const pSlow = await pollPost(pollReq(pf.deviceCode));
+  check("poll too fast → 400 slow_down", pSlow.status === 400 && ((await pSlow.json()) as { error?: string }).error === "slow_down");
+  check("poll missing device_code → 400 invalid_request", ((await (await pollPost(pollReq(undefined))).json()) as { error?: string }).error === "invalid_request");
+  check("poll unknown device_code → 400 expired_token", ((await (await pollPost(pollReq("nope"))).json()) as { error?: string }).error === "expired_token");
+
+  // approve via confirm, then poll → custom token that actually signs in
+  const { idToken: pIdToken, uid: pUid } = await mintIdToken();
+  await confirmPost(confirmReq({ idToken: pIdToken, userCode: pf.userCode, action: "approve" }));
+  const pOk = await pollPost(pollReq(pf.deviceCode));
+  const pJson = (await pOk.json()) as { firebaseCustomToken?: string };
+  check("poll approved → 200 firebaseCustomToken", pOk.status === 200 && typeof pJson.firebaseCustomToken === "string" && pJson.firebaseCustomToken!.length > 0);
+  const exchangedIdToken = pJson.firebaseCustomToken ? await exchangeCustomToken(pJson.firebaseCustomToken) : null;
+  const exchangedUid = exchangedIdToken ? (await getAdminAuth()!.verifyIdToken(exchangedIdToken)).uid : null;
+  check("poll custom token signs in as the approving uid", exchangedUid === pUid);
+  check("poll after consume → 400 expired_token (single-use)", ((await (await pollPost(pollReq(pf.deviceCode))).json()) as { error?: string }).error === "expired_token");
+
+  // denied flow surfaces access_denied
+  const pd = await store.createDeviceLogin();
+  await store.denyDeviceLogin(pd.userCode);
+  check("poll denied → 400 access_denied", ((await (await pollPost(pollReq(pd.deviceCode))).json()) as { error?: string }).error === "access_denied");
 }
 
 run()


### PR DESCRIPTION
Closes #181. Part of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md). Builds on the store (#177) and confirm (#180).

`POST /api/auth/device/poll` — the work-machine UI polls with its `device_code`:

- `pending` → 400 `authorization_pending`; too fast → 400 `slow_down`; `denied` → 400 `access_denied`; expired/unknown → 400 `expired_token` (RFC 8628 §3.5 codes).
- **`approved` → 200 `{ firebaseCustomToken }`** via `getAdminAuth().createCustomToken(uid)` — the UI hands this to `signInWithCustomToken` for a real session. **Single-use** (the code is consumed on the approved poll).
- Auth availability is checked **before** polling so a misconfigured server can't consume an approval it can't fulfil; **503** `server_error` otherwise.

### Tests
`tests/device-login.test.mts` extended: all error codes, missing input, and the approved path **end-to-end** — the returned custom token is exchanged via the Auth emulator (`signInWithCustomToken`) and `verifyIdToken` confirms it signs in as the **approving uid**; a re-poll after consumption → `expired_token`. `npm run test:device-login` all green (36 checks); `tsc`/`lint` clean.

### Follow-ups (epic #186)
`/device` consent page #182, login panel #183 (wires Start→QR→Poll→`signInWithCustomToken`), E2E #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)