### PR TITLE
feat(device-login): work-machine login panel + QR — #183

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "next": "^15.5.19",
         "node-mocks-http": "^1.17.2",
         "postcss": "^8.4.35",
+        "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -44,6 +45,7 @@
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/cli": "^0.1.13",
+        "@types/qrcode": "^1.5.6",
         "eslint": "8.57.0",
         "eslint-config-next": "^15.5.19",
         "tsx": "^4.22.4"
@@ -3110,6 +3112,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.3.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.21.tgz",
@@ -4324,6 +4336,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -4683,6 +4704,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4756,6 +4786,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -8418,6 +8454,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8449,7 +8494,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8604,6 +8648,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8982,6 +9035,161 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -9183,6 +9391,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -9504,6 +9718,12 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -10781,6 +11001,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "next": "^15.5.19",
     "node-mocks-http": "^1.17.2",
     "postcss": "^8.4.35",
+    "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
@@ -54,6 +55,7 @@
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/cli": "^0.1.13",
+    "@types/qrcode": "^1.5.6",
     "eslint": "8.57.0",
     "eslint-config-next": "^15.5.19",
     "tsx": "^4.22.4"

--- a/src/app/login/DeviceLoginPanel.tsx
+++ b/src/app/login/DeviceLoginPanel.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import QRCode from "qrcode";
+import { signInWithCustomToken } from "firebase/auth";
+import { auth } from "@/lib/firebase/firebase";
+
+// Work-machine side of the device-login flow (issue #183, epic #186). Starts a
+// flow (/api/auth/device/start), shows the user_code + a locally-generated QR of
+// the verification URL, and polls (/api/auth/device/poll) until the user approves
+// on their second device — then signs in with the returned Firebase custom token.
+// The QR is generated client-side (no third-party service) so the code never
+// leaks to the very proxy this flow exists to avoid.
+
+interface StartResp {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+type Phase = "idle" | "waiting" | "signing-in" | "error";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export default function DeviceLoginPanel() {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [info, setInfo] = useState<StartResp | null>(null);
+  const [qr, setQr] = useState("");
+  const [message, setMessage] = useState("");
+  const cancelled = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      cancelled.current = true;
+    };
+  }, []);
+
+  // Generate the QR for the prefilled verification URL whenever a flow starts.
+  useEffect(() => {
+    if (!info) {
+      setQr("");
+      return;
+    }
+    QRCode.toDataURL(info.verification_uri_complete, { margin: 1, width: 200 })
+      .then(setQr)
+      .catch(() => setQr(""));
+  }, [info]);
+
+  async function start() {
+    cancelled.current = false;
+    setPhase("waiting");
+    setMessage("");
+    setInfo(null);
+    let started: StartResp;
+    try {
+      const res = await fetch("/api/auth/device/start", { method: "POST" });
+      if (!res.ok) throw new Error("start failed");
+      started = (await res.json()) as StartResp;
+    } catch {
+      setPhase("error");
+      setMessage("Konnte die Anmeldung nicht starten. Bitte erneut versuchen.");
+      return;
+    }
+    setInfo(started);
+    void poll(started);
+  }
+
+  async function poll(started: StartResp) {
+    let interval = Math.max(1, started.interval) * 1000;
+    while (!cancelled.current) {
+      await sleep(interval);
+      if (cancelled.current) return;
+      let data: { firebaseCustomToken?: string; error?: string };
+      try {
+        const res = await fetch("/api/auth/device/poll", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ device_code: started.device_code }),
+        });
+        data = await res.json();
+      } catch {
+        continue; // transient network blip — keep polling
+      }
+      if (data.firebaseCustomToken) {
+        setPhase("signing-in");
+        try {
+          await signInWithCustomToken(auth, data.firebaseCustomToken);
+          // AuthProvider picks up the session; LoginPage redirects to /todos.
+        } catch {
+          setPhase("error");
+          setMessage("Anmeldung fehlgeschlagen. Bitte erneut versuchen.");
+        }
+        return;
+      }
+      switch (data.error) {
+        case "authorization_pending":
+          break; // keep waiting
+        case "slow_down":
+          interval += 5000;
+          break;
+        case "access_denied":
+          setPhase("error");
+          setMessage("Auf dem anderen Gerät abgelehnt.");
+          return;
+        case "expired_token":
+          setPhase("error");
+          setMessage("Der Code ist abgelaufen. Bitte erneut starten.");
+          return;
+        default:
+          setPhase("error");
+          setMessage("Anmeldung fehlgeschlagen. Bitte erneut starten.");
+          return;
+      }
+    }
+  }
+
+  function reset() {
+    cancelled.current = true;
+    setPhase("idle");
+    setInfo(null);
+    setMessage("");
+  }
+
+  if (phase === "idle") {
+    return (
+      <button
+        onClick={start}
+        className="inline-flex items-center px-6 py-3 bg-bg-card border border-border rounded-md shadow-sm text-base font-medium text-text hover:bg-row-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg focus:ring-accent"
+      >
+        Über Zweitgerät anmelden
+      </button>
+    );
+  }
+
+  if (phase === "signing-in") {
+    return <p className="text-text-dim">Anmeldung läuft …</p>;
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="w-full max-w-sm text-center">
+        <p className="text-sm text-danger mb-3">{message}</p>
+        <button onClick={start} className="rounded-full bg-accent px-4 py-2 font-extrabold text-white">
+          Erneut versuchen
+        </button>
+      </div>
+    );
+  }
+
+  // waiting
+  return (
+    <div className="w-full max-w-sm rounded-2xl border border-border bg-bg-card p-6 text-center shadow-sm">
+      <p className="text-text-dim mb-4">
+        Öffne <span className="font-semibold text-text">{info?.verification_uri}</span> auf deinem Handy
+        und gib diesen Code ein:
+      </p>
+      <p className="font-mono text-3xl font-black tracking-widest mb-4">{info?.user_code}</p>
+      {qr && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={qr} alt="QR-Code zum Anmelden" width={200} height={200} className="mx-auto mb-4 rounded-lg bg-white p-2" />
+      )}
+      <p className="text-sm text-text-dim mb-4">Warte auf Bestätigung vom anderen Gerät …</p>
+      <button onClick={reset} className="text-sm font-semibold text-text-dim hover:text-text">
+        Abbrechen
+      </button>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useAuth } from '@/lib/hooks/useAuth';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import DeviceLoginPanel from './DeviceLoginPanel';
 
 export default function LoginPage() {
   const { user, signInWithGoogle, loading } = useAuth();
@@ -43,6 +44,14 @@ export default function LoginPage() {
       >
         Sign in with Google
       </button>
+
+      <div className="flex items-center gap-3 my-6 w-full max-w-xs text-text-dim">
+        <span className="h-px flex-1 bg-border" />
+        <span className="text-xs uppercase tracking-wide">oder</span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+
+      <DeviceLoginPanel />
     </div>
   );
 } 


### PR DESCRIPTION
Closes #183. Part of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md). Wires together start (#179) / poll (#181) and the `/device` page (#182). **This completes the user-facing flow.**

Adds **"Über Zweitgerät anmelden"** to the login page (additive — the Google button is unchanged):

1. `POST /api/auth/device/start` → shows the `user_code` + a **locally generated QR** of `verification_uri_complete`.
2. Polls `POST /api/auth/device/poll` honouring `authorization_pending` / `slow_down` (+5s) / `expired_token` / `access_denied`.
3. On approval → `signInWithCustomToken(auth, …)`; the existing `AuthProvider` redirects to `/todos`.
4. Polling stops on unmount/cancel; expired/denied offer a restart.

**QR is generated client-side** via the `qrcode` package (added) — never a third-party service, so the code can't leak to the very proxy this flow avoids.

### Verification
`npx tsc --noEmit`, `npm run lint`, `npm run build` all clean — `/login` (10.6 kB) and all device routes build.

### End-to-end
The full chain is now in place. Manual E2E: open `/login` → "Über Zweitgerät anmelden" → scan QR / open `/device` on a second device → approve → work machine lands on `/todos`, with the Google login only ever happening on the second device. Automated E2E coverage is #184; hardening/revoke is #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)