### PR TITLE
feat(device-login): sign-out-everywhere + hardening — #185

### DIFF
--- a/docs/04-spezifikation-web-device-login.md
+++ b/docs/04-spezifikation-web-device-login.md
@@ -136,6 +136,11 @@ await signInWithCustomToken(auth, firebaseCustomToken); // → Session → route
   `revokeRefreshTokens(uid)`. Minimierung: kurze `ttlSec`, Single-use, sofortiger
   Exchange. **DPoP ist für Firebase-Sessions nicht anwendbar** (anders als der
   MCP-Pfad #174).
+- **Revoke (#185):** Für den Notfall gibt es „Auf allen Geräten abmelden" in den
+  Settings → `POST /api/auth/sessions/revoke` (verifiziert das ID-Token → uid,
+  `getAdminAuth().revokeRefreshTokens(uid)`). ID-Tokens bleiben bis Ablauf (~1 h)
+  gültig (kein `checkRevoked` auf jedem Read); der Client meldet sich lokal sofort
+  ab. TTL (5 min) + Single-use + per-IP-Rate-Limit auf confirm runden die Härtung ab.
 
 ## 3. Implementierungsplan
 

--- a/src/app/api/auth/sessions/revoke/route.ts
+++ b/src/app/api/auth/sessions/revoke/route.ts
@@ -1,0 +1,50 @@
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { rateLimit } from "@/lib/apiKeys";
+
+// Session-revoke endpoint (issue #185, epic #186). Lets a signed-in user revoke
+// all of their refresh tokens — the "sign out everywhere" escape hatch that
+// bounds the device-login residual: if a proxy ever rode the resulting session,
+// the user can kill it. The caller proves identity with their Firebase ID token
+// (Bearer); we verify it → uid and revoke. Same-origin only.
+//
+// Note: revokeRefreshTokens invalidates tokens issued before now; existing ID
+// tokens stay valid until they expire (~1h) unless verified with checkRevoked.
+// The client signs out locally for immediate effect on the current device.
+
+export const dynamic = "force-dynamic";
+
+function clientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  return fwd ? fwd.split(",")[0].trim() : "unknown";
+}
+function err(error: string, description: string, status: number): Response {
+  return Response.json({ error, error_description: description }, { status });
+}
+
+export async function POST(req: Request): Promise<Response> {
+  if (!rateLimit(`auth:sessions:revoke:${clientIp(req)}`, { max: 20, windowMs: 60 * 60 * 1000 })) {
+    return err("rate_limited", "Too many requests; try again later.", 429);
+  }
+
+  const header = req.headers.get("authorization") ?? "";
+  const match = header.match(/^Bearer (.+)$/i);
+  if (!match) return err("invalid_request", "Missing bearer ID token.", 401);
+
+  const adminAuth = getAdminAuth();
+  if (!adminAuth) return err("server_error", "Auth is not configured.", 503);
+
+  let uid: string;
+  try {
+    uid = (await adminAuth.verifyIdToken(match[1])).uid;
+  } catch {
+    return err("access_denied", "Invalid or expired Firebase ID token.", 401);
+  }
+
+  try {
+    await adminAuth.revokeRefreshTokens(uid);
+  } catch (e) {
+    console.error("[auth/sessions/revoke] revokeRefreshTokens failed", e);
+    return err("server_error", "Could not revoke sessions.", 503);
+  }
+  return Response.json({ revoked: true });
+}

--- a/src/components/SessionSettings.tsx
+++ b/src/components/SessionSettings.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+// "Sign out everywhere" control (issue #185, epic #186). Revokes all of the
+// user's refresh tokens server-side, then signs out locally. This is the escape
+// hatch that bounds the device-login residual (a proxy that saw a custom token
+// can only ride the session until it's revoked here).
+
+export default function SessionSettings() {
+  const { user, signOut } = useAuth();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function revokeAll() {
+    if (!user) return;
+    setBusy(true);
+    setError("");
+    try {
+      const idToken = await user.getIdToken();
+      const res = await fetch("/api/auth/sessions/revoke", {
+        method: "POST",
+        headers: { authorization: `Bearer ${idToken}` },
+      });
+      if (!res.ok) throw new Error("revoke failed");
+      // Local sign-out for immediate effect; the protected layout redirects to /login.
+      await signOut();
+    } catch {
+      setError("Konnte die Sitzungen nicht abmelden. Bitte erneut versuchen.");
+      setBusy(false);
+      setConfirming(false);
+    }
+  }
+
+  return (
+    <div className="bg-bg-card p-6 rounded-lg shadow">
+      <h2 className="text-xl font-semibold mb-2 text-text">Sicherheit</h2>
+      <p className="text-sm text-text-dim mb-4">
+        Meldet dich auf <span className="font-semibold text-text">allen</span> Geräten ab (widerruft alle
+        Sitzungen). Nutze dies, wenn du dich über ein fremdes Gerät angemeldet hast.
+      </p>
+
+      {error && <p className="text-sm text-danger mb-3">{error}</p>}
+
+      {!confirming ? (
+        <button
+          onClick={() => setConfirming(true)}
+          className="px-4 py-2 rounded-lg border border-danger text-danger hover:bg-danger-soft focus:outline-none focus:ring-2 focus:ring-danger"
+        >
+          Auf allen Geräten abmelden
+        </button>
+      ) : (
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-text-dim">Wirklich überall abmelden?</span>
+          <button
+            onClick={revokeAll}
+            disabled={busy}
+            className="px-4 py-2 rounded-lg bg-danger text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-danger disabled:opacity-50"
+          >
+            {busy ? "…" : "Bestätigen"}
+          </button>
+          <button
+            onClick={() => setConfirming(false)}
+            disabled={busy}
+            className="text-sm font-semibold text-text-dim hover:text-text disabled:opacity-50"
+          >
+            Abbrechen
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -8,6 +8,7 @@ import { useError } from '@/lib/hooks/useError';
 import { useTheme } from '@/lib/contexts/ThemeContext';
 import Image from 'next/image';
 import ApiKeySettings from './ApiKeySettings';
+import SessionSettings from './SessionSettings';
 
 interface UserSettingsState {
   displayName: string;
@@ -295,6 +296,8 @@ export default function UserSettings() {
         </div>
 
         <ApiKeySettings />
+
+        <SessionSettings />
 
         {error && (
           <div className="bg-danger-soft border border-danger text-danger px-4 py-3 rounded relative" role="alert">

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -26,7 +26,17 @@ const { getAdminDb } = await import("../src/lib/firebase/admin.ts");
 const { POST: startPost } = await import("../src/app/api/auth/device/start/route.ts");
 const { POST: confirmPost } = await import("../src/app/api/auth/device/confirm/route.ts");
 const { POST: pollPost } = await import("../src/app/api/auth/device/poll/route.ts");
+const { POST: revokePost } = await import("../src/app/api/auth/sessions/revoke/route.ts");
 const { getAdminAuth } = await import("../src/lib/firebase/admin.ts");
+
+function revokeReq(bearer: string | null, ip = "10.0.0.1"): Request {
+  return new Request("https://aido.example/api/auth/sessions/revoke", {
+    method: "POST",
+    headers: bearer
+      ? { authorization: `Bearer ${bearer}`, "x-forwarded-for": ip }
+      : { "x-forwarded-for": ip },
+  });
+}
 
 const sha256 = (v: string) => createHash("sha256").update(v).digest("hex");
 
@@ -260,6 +270,13 @@ async function run() {
     const denied = (await (await pollPost(pollReq(s.device_code, "9.0.0.1"))).json()) as { error?: string };
     check("e2e(deny): poll after deny → access_denied", denied.error === "access_denied");
   }
+
+  // --- session revoke endpoint (issue #185) ---
+  const { idToken: revIdToken } = await mintIdToken();
+  const revOk = await revokePost(revokeReq(revIdToken));
+  check("revoke valid id token → 200 {revoked}", revOk.status === 200 && ((await revOk.json()) as { revoked?: boolean }).revoked === true);
+  check("revoke missing bearer → 401", (await revokePost(revokeReq(null))).status === 401);
+  check("revoke invalid id token → 401", (await revokePost(revokeReq("not-a-token"))).status === 401);
 }
 
 run()


### PR DESCRIPTION
Closes #185. Final item of epic #186 — see [docs/04-spezifikation-web-device-login.md](docs/04-spezifikation-web-device-login.md).

Bounds the accepted device-login residual (a proxy that saw a custom token can ride the session only until it's revoked):

- **`POST /api/auth/sessions/revoke`** — verifies the caller's Firebase ID token → uid and `revokeRefreshTokens(uid)`; rate-limited; 503 without the Admin SDK.
- **Settings → "Sicherheit" → "Auf allen Geräten abmelden"** (two-step confirm) → revokes server-side, then signs out locally (the protected layout redirects to `/login`).
- **Hardening already in place** and now documented: 5-min `device_code` TTL, single-use approval, per-IP rate limits on start/confirm/poll.
- **Spec note:** DPoP is not applicable to Firebase sessions, so revoke is the mitigation; ID tokens stay valid until expiry (~1h).

### Tests
`tests/device-login.test.mts` extended: revoke valid token → 200 `{revoked}`, missing/invalid bearer → 401. `npm run test:device-login` all green (47 checks); `tsc`/`lint`/`build` clean (revoke route + `/settings` build).

**This completes epic #186** — the device-login web flow plus its safety hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)