### PR TITLE
fix(device-login): consent form action verb mismatch broke approval

### DIFF
--- a/src/app/device/DeviceConsentForm.tsx
+++ b/src/app/device/DeviceConsentForm.tsx
@@ -18,7 +18,7 @@ export default function DeviceConsentForm({ initialUserCode }: { initialUserCode
   const [error, setError] = useState("");
   const [outcome, setOutcome] = useState<Outcome | null>(null);
 
-  async function decide(action: Outcome) {
+  async function decide(action: "approve" | "deny") {
     if (!user) return;
     const code = userCode.trim();
     if (!code) {
@@ -103,14 +103,14 @@ export default function DeviceConsentForm({ initialUserCode }: { initialUserCode
 
                 <div className="flex gap-2">
                   <button
-                    onClick={() => decide("approved")}
+                    onClick={() => decide("approve")}
                     disabled={busy}
                     className="flex-1 rounded-full bg-accent px-4 py-2.5 font-extrabold text-white disabled:opacity-50"
                   >
                     {busy ? "…" : "Erlauben"}
                   </button>
                   <button
-                    onClick={() => decide("denied")}
+                    onClick={() => decide("deny")}
                     disabled={busy}
                     className="flex-1 rounded-full border border-border px-4 py-2.5 font-semibold text-text-dim hover:text-text disabled:opacity-50"
                   >

--- a/tests/device-login.test.mts
+++ b/tests/device-login.test.mts
@@ -205,6 +205,10 @@ async function run() {
   check("confirm unknown user_code → 400", (await confirmPost(confirmReq({ idToken, userCode: "ZZZZ-ZZZZ", action: "approve" }))).status === 400);
   check("confirm missing fields → 400", (await confirmPost(confirmReq({ idToken, action: "approve" }))).status === 400);
   check("confirm bad action → 400", (await confirmPost(confirmReq({ idToken, userCode: cerr.userCode, action: "frobnicate" }))).status === 400);
+  // Contract guard: the consent form must send the imperative action verbs. The
+  // past-tense forms (the original /device bug) are rejected — keep them in sync.
+  check("confirm rejects past-tense action 'approved' → 400", (await confirmPost(confirmReq({ idToken, userCode: cerr.userCode, action: "approved" }))).status === 400);
+  check("confirm accepts 'approve' (the form's value) → 200", (await confirmPost(confirmReq({ idToken, userCode: cerr.userCode, action: "approve" }))).status === 200);
 
   // --- poll endpoint (issue #181): RFC error codes, then custom token on approve ---
   const pf = await store.createDeviceLogin();


### PR DESCRIPTION
Fixes the device-login approval failure reported after epic #186: on `/device`, **every** approval showed *"Code unbekannt, abgelaufen oder bereits verwendet"* and login was impossible.

### Root cause
The consent form (`DeviceConsentForm`) posted its `Outcome` values as the action — `action: "approved" | "denied"` — but `POST /api/auth/device/confirm` only accepts the imperative verbs `"approve" | "deny"`. So confirm short-circuited to `invalid_request` **before** ever looking up the code, and the form maps any `invalid_request` to that "code unknown/expired/used" message.

It slipped through because the endpoint tests (and the #184 E2E) called confirm **directly** with the correct `"approve"/"deny"` — nothing exercised the form's real payload.

### Fix
- `DeviceConsentForm` now sends `"approve"/"deny"`; the success display still uses the endpoint's `{ status }` (`"approved"/"denied"`).
- Contract guard in `tests/device-login.test.mts`: confirm **rejects** `"approved"` (the bug) and **accepts** `"approve"` (the form's value).

`npm run test:device-login` green; `tsc`/`lint`/`build` clean. After merge + deploy, the second-device login completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)