### PR TITLE
docs(todo-verschieben): spec + Epic-Pattern in CLAUDE.md (#197)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,15 @@ Model Context Protocol endpoint with `streamable-http` (POST) and SSE (GET) tran
 - End commit messages with the `Co-Authored-By: Claude Fable 5` trailer and PR bodies with the Claude Code footer.
 - Vercel is the only CI check; it occasionally sticks on "pending" — an empty commit on the branch retriggers it.
 
+## Spec → Issues (Epic pattern)
+
+When a spec (e.g. the `docs/0X-*.md` flow from the `concept-analysis-spec` skill) is broken into **multiple** issues, **always** create one **Epic** issue as the parent and link the others as native GitHub **sub-issues** (not just a checklist):
+
+1. Create the Epic first (`gh issue create --label epic …`); its body holds the goal, links to the `docs/` spec files, the ordered sub-issue list, and the deploy ordering.
+2. Create each child issue (`Teil von Epic #<epic>` in the body; reference the same `docs/`).
+3. Link each child to the Epic via the sub-issues REST API — the child's **database id** (`gh api repos/{owner}/{repo}/issues/<child> --jq .id`), then `gh api --method POST repos/{owner}/{repo}/issues/<epic>/sub_issues -F sub_issue_id=<dbId>`. Verify with `gh api repos/{owner}/{repo}/issues/<epic>/sub_issues --jq '.[].number'`.
+4. The `epic` label already exists. A single issue from a spec needs no Epic.
+
 ## Merging
 
 - **Documentation-only changes may be merged immediately, without waiting for green CI.** This covers Markdown/docs, the `docs/` folder, README, comments — anything that does not affect application code or build output.

--- a/docs/01-konzept-todo-verschieben.md
+++ b/docs/01-konzept-todo-verschieben.md
@@ -1,0 +1,92 @@
+# Konzept: Todos in einen anderen Space verschieben
+
+## 1. Zusammenfassung
+
+Nutzer sollen ein bestehendes Todo aus seinem aktuellen Space in einen anderen
+Space, dem sie ebenfalls angehören, verschieben können ("Move to space"). Da
+Todos unter dem Firestore-Pfad `spaces/{spaceId}/todos/{id}` liegen und die
+`spaceId` Teil des Pfads ist, ist das technisch kein Feld-Update, sondern ein
+atomares **Anlegen im Ziel-Space + Löschen im Quell-Space**.
+
+## 2. Problemstellung
+
+Heute ist ein Todo dauerhaft an den Space gebunden, in dem es angelegt wurde.
+Wird ein Todo im falschen Space erstellt, oder ändert sich die Zuordnung
+(z. B. eine Aufgabe gehört thematisch in ein anderes Projekt/Team), gibt es
+keine Möglichkeit, es zu verschieben — der Nutzer muss es manuell im Ziel-Space
+neu anlegen (Titel, Body, Tags, Wartet-auf gehen dabei verloren) und das alte
+löschen. Das ist umständlich und fehleranfällig.
+
+## 3. Zielsetzung
+
+- Ein Todo kann mit wenigen Klicks/Taps von Space A nach Space B verschoben
+  werden, **ohne Datenverlust** (Titel, Body/Tiptap-JSON, Erledigt-Status,
+  Tags, Ersteller und Erstelldatum bleiben erhalten).
+- Die Aktion ist sowohl auf Desktop als auch auf Mobile erreichbar.
+- Die Operation ist **atomar** — es entstehen niemals Duplikate oder verlorene
+  Todos, auch wenn die Operation mittendrin abbricht.
+- Es können nur Spaces als Ziel gewählt werden, in denen der Nutzer Mitglied
+  ist (sonst würde die Firestore-Regel die Erstellung ohnehin ablehnen).
+- Datenkonsistenz: Felder, die an die Space-Mitgliedschaft gebunden sind
+  (`waitingOn`), werden beim Verschieben korrekt behandelt.
+
+## 4. Lösungsidee
+
+**Datenoperation (atomar via Firestore `writeBatch`):**
+1. Neues Todo-Dokument im Ziel-Space anlegen (`spaces/{zielId}/todos/{neueId}`)
+   mit allen übernommenen Feldern; `spaceId` wird auf die Ziel-`spaceId`
+   gesetzt; `order` wird im Ziel-Space neu berechnet (ans Ende).
+2. Quell-Todo (`spaces/{quellId}/todos/{id}`) löschen.
+3. Beide Schreibvorgänge in einem `writeBatch` → atomar.
+
+**`waitingOn`-Behandlung:** Ist `waitingOn` gesetzt und der referenzierte Nutzer
+ist **kein** Mitglied des Ziel-Spaces, wird `waitingOn` beim Verschieben auf
+`null` gesetzt (sonst lehnt die Firestore-Regel `hasValidWaitingOn()` den
+Schreibvorgang ab). Andernfalls bleibt es erhalten.
+
+**UI:** Eine neue Aktion "Verschieben →" im bestehenden Aktionsmenü pro Todo
+(`TodoActions`, genutzt sowohl im Desktop-Popover als auch im Mobile-
+BottomSheet der Liste). Beim Auswählen erscheint ein Picker mit allen anderen
+Spaces des Nutzers. Auswahl löst die Move-Operation aus; eine Toast-Meldung
+bestätigt ("In ‚<Space>' verschoben").
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Art der Änderung |
+|---|---|---|
+| Firestore-Schreiblogik | `src/lib/firebase/firebaseUtils.ts` | Neue Funktion `moveTodoToSpace(...)` (Batch: create im Ziel + delete in Quelle) |
+| Todos-State | `src/lib/contexts/TodosContext.tsx` | Neue Context-Methode `moveTodo(todoId, targetSpaceId)` |
+| Spaces-State | `src/lib/contexts/SpacesContext.tsx` | Liefert bereits Spaces+Mitglieder; ggf. Helfer zum Auflisten der Ziel-Spaces |
+| Listen-UI | `src/components/shell/list/TodoActions.tsx` | Neuer Eintrag "Verschieben" mit Space-Picker-Submenü (Desktop + Mobile) |
+| Board-UI (optional) | `src/components/shell/board/TodoCard.tsx` u. a. | Optional: Move-to-Space im Card-Menü (Abgrenzung beachten) |
+| Firestore-Regeln | `firestore.rules` | Voraussichtlich **keine** Änderung nötig (vorhandene create/delete-Regeln decken den Move ab) — wird in der Ist-Analyse verifiziert |
+| Tests | `tests/firestore-rules.test.mjs`, ggf. neuer Test | Regel-/Verhaltenstests für den Move |
+
+## 6. Abgrenzung
+
+Nicht Teil dieser Anforderung:
+
+- **Bulk-Move** (mehrere Todos gleichzeitig verschieben) — nur Einzel-Todo.
+- **Verschieben in einen Space, in dem der Nutzer NICHT Mitglied ist** — der
+  Picker zeigt nur eigene Spaces.
+- **Kopieren** (Original behalten) — es ist ein Verschieben, kein Duplizieren.
+- **Verschieben von Daily-/„Heute"-Items** — nur strukturierte Todos.
+- **Drag & Drop zwischen Spaces** — die Aktion läuft über das Menü/den Picker.
+  (Board-DnD bleibt auf Status/Person innerhalb des Spaces beschränkt.)
+- **Beibehalten der Todo-ID** im Ziel-Space — es wird eine neue ID vergeben
+  (Todos werden nirgends per ID referenziert).
+
+## 7. Offene Fragen (entschieden)
+
+1. **Board-Ansicht:** → **Nur Listen-Ansicht** im ersten Schritt. Board-Support
+   wird als optionales Folge-Issue erfasst, nicht Teil dieses Features.
+2. **`waitingOn` ungültig im Ziel-Space:** → **Vorher warnen/bestätigen.** Zeigt
+   der Wartet-auf-Nutzer im Ziel-Space nicht als Mitglied, wird der Nutzer
+   gewarnt, dass „Wartet auf" verloren geht, und muss bestätigen; bei Bestätigung
+   wird `waitingOn` auf `null` gesetzt.
+3. **Sichtbarkeit der Aktion bei nur einem Space:** → **Aktion ausblenden**, wenn
+   es keinen anderen Space als Ziel gibt.
+4. **Aktiver Space nach dem Verschieben:** → **Im aktuellen Space bleiben.** Das
+   Todo verschwindet aus der aktuellen Liste; ein Toast bestätigt das Verschieben.
+5. **`mentions` im Ziel-Space:** → **Unverändert übernehmen** (reine UIDs, bleiben
+   technisch gültig). Kein Filtern auf Ziel-Mitglieder in diesem Feature.

--- a/docs/02-ist-analyse-todo-verschieben.md
+++ b/docs/02-ist-analyse-todo-verschieben.md
@@ -1,0 +1,107 @@
+# Ist-Analyse: Todos in einen anderen Space verschieben
+
+## 1. Aktueller Zustand
+
+Todos sind heute fest an den Space gebunden, in dem sie erstellt wurden. Sie
+liegen unter `spaces/{spaceId}/todos/{id}`; die `spaceId` ist sowohl als Feld
+gespeichert als auch Teil des Firestore-Pfads. Es gibt keine Funktion zum
+Verschieben — weder in den Firestore-Utils, im `TodosContext`, noch in der UI.
+
+Die `TodosContext`-Subscription lädt ausschließlich die Todos des **aktiven**
+Spaces (`subscribeTodosForSpace(activeSpaceId, …)`). Andere Spaces sind dem
+Context nur über `useSpaces().spaces` als Metadaten (id, name, color, members)
+bekannt — deren Todos sind nicht geladen.
+
+Das Aktionsmenü pro Todo (`TodoActions`) bietet aktuell: **Bearbeiten**,
+**Wartet auf …** (Mitglieder-Picker + „Niemand"), **Löschen**. Es wird sowohl
+im Desktop-Popover (`TodoRow`) als auch im Mobile-BottomSheet (`MobileTodos`)
+mit derselben Komponente gerendert.
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/lib/firebase/firebaseUtils.ts` | Firestore-CRUD. `createTodo` (Z. 168–195), `deleteTodo` (Z. 262–263), `todosCol`/`todoRef` (Z. 146–149), `removeSpaceMember` (Z. 127–135, Batch-Vorbild) | **Hoch** — neue Funktion `moveTodoToSpace` hier ergänzen |
+| `src/lib/contexts/TodosContext.tsx` | State + CRUD des aktiven Spaces. `createTodo` berechnet `order` als `maxOrder+1` (Z. 164) | **Hoch** — neue Methode `moveTodo(id, targetSpaceId)` |
+| `src/lib/contexts/SpacesContext.tsx` | Liefert `spaces[]` (inkl. `members`), `activeSpace`, `activeSpaceId` | **Mittel** — Quelle der Ziel-Space-Liste; `members` zur `waitingOn`-Prüfung |
+| `src/components/shell/list/TodoActions.tsx` | Aktionsmenü pro Todo (Desktop + Mobile) | **Hoch** — neuer Eintrag „Verschieben →" mit Space-Picker-Submenü |
+| `src/components/shell/list/TodoRow.tsx` | Desktop-Zeile, rendert `TodoActions` im Popover (w-52) | **Niedrig** — ggf. nur Props-Durchreichung |
+| `src/components/shell/list/MobileTodos.tsx` | Rendert `TodoActions` im BottomSheet | **Niedrig** — funktioniert automatisch mit, da gleiche Komponente |
+| `src/lib/contexts/ToastContext.tsx` | `showToast(msg, action?)` (info, optional Undo-Button), `showError(msg)` | **Mittel** — Bestätigungs-Toast nach dem Verschieben |
+| `src/lib/types.ts` | `Todo`- und `Space`-Interface | **Niedrig** — keine Schemaänderung nötig |
+| `firestore.rules` | create/update/delete-Regeln für `spaces/{id}/todos/{id}` (Z. 117–156) | **Hoch** — bestimmt, was beim Verschieben erlaubt ist (siehe §4/§5) |
+| `tests/firestore-rules.test.mjs` | Regel-Tests für Todos | **Mittel** — Move-Verhalten (create im Ziel + delete in Quelle) absichern |
+
+## 3. Bestehende Abhängigkeiten
+
+- **`order`-Berechnung:** Im `TodosContext` wird `order` aus den **geladenen**
+  Todos des aktiven Spaces als `maxOrder+1` bestimmt. Der Ziel-Space ist nicht
+  geladen — sein `maxOrder` muss separat ermittelt werden (z. B.
+  `query(todosCol(target), orderBy("order","desc"), limit(1))`).
+- **`waitingOn`-Validierung:** `firestore.rules`' `hasValidWaitingOn()` verlangt,
+  dass `waitingOn` `null` ist **oder** ein Mitglied **des Ziel-Spaces** (per
+  `get()` auf das Ziel-Space-Dokument). Die Mitgliederliste des Ziels liegt
+  bereits im Client vor (`spaces[].members`) — keine Extra-Leseoperation nötig,
+  um die Gültigkeit vorab zu prüfen.
+- **`tags`/`mentions`:** Werden bei `createTodo` aus title/body abgeleitet
+  (`deriveTags`/`deriveMentions`). Beim Verschieben können die gespeicherten
+  Werte 1:1 übernommen werden (keine Space-Abhängigkeit bei `tags`; `mentions`
+  sind reine UIDs).
+- **Live-Updates:** Nach dem Verschieben aktualisiert sich die Quell-Liste
+  automatisch über die `onSnapshot`-Subscription (das Todo verschwindet). Der
+  Ziel-Space wird beim nächsten Aktivieren neu geladen / serverseitig gezählt.
+- **`openCounts`:** Werden für nicht-aktive Spaces einmalig serverseitig
+  gezählt (`countedRef`). Ein verschobenes Todo erhöht den Open-Count des Ziels
+  erst beim nächsten Zählen/Aktivieren — leichte, vorübergehende Ungenauigkeit
+  des Badges (siehe Risiken).
+
+## 4. Bekannte Einschränkungen
+
+- **Kein Modal/Confirm-Primitive vorhanden.** Es gibt im Code keine generische
+  Dialog-/Confirm-Komponente (nur `BottomSheet` und Popover-Muster). Die
+  „Wartet auf geht verloren"-Bestätigung muss daher **inline** im Picker gelöst
+  werden (zweistufig: Auswahl → Warnhinweis + „Trotzdem verschieben"), nicht über
+  `window.confirm` (Browser-Dialoge sind unerwünscht).
+- **`createdBy` ist beim Erstellen an den Schreibenden gebunden** (siehe §5,
+  Risiko 1) — der wichtigste Constraint dieses Features.
+- **Pfadgebundene `spaceId`:** Verschieben ist kein `updateDoc` — es erfordert
+  zwingend ein neues Dokument im Ziel + Löschen in der Quelle.
+- **Keine Transaktion über Collections nötig, aber Batch:** Ein `writeBatch`
+  (set Ziel + delete Quelle) ist atomar und ausreichend; die `order`-Ermittlung
+  ist ein vorgelagerter Lesevorgang außerhalb des Batches.
+
+## 5. Risiken bei Änderung
+
+1. **`createdBy` kann bei fremden Todos nicht erhalten bleiben (zentral).**
+   Die Todo-`create`-Regel (Z. 145–149) verlangt
+   `request.resource.data.createdBy == request.auth.uid`. Verschiebt Nutzer A
+   ein von Nutzer B erstelltes Todo, müsste das Ziel-Dokument `createdBy == B`
+   tragen — das lehnt die Regel ab. Konsequenzen/Optionen:
+   - **(empfohlen) `createdBy` = verschiebender Nutzer setzen, `createdAt` (Original) erhalten.**
+     Regelkonform ohne Rules-Änderung. Semantik: „A hat es hierher verschoben."
+     `createdAt` wird von keiner Todo-Regel beschränkt und darf den Originalwert behalten.
+   - `createdBy` **und** `createdAt` neu setzen (komplett „neu hier angelegt").
+   - Regeln aufweichen, um Original-`createdBy` zu erlauben — **abgelehnt**, da
+     das Fälschen von `createdBy` bei normalen Creates ermöglichen würde.
+   → **Gewählte Lösung (siehe Anforderungsanalyse):** Neues Feld **`modifiedBy`**
+   einführen. Die Todo-Regeln keyen den „wer schreibt"-Check künftig auf
+   `modifiedBy == request.auth.uid` (create *und* update); `createdBy` bleibt
+   damit beim Verschieben erhalten und unveränderlich. Zusätzlich verlangt die
+   create-Regel `createdBy in <Ziel-Mitglieder>`, womit ein Todo nur in Spaces
+   verschoben werden darf, in denen der **Ersteller** Mitglied ist (sonst
+   client-seitige Rückmeldung). Folge: **alle** Todo-Schreibpfade müssen
+   `modifiedBy` mitsetzen (Merge-Updates).
+2. **Atomaritäts-/Konsistenzrisiko bei nicht-atomarer Umsetzung.** Würde man
+   erst erstellen und dann löschen (zwei separate Writes), könnte ein Abbruch
+   ein Duplikat hinterlassen. → Zwingend `writeBatch` verwenden.
+3. **`waitingOn` wird im Ziel ungültig.** Zeigt `waitingOn` auf einen
+   Nicht-Mitglied des Ziels, lehnt die Regel den Create ab. → Vorab im Client
+   prüfen (`targetSpace.members.includes(todo.waitingOn)`), warnen und bei
+   Bestätigung `waitingOn` auf `null` setzen (Konzept-Entscheidung).
+4. **Open-Count-Badge des Ziels** ist kurzzeitig zu niedrig, bis der Ziel-Space
+   neu gezählt wird. Geringes, rein kosmetisches Risiko; ggf. `setOpenCount`
+   optimistisch anpassen.
+5. **Berechtigungen:** Verschieben erfordert Mitgliedschaft in **Quelle** (für
+   `delete`) und **Ziel** (für `create`). Da der Picker nur eigene Spaces zeigt,
+   ist die Ziel-Mitgliedschaft gegeben; ein Schreibfehler muss dennoch sauber
+   per `showError` abgefangen werden.

--- a/docs/03-anforderungsanalyse-todo-verschieben.md
+++ b/docs/03-anforderungsanalyse-todo-verschieben.md
@@ -1,0 +1,53 @@
+# Anforderungsanalyse: Todos in einen anderen Space verschieben
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Aktion „Verschieben →" | Muss | Im Todo-Aktionsmenü (`TodoActions`, Desktop-Popover **und** Mobile-BottomSheet) erscheint ein Eintrag „Verschieben →", der ein Submenü mit allen **anderen** Spaces des Nutzers öffnet. |
+| FA-02 | Atomares Verschieben | Muss | Auswahl eines Ziel-Spaces legt das Todo via **`writeBatch`** im Ziel an (`spaces/{ziel}/todos/{neueId}`) und löscht es in der Quelle — in einer atomaren Operation. Übernommen werden: `title`, `body`, `completed`, `tags`, `mentions`, `createdBy`, `createdAt`. `spaceId` = Ziel. |
+| FA-03 | `order` im Ziel | Muss | `order` im Ziel = `maxOrder(Ziel) + 1` (ans Ende). `maxOrder` wird per `query(todosCol(ziel), orderBy("order","desc"), limit(1))` ermittelt (1 Lesevorgang). |
+| FA-04 | Feld `modifiedBy` | Muss | Neues Todo-Feld `modifiedBy: string` = der zuletzt schreibende Nutzer. `createTodo`: `modifiedBy = createdBy = uid`. Jeder Update/Move: `modifiedBy = request.auth.uid`. Wird zum `Todo`-Typ, `mapTodo` und **allen** Schreibpfaden ergänzt. |
+| FA-05 | Regel-Anpassung (`firestore.rules`) | Muss | Todos `create`: `modifiedBy == request.auth.uid` **und** `createdBy in thisSpaceMembers()` (statt `createdBy == auth.uid`). Todos `update`: zusätzlich `modifiedBy == request.auth.uid`; `createdBy` bleibt unveränderlich. |
+| FA-06 | Ersteller muss Ziel-Zugriff haben | Muss | Ein Todo darf nur in einen Space verschoben werden, in dem sein **Ersteller** (`createdBy`) Mitglied ist. Client prüft `targetSpace.members.includes(todo.createdBy)` vorab; ist es nicht erfüllt → **Rückmeldung** (Toast/Hinweis), kein Move. Hart abgesichert durch FA-05 (`createdBy in thisSpaceMembers()`). |
+| FA-07 | `waitingOn`-Behandlung | Muss | Zeigt `waitingOn` auf einen Nicht-Mitglied des Ziels, wird vor dem Verschieben **inline gewarnt/bestätigt** („‚Wartet auf X' geht verloren — trotzdem verschieben?"). Bei Bestätigung wird `waitingOn = null` gesetzt; sonst Abbruch. (Kein `window.confirm`.) |
+| FA-08 | Aktion bei nur einem Space ausblenden | Soll | Existiert kein anderer Space als Ziel, wird „Verschieben →" nicht angezeigt. |
+| FA-09 | Bestätigungs-Toast | Soll | Nach erfolgreichem Verschieben: `showToast("In ‚<Space>' verschoben.")`. |
+| FA-10 | Undo | Kann | Der Toast bietet optional „Rückgängig" (verschiebt zurück in den Quell-Space). |
+| FA-11 | Verbleib im aktiven Space | Muss | Nach dem Verschieben bleibt der aktive Space unverändert; das Todo verschwindet aus der Quell-Liste (Live-Subscription). |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Berechtigung & Fälschungssicherheit | Sicherheit | Move regelseitig nur für Mitglieder von Quelle (delete) **und** Ziel (create). `modifiedBy == auth.uid` verhindert das Fälschen des Schreibenden; `createdBy in Ziel-Mitglieder` hält die Invariante „`createdBy` ist Mitglied seines Spaces" und verhindert Fremdzuweisung an Nicht-Mitglieder. |
+| NFA-02 | Atomarität / Konsistenz | Zuverlässigkeit | `writeBatch` garantiert: nie Duplikate, nie verlorene Todos, auch bei Abbruch. |
+| NFA-03 | Performance | Performance | Höchstens **1** zusätzlicher Lesevorgang (`maxOrder` im Ziel) pro Move; keine Vollladung des Ziel-Spaces. |
+| NFA-04 | Abwärtskompatibilität | Wartbarkeit | Bestehende Todos ohne `modifiedBy` bleiben editierbar — der erste Update setzt das Feld (Regel prüft den Post-Write-Zustand). Keine zwingende Datenmigration; `migrateLegacyTodos`/`createTodo` setzen `modifiedBy` für neue Schreibvorgänge mit. |
+| NFA-05 | Plattform-Parität & Scope | UX | Aktion auf Desktop und Mobile gleichwertig (gemeinsame `TodoActions`-Komponente). **Board** ist NICHT Teil dieses Features (optionales Folge-Issue). |
+| NFA-06 | Sprache & Tokens | UX/Konsistenz | Texte deutsch; Styling über bestehende Tokens/Muster (Popover `bg-bg-pop`/`border-border`, `BottomSheet`), keine neuen Design-Primitive außer der inline-Bestätigung. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] Im „…"-Menü eines Todos gibt es „Verschieben →" mit Liste der anderen Spaces (Desktop-Popover **und** Mobile-Sheet).
+- [ ] Auswahl eines Ziels verschiebt das Todo; danach ist es im Ziel-Space vorhanden und im Quell-Space verschwunden — ohne Datenverlust (Titel, Body, Tags, Erledigt-Status, `createdBy`, `createdAt` erhalten).
+- [ ] Die Operation ist atomar: Es entsteht nie ein Duplikat oder ein verlorenes Todo.
+- [ ] `order` im Ziel-Space ist `maxOrder+1` (Todo erscheint am Ende der Ziel-Liste).
+- [ ] `modifiedBy` ist nach dem Verschieben der verschiebende Nutzer; `createdBy`/`createdAt` sind unverändert.
+- [ ] Verschieben in einen Space, in dem der Ersteller **kein** Mitglied ist, ist nicht möglich; der Nutzer erhält eine klare Rückmeldung (kein roher Permission-Fehler).
+- [ ] Zeigt `waitingOn` auf einen Nicht-Mitglied des Ziels, erscheint vor dem Verschieben eine Bestätigung; nach Bestätigung ist `waitingOn` im Ziel `null`.
+- [ ] Hat der Nutzer nur einen Space, wird „Verschieben →" nicht angezeigt.
+- [ ] Nach erfolgreichem Verschieben erscheint ein Bestätigungs-Toast; der aktive Space bleibt gleich.
+- [ ] `firestore.rules`-Tests decken ab: erlaubter Move (Mitglied beider Spaces, Ersteller im Ziel), abgelehnter Move (Ersteller nicht im Ziel; `modifiedBy != auth.uid`; Nicht-Mitglied), `waitingOn`-Validierung im Ziel, sowie dass bestehende Update-Pfade weiterhin funktionieren (mit `modifiedBy`).
+- [ ] `npm run lint` und `npx tsc --noEmit` sind sauber.
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Baut auf dem Spaces-/Todos-Datenmodell (Issues #40, #41) und der Feld-Typ-Härtung (#71) auf.
+- Nutzt das Toast-Primitive (#43, inkl. optionalem Undo wie #70).
+- Verwandt mit `removeSpaceMember`/`waitingOn`-Aufräumlogik (#63) — gleiche Klasse von „Member-Referenz wird ungültig".
+- **Folge-Issue (nicht Teil):** Verschieben aus der Board-Ansicht (`TodoCard`).
+
+## 5. Priorisierung
+
+Hohe Dringlichkeit (vom User als „dringend" markiert). Reihenfolge: zuerst Datenschicht + Regeln (`modifiedBy`, `moveTodoToSpace`, Rules, Tests), dann Context-Methode, dann Listen-UI. Board-Support und Undo sind nachgelagert/optional.

--- a/docs/04-spezifikation-todo-verschieben.md
+++ b/docs/04-spezifikation-todo-verschieben.md
@@ -1,0 +1,253 @@
+# Spezifikation: Todos in einen anderen Space verschieben
+
+## 1. Übersicht
+
+Implementiert das Verschieben eines einzelnen Todos aus seinem Space in einen
+anderen Space des Nutzers. Technisch: atomares Anlegen im Ziel + Löschen in der
+Quelle (`writeBatch`). Begleitend wird ein Feld **`modifiedBy`** eingeführt, das
+den zuletzt schreibenden Nutzer festhält und auf das die Firestore-Regeln den
+„wer schreibt"-Check umstellen — so bleibt der ursprüngliche `createdBy` beim
+Verschieben erhalten, während die Regeln fälschungssicher bleiben. Basis:
+[Konzept](01-konzept-todo-verschieben.md),
+[Ist-Analyse](02-ist-analyse-todo-verschieben.md),
+[Anforderungsanalyse](03-anforderungsanalyse-todo-verschieben.md).
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+Drei Schichten, von unten nach oben:
+
+1. **Datenmodell + Regeln** — `modifiedBy`-Feld; Firestore-Regeln keyen auf
+   `modifiedBy == auth.uid` und `createdBy in Ziel-Mitglieder`.
+2. **Datenschicht** (`firebaseUtils.ts`) — alle Schreibpfade setzen `modifiedBy`;
+   neue `moveTodoToSpace`-Funktion (Batch).
+3. **State + UI** — `TodosContext.moveTodo(id, targetSpaceId)`; Eintrag
+   „Verschieben →" in `TodoActions` (Desktop-Popover + Mobile-Sheet).
+
+### 2.2 Datenmodell
+
+**`src/lib/types.ts` — `Todo` erweitern:**
+
+```ts
+export interface Todo {
+  // … bestehende Felder …
+  createdBy: string;
+  /** userId des zuletzt Schreibenden; rules erzwingen == auth.uid auf jedem Write. */
+  modifiedBy: string;
+  createdAt: Timestamp | null;
+  order: number;
+}
+```
+
+**`mapTodo` (firebaseUtils.ts)** — mit Legacy-Fallback auf `createdBy`:
+
+```ts
+modifiedBy:
+  typeof data.modifiedBy === "string" ? data.modifiedBy
+  : (typeof data.createdBy === "string" ? data.createdBy : ""),
+```
+
+Keine Schemaänderung an `Daily`/`Space`. Keine zwingende Datenmigration
+(NFA-04): Bestand bekommt `modifiedBy` beim ersten Schreibvorgang.
+
+### 2.3 Schnittstellen
+
+**`firestore.rules` — `spaces/{spaceId}/todos/{todoId}` (Diff):**
+
+```
+// neu
+function isValidModifiedBy() {
+  return request.resource.data.modifiedBy == request.auth.uid;
+}
+
+allow create: if isMemberOfThisSpace()
+  && isValidModifiedBy()
+  && request.resource.data.createdBy in thisSpaceMembers()   // war: createdBy == auth.uid
+  && hasValidTodoLists()
+  && hasValidTodoFields()
+  && hasValidWaitingOn();
+
+allow update: if isMemberOfThisSpace()
+  && request.resource.data.createdBy == resource.data.createdBy
+  && isValidModifiedBy()                                      // neu
+  && hasValidTodoLists()
+  && hasValidTodoFields()
+  && hasValidWaitingOn();
+```
+
+`thisSpaceMembers()` nutzt ein bereits gecachtes `get()` — kein Mehraufwand.
+
+**`firebaseUtils.ts` — Schreibpfade (`modifiedBy` ergänzen, Signaturen um `uid`):**
+
+```ts
+// create: modifiedBy = uid mitschreiben
+addDoc(todosCol(spaceId), { … , createdBy: uid, modifiedBy: uid, … });
+
+// Updates erhalten den schreibenden uid und setzen modifiedBy mit:
+editTodoContent(spaceId, todoId, title, body, uid, mentionMembers?)
+  → updateDoc(ref, { title, body, tags, mentions, modifiedBy: uid });
+setTodoCompleted(spaceId, todoId, completed, uid)
+  → updateDoc(ref, { completed, modifiedBy: uid });
+setTodoWaitingOn(spaceId, todoId, waitingOn, uid)
+  → updateDoc(ref, { waitingOn, modifiedBy: uid });
+setTodoStatus(spaceId, todoId, status, uid)
+  → updateDoc(ref, { ...status, modifiedBy: uid });
+```
+
+**`firebaseUtils.ts` — neue Funktion `moveTodoToSpace`:**
+
+```ts
+export const moveTodoToSpace = async (
+  todo: Todo,                 // Quelle steckt in todo.spaceId / todo.id
+  targetSpaceId: string,
+  uid: string,
+  opts?: { clearWaitingOn?: boolean }
+): Promise<string> => {
+  if (!todo.spaceId || !targetSpaceId || !uid) throw new Error("Missing args.");
+  const last = await getDocs(
+    query(todosCol(targetSpaceId), orderBy("order", "desc"), limit(1))
+  );
+  const maxOrder = last.empty ? 0 : (last.docs[0].data().order ?? 0);
+  const target = doc(todosCol(targetSpaceId)); // neue id
+  const batch = writeBatch(db);
+  batch.set(target, {
+    spaceId: targetSpaceId,
+    title: todo.title,
+    body: todo.body ?? null,
+    completed: todo.completed,
+    waitingOn: opts?.clearWaitingOn ? null : todo.waitingOn,
+    tags: todo.tags,
+    mentions: todo.mentions,
+    createdBy: todo.createdBy,          // Original-Autor erhalten
+    createdAt: todo.createdAt ?? serverTimestamp(),
+    modifiedBy: uid,
+    order: maxOrder + 1,
+  });
+  batch.delete(todoRef(todo.spaceId, todo.id));
+  await batch.commit();
+  return target.id;
+};
+```
+
+**`TodosContext.tsx` — neue Methode + uid an Updates durchreichen:**
+
+```ts
+// useSpaces zusätzlich: spaces
+const moveTodo = useCallback(
+  async (id: string, targetSpaceId: string): Promise<boolean> => {
+    if (!user) return false;
+    const todo = todos.find((t) => t.id === id);
+    const target = spaces.find((s) => s.id === targetSpaceId);
+    if (!todo || !target) return false;
+    if (!target.members.includes(todo.createdBy)) {
+      showError("Verschieben nicht möglich: der Ersteller hat keinen Zugriff auf diesen Space.");
+      return false;
+    }
+    const clearWaitingOn = !!todo.waitingOn && !target.members.includes(todo.waitingOn);
+    try {
+      await moveTodoToSpace(todo, targetSpaceId, user.uid, { clearWaitingOn });
+      showToast(`In „${target.name}" verschoben.`);
+      return true;
+    } catch (e) {
+      console.error("moveTodo failed", e);
+      showError("Todo konnte nicht verschoben werden.");
+      return false;
+    }
+  },
+  [user, todos, spaces, showToast, showError]
+);
+```
+
+Alle bestehenden Context-Mutationen (`setCompleted`/`setWaitingOn`/`setStatus`/
+`editContent`) übergeben künftig `user.uid` an die Utils.
+
+**`TodoActions.tsx` — Eintrag „Verschieben →":**
+
+- Bezieht `spaces` aus `useSpaces`, `moveTodo` aus `useTodos`.
+- `targets = spaces.filter((s) => s.id !== todo.spaceId)`. Ist `targets` leer →
+  Eintrag **nicht** rendern (FA-08).
+- Collapsible-Submenü analog zu „Wartet auf …" (gleiche Klassen/`item`-Styles).
+- Pro Ziel-Space:
+  - `creatorHasAccess = target.members.includes(todo.createdBy)` — wenn `false`:
+    Button **disabled** + dezenter Hinweis „Ersteller hat keinen Zugriff" (FA-06).
+  - `losesWaiting = !!todo.waitingOn && !target.members.includes(todo.waitingOn)`
+    — wenn `true`: Klick öffnet **inline-Bestätigung** im Submenü
+    („‚Wartet auf {nameOf(todo.waitingOn)}' geht verloren — Trotzdem
+    verschieben?" mit „Verschieben"/„Abbrechen"). Bestätigung → `moveTodo` +
+    `onClose`.
+  - sonst: Klick → `await moveTodo(todo.id, target.id); onClose();`
+- Lokaler State: `moveOpen` (Submenü auf/zu), `confirmTarget` (spaceId | null).
+- Farb-Punkt je Space optional über `spaceColorFromHue(target.color)`.
+
+### 3. Implementierungsplan
+
+#### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/types.ts` | `modifiedBy` zu `Todo` | Klein |
+| `src/lib/firebase/firebaseUtils.ts` | `mapTodo` + `createTodo` + 4 Update-Fns (Signatur/`modifiedBy`) + neue `moveTodoToSpace` | Mittel |
+| `src/lib/contexts/TodosContext.tsx` | `uid` an Updates, neue `moveTodo`-Methode, `spaces` aus `useSpaces` | Mittel |
+| `firestore.rules` | `isValidModifiedBy` + create/update-Regeln | Klein |
+| `src/components/shell/list/TodoActions.tsx` | „Verschieben →"-Submenü + Bestätigung/Feedback | Mittel |
+| `tests/firestore-rules.test.mjs` | Bestehende Todo-Writes um `modifiedBy` ergänzen + neue Move-/Spoof-Tests | Mittel |
+| `src/lib/firebase/firebaseUtils.ts` (`migrateLegacyTodos`) | `modifiedBy = createdBy` beim Migrieren mitsetzen (Admin, optional) | Klein |
+| MCP (`src/lib/mcp/*` add/complete/waiting) | `modifiedBy` mitsetzen (Admin-SDK umgeht Regeln; Konsistenz) — prüfen | Klein |
+
+#### 3.2 Reihenfolge der Implementierung
+
+1. **`modifiedBy` einführen** (App): Typ, `mapTodo`, `createTodo`, alle
+   Update-Pfade in `firebaseUtils` + `TodosContext`. (Issue A)
+2. **Firestore-Regeln** auf `modifiedBy`/`createdBy in Mitglieder` umstellen +
+   `firestore-rules`-Tests. **Deploy nach Schritt 1** (sonst lehnt die Regel die
+   Updates alter Clients ab). (Issue B)
+3. **`moveTodoToSpace` + `TodosContext.moveTodo`** (Datenoperation). (Issue C)
+4. **Listen-UI** „Verschieben →" in `TodoActions` inkl. `waitingOn`-Bestätigung,
+   Ersteller-Feedback und Bestätigungs-Toast. (Issue D)
+5. *(optional, Folge)* Board-Support; Undo im Toast. (Issue E)
+
+## 4. Testplan
+
+**Firestore-Regeln (`tests/firestore-rules.test.mjs`, `npm run test:rules`):**
+- Bestehende Todo-Create/Update-Tests um `modifiedBy = auth.uid` ergänzen
+  (sonst schlagen sie unter den neuen Regeln fehl).
+- Move erlaubt: Nutzer ist Mitglied von Quelle und Ziel, `createdBy` ist
+  Mitglied des Ziels, `modifiedBy == auth.uid` → create im Ziel + delete in
+  Quelle erlaubt.
+- Move abgelehnt: `createdBy` **nicht** Mitglied des Ziels → create denied.
+- Spoofing abgelehnt: `modifiedBy != auth.uid` (create und update) → denied.
+- `waitingOn` im Ziel ungültig (Nicht-Mitglied) → denied; `null` → erlaubt.
+- Regression: bestehende Update-Pfade (completed/waitingOn/edit) mit
+  `modifiedBy` weiterhin erlaubt; Nicht-Mitglieder weiterhin abgewiesen.
+
+**MCP-Tool-Tests (`npm run test:mcp`):** unverändert lauffähig; falls MCP-Writes
+`modifiedBy` setzen, dort abdecken.
+
+**Manuelle Tests:**
+- Eigenes Todo in anderen Space verschieben → erscheint dort am Ende, weg aus
+  Quelle, Toast erscheint, aktiver Space bleibt.
+- Fremdes Todo verschieben, dessen Ersteller im Ziel Mitglied ist → erfolgreich,
+  `createdBy` unverändert.
+- Ziel, in dem der Ersteller kein Mitglied ist → Button disabled/Feedback.
+- Todo mit `waitingOn` auf Nicht-Ziel-Mitglied → Bestätigung, danach `waitingOn`
+  leer im Ziel.
+- Nur ein Space vorhanden → kein „Verschieben →"-Eintrag.
+- Desktop-Popover und Mobile-BottomSheet beide geprüft.
+
+## 5. Migration / Deployment
+
+- **Reihenfolge zwingend:** Zuerst die App mit `modifiedBy`-Schreibpfaden
+  (Issue A) deployen (Vercel/`main`), **danach** die Regeln
+  (`npx -y firebase-tools@13 deploy --only firestore:rules`, Issue B). Sonst
+  würden bereits ausgelieferte alte Clients (ohne `modifiedBy`) bei jedem
+  Todo-Update von der neuen Regel abgewiesen.
+- Keine Datenmigration nötig; `modifiedBy` füllt sich lazy beim ersten Write.
+- Move-Feature (Issue C/D) setzt voraus, dass die Regeln (B) deployed sind,
+  damit auch **fremde** Todos verschoben werden können.
+
+## 6. Referenzen
+
+- [Konzeptdokument](01-konzept-todo-verschieben.md)
+- [Ist-Analyse](02-ist-analyse-todo-verschieben.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-todo-verschieben.md)


### PR DESCRIPTION
Spec-Dokumente (Konzept/Ist/Anforderungen/Spezifikation) für **Todos in einen anderen Space verschieben** und das Epic-Pattern in `CLAUDE.md`.

Teil von Epic #197 (Sub-Issues #198–#202).

Doc-only → laut Workflow sofort mergebar (kein Warten auf CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)