### PR TITLE
feat(todos): modifiedBy field + set on every todo write path (#198)

### DIFF
--- a/scripts/migrate-legacy-todos-admin.mjs
+++ b/scripts/migrate-legacy-todos-admin.mjs
@@ -226,6 +226,7 @@ export async function migrateOwner(db, uid, { dryRun = false } = {}) {
         tags,
         mentions,
         createdBy: uid,
+        modifiedBy: uid,
         createdAt: FieldValue.serverTimestamp(),
         order,
       });

--- a/src/lib/contexts/SpacesContext.tsx
+++ b/src/lib/contexts/SpacesContext.tsx
@@ -226,14 +226,15 @@ export const SpacesProvider = ({ children }: { children: ReactNode }) => {
 
   const removeMember = useCallback(
     async (spaceId: string, uid: string) => {
+      if (!user) return;
       try {
-        await removeSpaceMember(spaceId, uid);
+        await removeSpaceMember(spaceId, uid, user.uid);
       } catch (e) {
         console.error("removeMember failed", e);
         showError("Mitglied konnte nicht entfernt werden.");
       }
     },
-    [showError]
+    [user, showError]
   );
 
   const setOpenCount = useCallback((spaceId: string, count: number) => {

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -180,9 +180,9 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
 
   const editContent = useCallback(
     async (id: string, title: string, body: TiptapContent | null): Promise<boolean> => {
-      if (!activeSpaceId) return false;
+      if (!activeSpaceId || !user) return false;
       try {
-        await editTodoContent(activeSpaceId, id, title, body, mentionMembers);
+        await editTodoContent(activeSpaceId, id, title, body, user.uid, mentionMembers);
         return true;
       } catch (e) {
         console.error("editContent failed", e);
@@ -190,46 +190,46 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
     },
-    [activeSpaceId, mentionMembers, showError]
+    [activeSpaceId, user, mentionMembers, showError]
   );
 
   const setCompleted = useCallback(
     async (id: string, completed: boolean) => {
-      if (!activeSpaceId) return;
+      if (!activeSpaceId || !user) return;
       try {
-        await setTodoCompleted(activeSpaceId, id, completed);
+        await setTodoCompleted(activeSpaceId, id, completed, user.uid);
       } catch (e) {
         console.error("setCompleted failed", e);
         showError("Status konnte nicht geändert werden.");
       }
     },
-    [activeSpaceId, showError]
+    [activeSpaceId, user, showError]
   );
 
   const setWaitingOn = useCallback(
     async (id: string, waitingOn: string | null) => {
-      if (!activeSpaceId) return;
+      if (!activeSpaceId || !user) return;
       try {
-        await setTodoWaitingOn(activeSpaceId, id, waitingOn);
+        await setTodoWaitingOn(activeSpaceId, id, waitingOn, user.uid);
       } catch (e) {
         console.error("setWaitingOn failed", e);
         showError("Zuweisung konnte nicht gespeichert werden.");
       }
     },
-    [activeSpaceId, showError]
+    [activeSpaceId, user, showError]
   );
 
   const setStatus = useCallback(
     async (id: string, status: { completed: boolean; waitingOn: string | null }) => {
-      if (!activeSpaceId) return;
+      if (!activeSpaceId || !user) return;
       try {
-        await setTodoStatus(activeSpaceId, id, status);
+        await setTodoStatus(activeSpaceId, id, status, user.uid);
       } catch (e) {
         console.error("setStatus failed", e);
         showError("Status konnte nicht geändert werden.");
       }
     },
-    [activeSpaceId, showError]
+    [activeSpaceId, user, showError]
   );
 
   const remove = useCallback(

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -124,13 +124,19 @@ export const addSpaceMember = (spaceId: string, uid: string) =>
 // the todo can no longer be completed or edited, only deleted (issue #63). Done
 // as one atomic batch so there is never a window where the member is gone but
 // the dangling references remain.
-export const removeSpaceMember = async (spaceId: string, uid: string) => {
+export const removeSpaceMember = async (
+  spaceId: string,
+  uid: string,
+  actorUid: string
+) => {
   const stranded = await getDocs(
     query(todosCol(spaceId), where("waitingOn", "==", uid))
   );
   const batch = writeBatch(db);
   batch.update(doc(db, SPACES_COLLECTION, spaceId), { members: arrayRemove(uid) });
-  stranded.forEach((d) => batch.update(d.ref, { waitingOn: null }));
+  // Clearing the dangling waitingOn is a todo update, so it must carry the actor
+  // as modifiedBy to satisfy the rules' `modifiedBy == auth.uid` check (#198).
+  stranded.forEach((d) => batch.update(d.ref, { waitingOn: null, modifiedBy: actorUid }));
   await batch.commit();
 };
 
@@ -160,6 +166,14 @@ const mapTodo = (d: QueryDocumentSnapshot<DocumentData>): Todo => {
     tags: Array.isArray(data.tags) ? data.tags : [],
     mentions: Array.isArray(data.mentions) ? data.mentions : [],
     createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
+    // Legacy todos (pre-#198) carry no modifiedBy; fall back to createdBy so the
+    // field is always populated for the UI and the rules' merge-update checks.
+    modifiedBy:
+      typeof data.modifiedBy === "string"
+        ? data.modifiedBy
+        : typeof data.createdBy === "string"
+          ? data.createdBy
+          : "",
     createdAt: data.createdAt ?? null,
     order: typeof data.order === "number" ? data.order : 0,
   };
@@ -188,6 +202,7 @@ export const createTodo = async (
     tags: deriveTags(input.title, body),
     mentions: deriveMentions(body, input.title, input.mentionMembers),
     createdBy: uid,
+    modifiedBy: uid,
     createdAt: serverTimestamp(),
     order: input.order ?? 0,
   });
@@ -230,6 +245,7 @@ export const editTodoContent = (
   todoId: string,
   title: string,
   body: TiptapContent | null,
+  uid: string,
   mentionMembers?: MentionMember[]
 ) =>
   updateDoc(todoRef(spaceId, todoId), {
@@ -237,16 +253,22 @@ export const editTodoContent = (
     body,
     tags: deriveTags(title, body),
     mentions: deriveMentions(body, title, mentionMembers),
+    modifiedBy: uid,
   });
 
-export const setTodoCompleted = (spaceId: string, todoId: string, completed: boolean) =>
-  updateDoc(todoRef(spaceId, todoId), { completed });
+export const setTodoCompleted = (
+  spaceId: string,
+  todoId: string,
+  completed: boolean,
+  uid: string
+) => updateDoc(todoRef(spaceId, todoId), { completed, modifiedBy: uid });
 
 export const setTodoWaitingOn = (
   spaceId: string,
   todoId: string,
-  waitingOn: string | null
-) => updateDoc(todoRef(spaceId, todoId), { waitingOn });
+  waitingOn: string | null,
+  uid: string
+) => updateDoc(todoRef(spaceId, todoId), { waitingOn, modifiedBy: uid });
 
 // Atomic status transition for the board status drops (issue #79): writes
 // `completed` and `waitingOn` together in one updateDoc, so a card never flashes
@@ -256,8 +278,9 @@ export const setTodoWaitingOn = (
 export const setTodoStatus = (
   spaceId: string,
   todoId: string,
-  status: { completed: boolean; waitingOn: string | null }
-) => updateDoc(todoRef(spaceId, todoId), status);
+  status: { completed: boolean; waitingOn: string | null },
+  uid: string
+) => updateDoc(todoRef(spaceId, todoId), { ...status, modifiedBy: uid });
 
 export const deleteTodo = (spaceId: string, todoId: string) =>
   deleteDoc(todoRef(spaceId, todoId));
@@ -961,6 +984,7 @@ export const migrateLegacyTodos = async (uid: string): Promise<void> => {
           tags,
           mentions,
           createdBy: uid,
+          modifiedBy: uid,
           createdAt: serverTimestamp(),
           order,
         });

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -255,6 +255,7 @@ export async function addTodo(
     tags: deriveTags(title, body),
     mentions: deriveMentions(body, title, members),
     createdBy: uid,
+    modifiedBy: uid,
     createdAt: FieldValue.serverTimestamp(),
     order: maxOrder + 1,
   });
@@ -274,7 +275,7 @@ export async function completeTodo(
   const ref = db.collection("spaces").doc(spaceId).collection("todos").doc(todoId);
   const snap = await ref.get();
   if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
-  await ref.update({ completed: !!completed });
+  await ref.update({ completed: !!completed, modifiedBy: uid });
   return mapTodoView(await ref.get());
 }
 
@@ -293,7 +294,7 @@ export async function setWaitingOn(
   const ref = db.collection("spaces").doc(spaceId).collection("todos").doc(todoId);
   const snap = await ref.get();
   if (!snap.exists) throw new McpToolError("not_found", `Todo ${todoId} not found.`);
-  await ref.update({ waitingOn: userId });
+  await ref.update({ waitingOn: userId, modifiedBy: uid });
   return mapTodoView(await ref.get());
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,6 +43,13 @@ export interface Todo {
   mentions: string[];
   /** Author; immutable after creation. */
   createdBy: string;
+  /**
+   * userId of the last writer. The rules enforce `modifiedBy == auth.uid` on
+   * every create/update, so the "who wrote this" check no longer rides on
+   * `createdBy` — that lets `createdBy` survive a move to another space while
+   * staying unforgeable (issue #198).
+   */
+  modifiedBy: string;
   createdAt: Timestamp | null;
   /**
    * Insertion order (`maxOrder + 1` at creation); drives the stable


### PR DESCRIPTION
Closes #198. Teil von Epic #197.

## Was
Führt `Todo.modifiedBy` (zuletzt schreibender Nutzer) ein und setzt es auf **jedem** Todo-Schreibpfad. Grundlage dafür, dass die Firestore-Regeln (#199) den „wer schreibt"-Check auf `modifiedBy` umstellen — so bleibt `createdBy` beim Verschieben erhalten und unfälschbar.

## Schreibpfade (alle setzen `modifiedBy = uid`)
- `createTodo`, `editTodoContent`, `setTodoCompleted`, `setTodoWaitingOn`, `setTodoStatus` (Signatur um Writer-uid erweitert; `TodosContext` reicht `user.uid` durch)
- `removeSpaceMember`: räumt dangling `waitingOn` mit `modifiedBy = actor` auf (neuer `actorUid`-Param; `SpacesContext` reicht `user.uid` durch)
- `migrateLegacyTodos` (Client) + Admin-Migrationsskript
- MCP `add`/`complete`/`set-waiting-on` (Admin-SDK, Konsistenz)

`mapTodo` fällt für Altbestand ohne Feld auf `createdBy` zurück.

## Reihenfolge / Deploy
**Keine** `firestore.rules`-Änderung hier (das ist #199) — daher safe, vor dem Rules-Deploy auszuliefern. Genau diese App-Änderung muss **vor** #199 live sein.

## Verifiziert
- `npx tsc --noEmit` — sauber
- `next lint` — sauber (nur vorbestehende `<img>`-Warnungen)
- `npm run test:mcp` — 32/32 grün
- Admin-Migrationstest — grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)