### PR TITLE
feat(todos): moveTodoToSpace + TodosContext.moveTodo (#200)

### DIFF
--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -22,6 +22,7 @@ import {
   setTodoWaitingOn,
   setTodoStatus,
   deleteTodo,
+  moveTodoToSpace,
 } from "@/lib/firebase/firebaseUtils";
 import type { MentionMember } from "@/lib/utils/textUtils";
 import type { Todo, TiptapContent } from "@/lib/types";
@@ -51,6 +52,13 @@ interface TodosContextType {
   /** Atomic status transition (completed + waitingOn in one write); board drops. */
   setStatus: (id: string, status: { completed: boolean; waitingOn: string | null }) => Promise<void>;
   remove: (id: string) => Promise<void>;
+  /**
+   * Move a todo to another space (issue #200). Blocks with an error toast if the
+   * todo's creator isn't a member of the target (the rules would reject it). On
+   * success shows a confirmation toast and returns true. `waitingOn` is cleared
+   * when the target doesn't have that member.
+   */
+  moveTodo: (id: string, targetSpaceId: string) => Promise<boolean>;
 }
 
 const TodosContext = createContext<TodosContextType | undefined>(undefined);
@@ -61,8 +69,8 @@ const TodosContext = createContext<TodosContextType | undefined>(undefined);
  */
 export const TodosProvider = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
-  const { activeSpaceId, activeSpace, setOpenCount } = useSpaces();
-  const { showError } = useToast();
+  const { spaces, activeSpaceId, activeSpace, setOpenCount } = useSpaces();
+  const { showToast, showError } = useToast();
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(true);
   const [tagFilters, setTagFilters] = useState<string[]>([]);
@@ -245,6 +253,32 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     [activeSpaceId, showError]
   );
 
+  const moveTodo = useCallback(
+    async (id: string, targetSpaceId: string): Promise<boolean> => {
+      if (!user) return false;
+      const todo = todos.find((t) => t.id === id);
+      const target = spaces.find((s) => s.id === targetSpaceId);
+      if (!todo || !target) return false;
+      // The rules require the (preserved) creator to be a member of the target;
+      // check here so the user gets a clear message instead of a permission error.
+      if (!target.members.includes(todo.createdBy)) {
+        showError("Verschieben nicht möglich: der Ersteller hat keinen Zugriff auf diesen Space.");
+        return false;
+      }
+      const clearWaitingOn = !!todo.waitingOn && !target.members.includes(todo.waitingOn);
+      try {
+        await moveTodoToSpace(todo, targetSpaceId, user.uid, { clearWaitingOn });
+        showToast(`In „${target.name}" verschoben.`);
+        return true;
+      } catch (e) {
+        console.error("moveTodo failed", e);
+        showError("Todo konnte nicht verschoben werden.");
+        return false;
+      }
+    },
+    [user, todos, spaces, showToast, showError]
+  );
+
   const value: TodosContextType = {
     todos,
     loading,
@@ -260,6 +294,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     setWaitingOn,
     setStatus,
     remove,
+    moveTodo,
   };
 
   return <TodosContext.Provider value={value}>{children}</TodosContext.Provider>;

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -285,6 +285,51 @@ export const setTodoStatus = (
 export const deleteTodo = (spaceId: string, todoId: string) =>
   deleteDoc(todoRef(spaceId, todoId));
 
+// Move a todo to another space (issue #200). Because spaceId is part of the
+// Firestore path this can't be an updateDoc: it's a create in the target plus a
+// delete in the source, committed as one writeBatch so a move can never leave a
+// duplicate or lose the todo. All fields carry over; createdBy/createdAt are
+// preserved (firestore.rules keys the writer check on modifiedBy, #199, and
+// requires createdBy to be a member of the target — the caller must check that
+// before calling). order is recomputed to land at the end of the target list;
+// waitingOn is cleared when the target space doesn't have that member, since the
+// rules reject a waitingOn pointing at a non-member. Returns the new todo id.
+export const moveTodoToSpace = async (
+  todo: Todo,
+  targetSpaceId: string,
+  uid: string,
+  opts?: { clearWaitingOn?: boolean }
+): Promise<string> => {
+  if (!todo.spaceId || !todo.id || !targetSpaceId || !uid) {
+    throw new Error("Missing todo, target space or user.");
+  }
+  if (targetSpaceId === todo.spaceId) throw new Error("Todo is already in this space.");
+
+  const last = await getDocs(
+    query(todosCol(targetSpaceId), orderBy("order", "desc"), limit(1))
+  );
+  const maxOrder = last.empty ? 0 : (last.docs[0].data().order ?? 0);
+
+  const targetRef = doc(todosCol(targetSpaceId));
+  const batch = writeBatch(db);
+  batch.set(targetRef, {
+    spaceId: targetSpaceId,
+    title: todo.title,
+    body: todo.body ?? null,
+    completed: todo.completed,
+    waitingOn: opts?.clearWaitingOn ? null : todo.waitingOn,
+    tags: todo.tags,
+    mentions: todo.mentions,
+    createdBy: todo.createdBy,
+    modifiedBy: uid,
+    createdAt: todo.createdAt ?? serverTimestamp(),
+    order: maxOrder + 1,
+  });
+  batch.delete(todoRef(todo.spaceId, todo.id));
+  await batch.commit();
+  return targetRef.id;
+};
+
 // --- Daily "Heute" items (space-scoped, issue #41) ---
 // Short-lived items, deliberately separate from todos (never appear in the list).
 


### PR DESCRIPTION
Closes #200. Teil von Epic #197. **Stacked auf #199** (PR #205) — Base hängt sich beim Merge automatisch weiter.

## Was
Die Datenoperation hinter „in anderen Space verschieben".

`firebaseUtils.moveTodoToSpace(todo, targetSpaceId, uid, { clearWaitingOn })`:
- **atomar**: create im Ziel + delete in der Quelle als ein `writeBatch` → nie Duplikat, nie verlorenes Todo (`spaceId` ist Teil des Pfads, daher kein `updateDoc`);
- `order = max(Ziel)+1` via einem `orderBy desc`/`limit(1)`-Read (landet am Ende);
- `createdBy`/`createdAt` bleiben erhalten (Regeln keyen auf `modifiedBy`, #199); `modifiedBy` = verschiebender Nutzer;
- `waitingOn` wird geleert, wenn das Ziel dieses Mitglied nicht hat (sonst lehnen die Regeln ab); No-op-Move in denselben Space wird abgefangen.

`TodosContext.moveTodo(id, targetSpaceId)`: löst Todo + Ziel auf, blockt mit Fehler-Toast wenn der **Ersteller** kein Mitglied des Ziels ist (klare Meldung statt Permission-Error), berechnet `clearWaitingOn`, zeigt Bestätigungs-Toast. Aktiver Space bleibt (FA-11); das Todo verlässt die Quell-Liste über die Live-Subscription.

## Verifiziert
- `npx tsc --noEmit` — sauber
- `next lint` — sauber (nur vorbestehende `<img>`-Warnungen)

Der Security-Kontrakt (create-in-Ziel + delete-in-Quelle, Ersteller muss Ziel-Mitglied sein) ist durch die #199-Rules-Tests abgedeckt. Die Batch-Logik (Feldübernahme/order/waitingOn) wird mit der UI in #201 manuell getestet — es gibt keine Unit-Test-Infra für Client-SDK-Code in `firebaseUtils.ts`.

## UI
Folgt in #201 (`TodoActions` „Verschieben →").

🤖 Generated with [Claude Code](https://claude.com/claude-code)