### PR TITLE
feat(list): "Verschieben …" action in TodoActions (#201)

### DIFF
--- a/src/components/shell/list/TodoActions.tsx
+++ b/src/components/shell/list/TodoActions.tsx
@@ -3,11 +3,13 @@
 import React, { useState } from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { spaceColorFromHue } from "@/lib/theme/colors";
 import type { Todo } from "@/lib/types";
 
 /**
  * "…" menu actions for a todo (issue #45): Bearbeiten · Wartet auf … (members +
- * Niemand) · Löschen. Used inside the desktop popover and the mobile sheet.
+ * Niemand) · Verschieben → (other spaces, issue #201) · Löschen. Used inside the
+ * desktop popover and the mobile sheet.
  */
 export default function TodoActions({
   todo,
@@ -20,12 +22,25 @@ export default function TodoActions({
   onEdit: () => void;
   onClose: () => void;
 }) {
-  const { setWaitingOn, remove } = useTodos();
-  const { activeSpace } = useSpaces();
+  const { setWaitingOn, moveTodo, remove } = useTodos();
+  const { activeSpace, spaces } = useSpaces();
   const [waitOpen, setWaitOpen] = useState(false);
+  const [moveOpen, setMoveOpen] = useState(false);
+  // spaceId whose waitingOn-loss warning is currently expanded (null = none).
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
   const members = activeSpace?.members ?? [];
 
+  // Every space except the one the todo lives in (FA-08: hide the entry when
+  // there is nowhere to move it to).
+  const targets = spaces.filter((s) => s.id !== todo.spaceId);
+
   const item = "rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover";
+
+  const doMove = async (targetId: string) => {
+    // moveTodo shows its own toast (success or error). Close only on success so
+    // a failed move keeps the menu open for another try.
+    if (await moveTodo(todo.id, targetId)) onClose();
+  };
 
   return (
     <div className="flex flex-col">
@@ -77,6 +92,93 @@ export default function TodoActions({
             </button>
           ))}
         </div>
+      )}
+
+      {targets.length > 0 && (
+        <>
+          <button
+            type="button"
+            className={`flex items-center justify-between ${item}`}
+            style={{ minHeight: 44 }}
+            onClick={() => setMoveOpen((o) => !o)}
+          >
+            Verschieben … <span className="text-text-dim">{moveOpen ? "⌄" : "›"}</span>
+          </button>
+          {moveOpen && (
+            <div className="flex flex-col border-l border-border pl-2">
+              {targets.map((target) => {
+                const creatorHasAccess = target.members.includes(todo.createdBy);
+                const losesWaiting =
+                  !!todo.waitingOn && !target.members.includes(todo.waitingOn);
+                const confirming = confirmTarget === target.id;
+
+                return (
+                  <div key={target.id} className="flex flex-col">
+                    <button
+                      type="button"
+                      disabled={!creatorHasAccess}
+                      className={`flex items-center gap-2 ${item} ${
+                        creatorHasAccess ? "" : "cursor-not-allowed opacity-50 hover:bg-transparent"
+                      }`}
+                      style={{ minHeight: 44 }}
+                      onClick={() => {
+                        if (!creatorHasAccess) return;
+                        if (losesWaiting) {
+                          setConfirmTarget(target.id);
+                          return;
+                        }
+                        doMove(target.id);
+                      }}
+                    >
+                      <span
+                        aria-hidden
+                        className="shrink-0"
+                        style={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: 3,
+                          background: spaceColorFromHue(target.color),
+                        }}
+                      />
+                      <span className="min-w-0 flex-1 truncate">{target.name}</span>
+                    </button>
+                    {!creatorHasAccess && (
+                      <span className="px-3 pb-1 text-xs text-text-dim">
+                        Ersteller hat keinen Zugriff
+                      </span>
+                    )}
+                    {confirming && (
+                      <div className="mx-3 mb-2 rounded-lg border border-border p-2 text-xs">
+                        <p className="text-text-dim">
+                          „Wartet auf {nameOf(todo.waitingOn as string)}“ geht beim Verschieben
+                          verloren.
+                        </p>
+                        <div className="mt-2 flex gap-2">
+                          <button
+                            type="button"
+                            className="rounded-md px-2 py-1 font-semibold text-white"
+                            style={{ background: "var(--accent)", minHeight: 36 }}
+                            onClick={() => doMove(target.id)}
+                          >
+                            Verschieben
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-md px-2 py-1 hover:bg-row-hover"
+                            style={{ minHeight: 36 }}
+                            onClick={() => setConfirmTarget(null)}
+                          >
+                            Abbrechen
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
 
       <button


### PR DESCRIPTION
Closes #201. Teil von Epic #197. **Stacked auf #200** (PR #206) — schließt den Kern-Scope des Features ab.

## Was
Die sichtbare Aktion: collapsible Submenü **„Verschieben …"** im Todo-Aktionsmenü (`TodoActions`), gerendert im Desktop-Popover **und** im Mobile-BottomSheet (eine Komponente).

- `targets` = alle Spaces außer dem eigenen; Eintrag wird ausgeblendet, wenn keiner existiert (FA-08);
- jedes Ziel zeigt Farbpunkt + Name; Klick ruft `TodosContext.moveTodo` und schließt das Menü bei Erfolg (bleibt bei Fehler offen, Toast erklärt);
- ein Ziel, dessen Mitglieder den **Ersteller** nicht enthalten, ist **disabled** mit Hinweis „Ersteller hat keinen Zugriff" (FA-06) — die Regeln würden es ablehnen;
- ist `waitingOn` kein Mitglied des Ziels, klappt die Zeile eine **Inline-Bestätigung** auf („…geht beim Verschieben verloren" · Verschieben/Abbrechen) statt eines Browser-Dialogs (FA-07).

## Verifiziert
- `npx tsc --noEmit` — sauber
- `next lint` — sauber
- `next build` — grün (`/todos` kompiliert)

## Manuelle Test-Checkliste (nach Deploy, FA-Akzeptanzkriterien)
- [ ] Eigenes Todo in anderen Space verschieben → erscheint dort am Ende, weg aus Quelle, Toast, aktiver Space bleibt
- [ ] Fremdes Todo (Ersteller im Ziel Mitglied) → erfolgreich, `createdBy` unverändert
- [ ] Ziel ohne Ersteller-Zugriff → disabled + Hinweis
- [ ] Todo mit `waitingOn` auf Nicht-Ziel-Mitglied → Bestätigung, danach `waitingOn` leer
- [ ] Nur ein Space → kein „Verschieben …"
- [ ] Desktop-Popover **und** Mobile-Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)