### PR TITLE
feat(board): move-to-space on board cards + undo toast (#202)

### DIFF
--- a/src/components/shell/MoveToSpaceMenu.tsx
+++ b/src/components/shell/MoveToSpaceMenu.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { useState } from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { spaceColorFromHue } from "@/lib/theme/colors";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Target-space picker for moving a todo (issue #201/#202). Shared by the list
+ * actions (TodoActions) and the board card sheets so the rules — hide when there
+ * is no other space, disable a target the todo's creator can't access (FA-06),
+ * and confirm before dropping a waitingOn the target doesn't have (FA-07) — live
+ * in one place. Calls TodosContext.moveTodo (which also wires the undo toast) and
+ * onDone() on a successful move.
+ */
+export default function MoveToSpaceMenu({
+  todo,
+  nameOf,
+  onDone,
+}: {
+  todo: Todo;
+  nameOf: (uid: string) => string;
+  onDone: () => void;
+}) {
+  const { moveTodo } = useTodos();
+  const { spaces } = useSpaces();
+  // spaceId whose waitingOn-loss warning is currently expanded (null = none).
+  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
+
+  const targets = spaces.filter((s) => s.id !== todo.spaceId);
+  const item = "rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover";
+
+  const doMove = async (targetId: string) => {
+    // moveTodo shows its own toast (success or error). Close only on success so
+    // a failed move keeps the menu open for another try.
+    if (await moveTodo(todo.id, targetId)) onDone();
+  };
+
+  if (targets.length === 0) {
+    return <p className="px-3 py-2 text-sm text-text-dim">Kein anderer Space vorhanden.</p>;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {targets.map((target) => {
+        const creatorHasAccess = target.members.includes(todo.createdBy);
+        const losesWaiting = !!todo.waitingOn && !target.members.includes(todo.waitingOn);
+        const confirming = confirmTarget === target.id;
+
+        return (
+          <div key={target.id} className="flex flex-col">
+            <button
+              type="button"
+              disabled={!creatorHasAccess}
+              className={`flex items-center gap-2 ${item} ${
+                creatorHasAccess ? "" : "cursor-not-allowed opacity-50 hover:bg-transparent"
+              }`}
+              style={{ minHeight: 44 }}
+              onClick={() => {
+                if (!creatorHasAccess) return;
+                if (losesWaiting) {
+                  setConfirmTarget(target.id);
+                  return;
+                }
+                doMove(target.id);
+              }}
+            >
+              <span
+                aria-hidden
+                className="shrink-0"
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 3,
+                  background: spaceColorFromHue(target.color),
+                }}
+              />
+              <span className="min-w-0 flex-1 truncate">{target.name}</span>
+            </button>
+            {!creatorHasAccess && (
+              <span className="px-3 pb-1 text-xs text-text-dim">Ersteller hat keinen Zugriff</span>
+            )}
+            {confirming && (
+              <div className="mx-3 mb-2 rounded-lg border border-border p-2 text-xs">
+                <p className="text-text-dim">
+                  „Wartet auf {nameOf(todo.waitingOn as string)}“ geht beim Verschieben verloren.
+                </p>
+                <div className="mt-2 flex gap-2">
+                  <button
+                    type="button"
+                    className="rounded-md px-2 py-1 font-semibold text-white"
+                    style={{ background: "var(--accent)", minHeight: 36 }}
+                    onClick={() => doMove(target.id)}
+                  >
+                    Verschieben
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md px-2 py-1 hover:bg-row-hover"
+                    style={{ minHeight: 36 }}
+                    onClick={() => setConfirmTarget(null)}
+                  >
+                    Abbrechen
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -1,18 +1,28 @@
 "use client";
 
 import React, { useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import BottomSheet from "../BottomSheet";
+import MoveToSpaceMenu from "../MoveToSpaceMenu";
 import BoardGroupToggle from "./BoardGroupToggle";
 import ColumnHeader from "./ColumnHeader";
 import TodoCard from "./TodoCard";
 import { useBoardColumns } from "./useBoardColumns";
 import { type BoardColumn, type GroupBy } from "./columns";
+import type { Todo } from "@/lib/types";
 
 /** Desktop Board view (issue #46): horizontal columns with HTML5 drag & drop. */
 export default function BoardView() {
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
   const { columns, loading, accent, nameOf } = useBoardColumns(groupBy);
+  const { spaces } = useSpaces();
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<string | null>(null);
+  // Drag & drop moves cards between columns (same space); "In Space" opens a
+  // picker to move to another space (issue #202). All board todos are in the
+  // active space, so "another space exists" is global.
+  const [moveSpaceCard, setMoveSpaceCard] = useState<Todo | null>(null);
+  const canMoveToSpace = spaces.length > 1;
 
   const onDrop = async (col: BoardColumn) => {
     const id = dragId;
@@ -65,6 +75,7 @@ export default function BoardView() {
                   nameOf={nameOf}
                   draggable
                   onDragStart={() => setDragId(t.id)}
+                  onMoveToSpace={canMoveToSpace ? () => setMoveSpaceCard(t) : undefined}
                 />
               ))}
               {col.todos.length === 0 && col.apply && (
@@ -74,6 +85,20 @@ export default function BoardView() {
           ))}
         </div>
       )}
+
+      <BottomSheet
+        open={!!moveSpaceCard}
+        onClose={() => setMoveSpaceCard(null)}
+        title="In Space verschieben"
+      >
+        {moveSpaceCard && (
+          <MoveToSpaceMenu
+            todo={moveSpaceCard}
+            nameOf={nameOf}
+            onDone={() => setMoveSpaceCard(null)}
+          />
+        )}
+      </BottomSheet>
     </div>
   );
 }

--- a/src/components/shell/board/MobileBoard.tsx
+++ b/src/components/shell/board/MobileBoard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { useState } from "react";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
 import Avatar from "../Avatar";
 import BottomSheet from "../BottomSheet";
+import MoveToSpaceMenu from "../MoveToSpaceMenu";
 import BoardGroupToggle from "./BoardGroupToggle";
 import ColumnHeader from "./ColumnHeader";
 import TodoCard from "./TodoCard";
@@ -17,9 +19,13 @@ import type { Todo } from "@/lib/types";
 export default function MobileBoard() {
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
   const { columns, loading, accent, nameOf } = useBoardColumns(groupBy);
+  const { spaces } = useSpaces();
   const [moveCard, setMoveCard] = useState<Todo | null>(null);
+  const [moveSpaceCard, setMoveSpaceCard] = useState<Todo | null>(null);
 
   const targets = columns.filter((c) => c.apply);
+  // All board todos live in the active space, so "another space exists" is global.
+  const canMoveToSpace = spaces.length > 1;
 
   return (
     <div className="flex flex-col gap-4">
@@ -32,7 +38,14 @@ export default function MobileBoard() {
           <section key={col.id} className="flex flex-col gap-2">
             <ColumnHeader col={col} nameOf={nameOf} />
             {col.todos.map((t) => (
-              <TodoCard key={t.id} todo={t} accent={accent} nameOf={nameOf} onMove={() => setMoveCard(t)} />
+              <TodoCard
+                key={t.id}
+                todo={t}
+                accent={accent}
+                nameOf={nameOf}
+                onMove={() => setMoveCard(t)}
+                onMoveToSpace={canMoveToSpace ? () => setMoveSpaceCard(t) : undefined}
+              />
             ))}
             {col.todos.length === 0 && <p className="text-xs text-text-dim">—</p>}
           </section>
@@ -57,6 +70,20 @@ export default function MobileBoard() {
             </button>
           ))}
         </div>
+      </BottomSheet>
+
+      <BottomSheet
+        open={!!moveSpaceCard}
+        onClose={() => setMoveSpaceCard(null)}
+        title="In Space verschieben"
+      >
+        {moveSpaceCard && (
+          <MoveToSpaceMenu
+            todo={moveSpaceCard}
+            nameOf={nameOf}
+            onDone={() => setMoveSpaceCard(null)}
+          />
+        )}
       </BottomSheet>
     </div>
   );

--- a/src/components/shell/board/TodoCard.tsx
+++ b/src/components/shell/board/TodoCard.tsx
@@ -13,12 +13,14 @@ interface TodoCardProps {
   nameOf: (uid: string) => string;
   draggable?: boolean;
   onDragStart?: () => void;
-  /** Mobile: open the "Verschieben" sheet for this card. */
+  /** Mobile: open the column "Verschieben" sheet for this card. */
   onMove?: () => void;
+  /** Open the "In Space" target-space picker for this card (issue #202). */
+  onMoveToSpace?: () => void;
 }
 
 /** Board card (issue #46): title + progress + "bei X" chip + check circle. */
-export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove }: TodoCardProps) {
+export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove, onMoveToSpace }: TodoCardProps) {
   const { setCompleted } = useTodos();
   const progress = checklistProgress(todo.body);
 
@@ -64,15 +66,29 @@ export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart,
         </div>
       )}
 
-      {onMove && (
-        <button
-          type="button"
-          onClick={onMove}
-          className="self-end rounded-full border border-border px-3 py-1 text-xs font-semibold"
-          style={{ minHeight: 32 }}
-        >
-          Verschieben
-        </button>
+      {(onMove || onMoveToSpace) && (
+        <div className="flex flex-wrap justify-end gap-2">
+          {onMove && (
+            <button
+              type="button"
+              onClick={onMove}
+              className="rounded-full border border-border px-3 py-1 text-xs font-semibold"
+              style={{ minHeight: 32 }}
+            >
+              Verschieben
+            </button>
+          )}
+          {onMoveToSpace && (
+            <button
+              type="button"
+              onClick={onMoveToSpace}
+              className="rounded-full border border-border px-3 py-1 text-xs font-semibold"
+              style={{ minHeight: 32 }}
+            >
+              In Space
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/components/shell/list/TodoActions.tsx
+++ b/src/components/shell/list/TodoActions.tsx
@@ -3,13 +3,14 @@
 import React, { useState } from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
-import { spaceColorFromHue } from "@/lib/theme/colors";
+import MoveToSpaceMenu from "../MoveToSpaceMenu";
 import type { Todo } from "@/lib/types";
 
 /**
  * "…" menu actions for a todo (issue #45): Bearbeiten · Wartet auf … (members +
- * Niemand) · Verschieben → (other spaces, issue #201) · Löschen. Used inside the
- * desktop popover and the mobile sheet.
+ * Niemand) · Verschieben … (other spaces, issue #201 — picker shared with the
+ * board via MoveToSpaceMenu, #202) · Löschen. Used inside the desktop popover
+ * and the mobile sheet.
  */
 export default function TodoActions({
   todo,
@@ -22,25 +23,16 @@ export default function TodoActions({
   onEdit: () => void;
   onClose: () => void;
 }) {
-  const { setWaitingOn, moveTodo, remove } = useTodos();
+  const { setWaitingOn, remove } = useTodos();
   const { activeSpace, spaces } = useSpaces();
   const [waitOpen, setWaitOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
-  // spaceId whose waitingOn-loss warning is currently expanded (null = none).
-  const [confirmTarget, setConfirmTarget] = useState<string | null>(null);
   const members = activeSpace?.members ?? [];
 
-  // Every space except the one the todo lives in (FA-08: hide the entry when
-  // there is nowhere to move it to).
-  const targets = spaces.filter((s) => s.id !== todo.spaceId);
+  // FA-08: hide the move entry when there is nowhere to move the todo to.
+  const hasTargets = spaces.some((s) => s.id !== todo.spaceId);
 
   const item = "rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover";
-
-  const doMove = async (targetId: string) => {
-    // moveTodo shows its own toast (success or error). Close only on success so
-    // a failed move keeps the menu open for another try.
-    if (await moveTodo(todo.id, targetId)) onClose();
-  };
 
   return (
     <div className="flex flex-col">
@@ -94,7 +86,7 @@ export default function TodoActions({
         </div>
       )}
 
-      {targets.length > 0 && (
+      {hasTargets && (
         <>
           <button
             type="button"
@@ -105,77 +97,8 @@ export default function TodoActions({
             Verschieben … <span className="text-text-dim">{moveOpen ? "⌄" : "›"}</span>
           </button>
           {moveOpen && (
-            <div className="flex flex-col border-l border-border pl-2">
-              {targets.map((target) => {
-                const creatorHasAccess = target.members.includes(todo.createdBy);
-                const losesWaiting =
-                  !!todo.waitingOn && !target.members.includes(todo.waitingOn);
-                const confirming = confirmTarget === target.id;
-
-                return (
-                  <div key={target.id} className="flex flex-col">
-                    <button
-                      type="button"
-                      disabled={!creatorHasAccess}
-                      className={`flex items-center gap-2 ${item} ${
-                        creatorHasAccess ? "" : "cursor-not-allowed opacity-50 hover:bg-transparent"
-                      }`}
-                      style={{ minHeight: 44 }}
-                      onClick={() => {
-                        if (!creatorHasAccess) return;
-                        if (losesWaiting) {
-                          setConfirmTarget(target.id);
-                          return;
-                        }
-                        doMove(target.id);
-                      }}
-                    >
-                      <span
-                        aria-hidden
-                        className="shrink-0"
-                        style={{
-                          width: 8,
-                          height: 8,
-                          borderRadius: 3,
-                          background: spaceColorFromHue(target.color),
-                        }}
-                      />
-                      <span className="min-w-0 flex-1 truncate">{target.name}</span>
-                    </button>
-                    {!creatorHasAccess && (
-                      <span className="px-3 pb-1 text-xs text-text-dim">
-                        Ersteller hat keinen Zugriff
-                      </span>
-                    )}
-                    {confirming && (
-                      <div className="mx-3 mb-2 rounded-lg border border-border p-2 text-xs">
-                        <p className="text-text-dim">
-                          „Wartet auf {nameOf(todo.waitingOn as string)}“ geht beim Verschieben
-                          verloren.
-                        </p>
-                        <div className="mt-2 flex gap-2">
-                          <button
-                            type="button"
-                            className="rounded-md px-2 py-1 font-semibold text-white"
-                            style={{ background: "var(--accent)", minHeight: 36 }}
-                            onClick={() => doMove(target.id)}
-                          >
-                            Verschieben
-                          </button>
-                          <button
-                            type="button"
-                            className="rounded-md px-2 py-1 hover:bg-row-hover"
-                            style={{ minHeight: 36 }}
-                            onClick={() => setConfirmTarget(null)}
-                          >
-                            Abbrechen
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+            <div className="border-l border-border pl-2">
+              <MoveToSpaceMenu todo={todo} nameOf={nameOf} onDone={onClose} />
             </div>
           )}
         </>

--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -266,9 +266,24 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
         return false;
       }
       const clearWaitingOn = !!todo.waitingOn && !target.members.includes(todo.waitingOn);
+      const sourceSpaceId = todo.spaceId;
       try {
-        await moveTodoToSpace(todo, targetSpaceId, user.uid, { clearWaitingOn });
-        showToast(`In „${target.name}" verschoben.`);
+        const newId = await moveTodoToSpace(todo, targetSpaceId, user.uid, { clearWaitingOn });
+        // Undo (issue #202): move the now-target-resident todo back to its source.
+        // The source had the original members, so the original waitingOn is valid
+        // there again — reconstruct from the original `todo` (with the new id) so
+        // undo also restores a waitingOn the forward move had to clear.
+        showToast(`In „${target.name}" verschoben.`, {
+          label: "Rückgängig",
+          onAction: () => {
+            moveTodoToSpace({ ...todo, id: newId, spaceId: targetSpaceId }, sourceSpaceId, user.uid)
+              .then(() => showToast("Verschieben rückgängig gemacht."))
+              .catch((e) => {
+                console.error("undo move failed", e);
+                showError("Rückgängig machen fehlgeschlagen.");
+              });
+          },
+        });
         return true;
       } catch (e) {
         console.error("moveTodo failed", e);


### PR DESCRIPTION
Closes #202. Schließt das optionale Folge-Issue von Epic #197 ab.

## Was
- **Geteilter Picker:** Die Ziel-Space-Auswahl (ausblenden wenn kein anderer Space, Ziel disabled wenn Ersteller keinen Zugriff hat, Inline-Bestätigung bei `waitingOn`-Verlust) ist jetzt in **`MoveToSpaceMenu`** extrahiert und wird von Liste **und** Board genutzt. `TodoActions` delegiert sein „Verschieben …"-Submenü daran (DRY, kein Logik-Duplikat).
- **Board:** Karten bekommen einen **„In Space"-Button** (bewusst getrennt vom bestehenden Spalten-„Verschieben" des Boards). `TodoCard.onMoveToSpace`, verdrahtet in `BoardView` (Desktop) und `MobileBoard` (Mobile) zu einem `BottomSheet`-Picker; nur sichtbar, wenn ein anderer Space existiert.
- **Undo:** `TodosContext.moveTodo` hängt dem Bestätigungs-Toast eine **„Rückgängig"**-Aktion an, die das Todo in den Quell-Space zurückverschiebt (rekonstruiert aus Original-Todo + neuer id) — stellt auch ein beim Hinverschieben geleertes `waitingOn` wieder her. Liegt in `moveTodo`, daher bekommt die **Listen-Ansicht das Undo ebenfalls**.

## Verifiziert
- `npx tsc --noEmit` — sauber
- `next lint` — sauber
- `next build` — grün

## Manuelle Test-Checkliste
- [ ] Board Desktop: „In Space" → Picker → Todo verschoben, Toast mit „Rückgängig"
- [ ] Board Mobile: „In Space"-Sheet funktioniert; Spalten-„Verschieben" unverändert
- [ ] „Rückgängig" verschiebt zurück in den Quell-Space
- [ ] Liste: Verschieben weiterhin ok (Refactor), jetzt mit „Rückgängig"
- [ ] Nur ein Space → kein „In Space"-Button

🤖 Generated with [Claude Code](https://claude.com/claude-code)