### PR TITLE
docs: Agent-Session-gebundene Todos – Konzept bis Spezifikation

### DIFF
--- a/docs/01-konzept-aido-sessions.md
+++ b/docs/01-konzept-aido-sessions.md
@@ -1,0 +1,243 @@
+# Konzept: Todos an eine Claude-Code-Session binden und abarbeiten lassen
+
+## 1. Zusammenfassung
+
+Statt Todos pauschal „aido" zuzuweisen, bindet der Nutzer ein Todo an eine **konkrete,
+laufende Claude-Code-Session**. Eine Session meldet sich beim Start über ein neues MCP-Tool
+(`register-session`) mit **Hostname** und **Working Folder** an und wird dadurch in der aido-UI
+sichtbar. Dort kann der Nutzer ein Todo per **„An Session anhängen…"** einer Session zuordnen
+(mehrere Sessions pro Nutzer möglich). Die Session fragt im `/loop` über `next-todo` jeweils das
+**älteste, noch nicht erledigte, an sie gebundene Todo** ab, liest dessen Rich-Text-Body,
+**beantwortet Fragen darin und ergänzt es** (Tiptap inkl. **Codeblöcken**) und gibt es entweder
+**zurück an den Menschen** (offen) oder **schließt es ab**. Ein **Claim+Lease+Status-Mechanismus**
+stellt sicher, dass nie endlos dasselbe Todo abgeholt wird.
+
+> **Abgrenzung zu [Konzept 01 – Claude Code Channels](01-konzept-claude-code-channels.md):**
+> Channels sind der **Push-Weg** (aido benachrichtigt eine Session über Ereignisse). Dieses
+> Konzept ist der **Pull-/Arbeits-Weg** (eine Session holt sich gezielt die ihr zugewiesenen
+> Todos und schreibt Antworten zurück). Beide sind komplementär.
+
+## 2. Problemstellung
+
+Der erste Entwurf („Todo an *aido* zuweisen") trägt nicht, aus zwei Gründen:
+
+1. **Nicht jeder Nutzer betreibt einen MCP-Loop.** Eine generische `assignTo: aido`-Markierung
+   würde ohne ein laufendes Claude-Code-Setup **nichts bewirken** — das Todo bliebe einfach
+   liegen.
+2. **„aido" ist nicht von „mir mit Claude" unterscheidbar.** Der Nutzer ist über seinen
+   Personal-API-Key mit dem MCP-Server verbunden und handelt dabei unter der **eigenen uid**
+   (`requireUserUid()` in `tool-logic.ts`). Ob ich ein Todo *interaktiv* mit Claude bearbeite
+   oder ein `/loop` es *automatisch* abarbeitet, ist serverseitig identisch. Eine pauschale
+   „aido"-Zuständigkeit ist deshalb mehrdeutig.
+
+Die Bindung an eine **benannte, konkrete Session** (Host + Ordner) löst beides: es passiert nur
+dann etwas, wenn (a) eine Session tatsächlich läuft und sich gemeldet hat **und** (b) der Nutzer
+ein Todo **explizit** an genau diese Session gehängt hat. Keine Magie, keine Mehrdeutigkeit.
+
+Zusätzlich bestehen weiterhin die technischen Lücken aus dem ersten Entwurf:
+
+- Das von `list-todos` gelieferte `TodoView` (`src/lib/mcp/data.ts`) enthält **nicht den
+  `body`** — die eigentliche Aufgabe/Frage ist für Claude unsichtbar.
+- Es gibt **kein Tool, das `body` schreibt** (`add-todo` erzeugt nur Plain-Text-Bodies, ohne
+  Codeblöcke); „eine Frage beantworten, ohne zu schließen" ist damit unmöglich.
+
+## 3. Zielsetzung
+
+- Eine Claude-Code-Session **registriert sich** zu Beginn mit Hostname + Working Folder und ist
+  danach in der aido-UI als anhängbares Ziel sichtbar (mit „zuletzt aktiv").
+- Der Nutzer kann ein Todo in der Web-UI **einer Session anhängen** und die Bindung wieder lösen;
+  der Bindungs-/Bearbeitungszustand ist **sichtbar** (Badge „bei aido / in Arbeit / bei dir").
+- Eine Session holt per `next-todo` deterministisch das **älteste offene gebundene Todo**, liest
+  den **vollständigen Body**, kann ihn **mit formatiertem Text (Markdown→Tiptap, Codeblöcke)
+  ergänzen/beantworten** und es **offen zurückgeben** oder **abschließen**.
+- **Kein Todo wird endlos erneut abgeholt:** ein Todo kehrt erst zu „bei aido" zurück, wenn ein
+  **Mensch** reagiert hat — oder ein abgestürzter Claim per **Lease** verfällt.
+- aido-Antworten **rendern korrekt** in der Web-UI (read-only Body, inkl. Codeblöcke) und sind
+  als **„von aido"** erkennbar.
+- Sicherheit/Parität bleiben gewahrt: alle Schreibpfade durchlaufen die bestehenden Member-Gates,
+  `firestore.rules` validiert die neuen Felder, der Body bleibt XSS-sicher.
+
+**Messbar erreicht**, wenn: eine in `~/project` auf Host *MacBook* registrierte Session ein dort
+angehängtes Todo mit einer Frage per `next-todo` erhält, eine codeblock-haltige Antwort per
+`update-todo` **append** zurückschreibt, per `handoff` offen an den Menschen zurückgibt — und das
+Todo danach in der UI als „bei dir / aido hat geantwortet" mit formatierter Antwort erscheint,
+während `next-todo` im selben Loop bereits das **nächste** Todo liefert (nie wieder dasselbe).
+
+## 4. Lösungsidee
+
+### 4.1 Agent-Sessions als eigenständige Objekte
+
+Eine Session ist eine **„Agent-Session"** (bewusst anders benannt als die bestehenden
+**Geräte-/Login-Sessions**, um Verwechslung zu vermeiden) und an **genau einen Space gebunden**.
+Neue Collection `users/{uid}/sessions/{sessionId}` (owner-only lesbar, damit der Nutzer seine
+Sessions im Attach-Picker sieht; vom MCP-Server via Admin-SDK geschrieben). Felder: `spaceId`,
+`hostname`, `workingFolder`, `label?`, `allowedTools`, `leaseTtlSeconds`, `createdAt`, `lastSeenAt`.
+
+- **Space-Bindung:** `register-session(spaceId, …)` registriert die Session für **einen** Space (der
+  Aufrufer muss Mitglied sein, `requireMember`). Dadurch bleibt `next-todo` ein **reiner
+  Per-Space-Query** — **kein** Collection-Group-Query, kein Cross-Space-Leak, Member-Gate =
+  bestehendes `requireMember`.
+- **Identität deterministisch:** `sessionId = hash(spaceId + hostname + workingFolder)`. So kann
+  **jeder** spätere MCP-Aufruf seine Session **aus der Umgebung neu herleiten** (Claude Code kennt
+  cwd + Hostname; den Space hält die Loop-Konfiguration) — der zustandslose Server muss sich nichts
+  „merken", der Loop keine ID mitschleppen.
+- `register-session` ist ein **Upsert**: legt an bzw. aktualisiert `lastSeenAt`. Jeder
+  `next-todo`-Aufruf frischt `lastSeenAt` als Heartbeat. Stale Sessions kann die UI ausgrauen.
+
+### 4.2 Anhängen in der Web-UI
+
+Neues Todo-Feld **`attachedSession: sessionId | null`**. Ein Todo hängt an **genau einer** Session,
+die **im selben Space** registriert ist (v1; per Identität ohnehin space-gebunden). UI: Aktion
+**„An Agent-Session anhängen…"** in `TodoActions` und im Board-Karten-Menü (analog zum frischen
+„Verschieben…" #201/#202), die die für **diesen Space** registrierten Sessions des Nutzers anbietet,
+z.B. `MacBook · ~/Documents/GitHub/aido (aktiv vor 2 min)`. Beim Anhängen → Zustand **`bei aido`**.
+
+### 4.3 Zustandsmaschine (Claim + Lease + „Ball im Feld")
+
+Pro angehängtem Todo zwei Aspekte: **wessen Zug** (`aidoTurn: 'aido' | 'user'`) und der **Claim/
+Lease** (`claimedBy: sessionId | null`, `claimedAt: Timestamp | null`).
+
+```
+        attach (UI)          next-todo (claim, Lease)        complete-todo
+ offen ──────────────► [bei aido] ───────────────► [in Arbeit] ───────────► erledigt
+                          ▲                            │
+   User: „zurück an       │                            │ Claude: handoff
+   aido" / Antwort        └───────────[bei dir]◄───────┘ (Antwort, offen lassen)
+                                          ▲_________________│
+                                          Lease abgelaufen → zurück zu [bei aido]
+```
+
+- **`next-todo`** wählt das **älteste (`createdAt` asc) offene** Todo mit
+  `attachedSession == meineSession && aidoTurn == 'aido'`, dessen Claim frei oder dessen Lease
+  abgelaufen ist, und **claimt es atomar** (Transaction): `claimedBy = sessionId`,
+  `claimedAt = now`. Damit ist es **sofort aus der Warteschlange** — der nächste `next-todo`-Aufruf
+  bekommt das *nächste* Todo, nie dasselbe doppelt.
+- Claude beendet seinen Zug **genau zweifach**: **`complete-todo`** (erledigt) **oder** **`handoff`**
+  → `aidoTurn = 'user'` (offen, Ball zurück beim Menschen). Beides löscht den Claim.
+- Ein Todo kehrt nur über einen **menschlichen Zug** zu `bei aido` zurück (expliziter
+  **„Zurück an aido"-Button** in der UI; kein Auto-on-edit in v1) — **oder** über **Lease-Ablauf**
+  als **Crash-Absicherung**, falls Claude weder abschließt noch zurückgibt. Die **Lease-Dauer ist
+  in den Einstellungen konfigurierbar** (je Session, mit nutzerweitem Default).
+
+So ist „endlos dasselbe Todo" strukturell ausgeschlossen, und „Frage beantworten ohne zu
+schließen" ist exakt der `handoff`-Pfad.
+
+### 4.4 MCP-Server-Erweiterung
+
+| Tool | Zweck |
+|---|---|
+| `register-session` (neu) | Upsert der **space-gebundenen** Session (`spaceId`, `hostname`, `workingFolder`, `label?`, `allowedTools?`) → `sessionId`; zuerst aufgerufen, bevor der Loop startet |
+| `next-todo` (neu) | **Per-Space-Query**: claimt & liefert das älteste offene Todo der Session **inkl. Body** (Markdown **und** Tiptap-JSON) + `spaceId`/`todoId`; leer, wenn nichts ansteht |
+| `update-todo` (neu) | schreibt `body` aus **Markdown** (→ Tiptap, inkl. Codeblock); Modi **`append`** (Default, „Antwort von aido"-Block) und `replace`; leitet `tags`/`mentions` neu ab; setzt `modifiedBy` + „von aido"-Marker; **kein** Auto-Handoff (Claude darf mehrfach editieren) |
+| `handoff` (neu) | `aidoTurn = 'user'`, Claim lösen — Ball zurück an den Menschen (Todo bleibt offen) |
+| `complete-todo` (vorhanden) | Abschluss |
+
+`list-todos`/`list-spaces`/… bleiben wie sie sind. Schreib-Tools laufen weiter durch das
+Rate-Limit (`enforceWriteRateLimit`).
+
+### 4.5 Markdown ↔ Tiptap
+
+Claude denkt in Markdown, der Body ist Tiptap-/ProseMirror-JSON. Konvertierung in **beide
+Richtungen** (Tiptap→Markdown fürs Lesen in `next-todo`, Markdown→Tiptap fürs Schreiben in
+`update-todo`), mindestens für **Codeblöcke**, Fett/Kursiv, Listen, Überschriften und Links
+(abgesichert über `linkSecurity`). **Inline-Code wird auf einen Codeblock abgebildet** — die
+Inline-`code`-Mark ist im Editor deaktiviert (`useTiptapConfig` `code:false`). `tags`/`mentions`
+werden aus dem neuen Body wie gehabt abgeleitet.
+
+### 4.6 „Von aido" sichtbar machen
+
+Da aido unter der uid des Nutzers schreibt (`modifiedBy` = Nutzer-uid), erhält die angehängte
+Antwort einen **Marker**, damit Mitglieder sie nicht für eine menschliche Eingabe halten — z.B. ein
+eigener Body-Block „💬 Antwort von aido" beim `append` und/oder ein Feld `lastAidoEditAt`. Die UI
+zeigt den Bearbeitungszustand als Badge (`bei aido` / `in Arbeit` / `bei dir`).
+
+### 4.7 Ablauf im `/loop`
+
+`register-session` (einmal beim Start) → dann je Tick: `next-todo` → Body lesen → bearbeiten/
+antworten via `update-todo` → `complete-todo` **oder** `handoff` → nächster Tick. Liefert
+`next-todo` nichts, idlet der Loop.
+
+### 4.8 Eingrenzung der Wirkung (Least Privilege)
+
+Die Wirkung einer automatisierten Session wird auf zwei serverseitig durchsetzbaren Ebenen
+begrenzt — wichtig, weil ein gebundenes Todo von einem anderen Space-Mitglied stammen kann und im
+Loop einen Agenten steuert (Prompt-Injection-Risiko):
+
+1. **Scope auf das geclaimte Todo.** `update-todo`/`handoff`/`complete-todo` wirken **nur** auf das
+   Todo, das die aufrufende Session aktuell hält (`claimedBy == meineSession`, Lease gültig); ein
+   Aufruf gegen ein anderes Todo wird abgewiesen. Eine Session hält **höchstens einen** aktiven
+   Claim (strikt seriell). Damit kann ein bösartiger Todo-Inhalt den Loop nicht dazu bringen,
+   *andere* Todos zu verändern oder zu löschen — der Blast-Radius ist genau dieses eine Todo.
+2. **Per-Session-Tool-Allowlist.** `register-session` deklariert (und die Settings-UI editiert) die
+   Liste **erlaubter Aktionen** der Session, z.B. `['update-todo','handoff','complete-todo']`. Der
+   Server erzwingt sie für die Session-Tools — eine Session lässt sich so auf „antworten &
+   zurückgeben, aber nie schließen" oder „nur lesen" beschränken.
+
+Die breiten CRUD-Tools (`add-todo`, `delete-todo`, `set-waiting-on`, …) sind **nicht** Teil der
+Session-Arbeitsfläche; der Loop bekommt sie gar nicht erst an die Hand.
+
+> **Ehrliche Grenze:** Die Allowlist bindet die **Session-Tools**, nicht den API-Key an sich — sie
+> verhindert nicht, dass *derselbe Key* die globalen CRUD-Tools direkt aufruft. Die eigentliche
+> Bedrohung ist aber die Injection *in den Loop*, und die ist durch (1)+(2) eingegrenzt. Welche
+> Tools eine Session real erhält, bestimmt zusätzlich die Claude-Code-MCP-Konfiguration des Loops.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Art der Betroffenheit |
+|---|---|---|
+| Datenmodell Sessions | `src/lib/types.ts` | Neu: `Session`-Typ (inkl. `spaceId`, `allowedTools`, `leaseTtlSeconds`) |
+| Datenmodell Todo | `src/lib/types.ts` (`Todo`) | Neu: `attachedSession`, `aidoTurn`, `claimedBy`, `claimedAt`, `lastAidoEditAt` |
+| Sicherheitsregeln | `firestore.rules`, `tests/firestore-rules.test.mjs` | `users/{uid}/sessions` (owner-only); Validierung der neuen Todo-Felder; gemeinsam aktualisiert |
+| MCP-Datenzugriff | `src/lib/mcp/data.ts` | `registerSession`, `nextTodo` (**Per-Space-Query** + atomarer Claim/Lease per Transaction), `updateTodo`, `handoffTodo`; `TodoView` um Body/Status erweitern |
+| MCP-Tools/Dispatch | `src/lib/mcp/tool-logic.ts`, Schemas (Zod), `src/app/api/mcp/sse/route.ts` | Neue Tools registrieren + Rate-Limit |
+| Tiptap-Konvertierung | neu unter `src/lib/tiptap/` (`markdown.ts`), `src/lib/tiptap/linkSecurity.ts` | Markdown↔Tiptap inkl. Codeblock; Link-Härtung |
+| Rich-Text-Render | `src/lib/hooks/useTiptapConfig.ts`, `src/components/shell/list/TodoBody` | Codeblock-Rendering sicherstellen |
+| Web-UI Agent-Sessions | neue Komponente (Settings-Panel, klar von Geräte-`SessionSettings` getrennt) | Agent-Sessions auflisten, umbenennen (`label`), entfernen, **erlaubte Tools** & **Lease-TTL** je Session einstellen |
+| Web-UI Attach/Status | `src/components/shell/list/TodoActions`, Board-Karten-Menü | „An Agent-Session anhängen…", „Zurück an aido", Badge, ggf. Filter |
+| Workspace-State | `src/lib/contexts/TodosContext.tsx` (ggf. `SpacesContext`) | `attachedSession`/Status-CRUD, Filter |
+| Indizes | `firestore.indexes.json` (neu, minimal) | Per-Space-Query auf `todos`; ggf. **einfacher** Composite-Index (`attachedSession`,`completed`) — **kein** Collection-Group-Index (Space-Bindung) |
+| MCP-Tool-Tests | `tests/mcp-tools.test.mts` | Neue Tools, Claim/Lease, gegen Firestore-Emulator |
+| Doku | `CLAUDE.md`, `README`, `.env.example` | Setup, Tool-Liste, `/loop`-Nutzung |
+
+## 6. Abgrenzung
+
+Nicht Teil dieser Anforderung:
+
+- **Der Push-/Channels-Weg** ([Konzept 01](01-konzept-claude-code-channels.md)) — getrennt.
+- **Eine separate Firestore-/Auth-Identität „aido".** Sessions handeln unter der uid des
+  Personal-API-Key-Eigentümers; kein Bot-User.
+- **Mehrere Sessions pro Todo / Menschen-Zuweisung.** v1: ein Todo ↔ eine Session; keine
+  Human-Assignees.
+- **Autonome Aktionen außerhalb des gebundenen Todos.** Scope: das per `next-todo` erhaltene Todo
+  lesen, Body ergänzen/beantworten, zurückgeben oder abschließen. Kein Handeln „in der Welt".
+- **Bau des `/loop` selbst** — Claude-Code-Nutzungsmuster; wir liefern nur die MCP-Tools.
+- **Migration von Bestandsdaten.** Alle neuen Felder sind optional/`null`; kein Backfill.
+
+## 7. Offene Fragen
+
+**Bereits entschieden:**
+- **Rückgabe an aido:** nur expliziter **„Zurück an aido"-Button** in der UI (kein Auto-on-edit in v1).
+- **Lease-TTL:** in den Einstellungen konfigurierbar (je Session, mit nutzerweitem Default) statt fest verdrahtet.
+- **Wirkungs-Eingrenzung:** Scope auf das geclaimte Todo **+** Per-Session-Tool-Allowlist via `register-session` (siehe 4.8).
+- **Default-Allowlist:** eine frisch registrierte Session darf `['update-todo','handoff']` — also
+  antworten & zurückgeben, **nicht** selbst abschließen; `complete-todo` wird pro Session in den
+  Settings freigeschaltet.
+- **Space-Bindung:** `register-session` ist auf **einen Space** beschränkt → `next-todo` ist ein
+  Per-Space-Query (kein Collection-Group, kein Cross-Space-Leak, kein Spezial-Index).
+- **Benennung:** „**Agent-Sessions**" (klar getrennt von Geräte-/Login-Sessions).
+- **Inline-Code:** wird in `update-todo` auf einen **Codeblock** abgebildet (Inline-`code`-Mark ist deaktiviert).
+- **Session-Speicherort:** `users/{uid}/sessions/{sessionId}` (owner-only) mit `spaceId`-Feld.
+
+**Noch offen:**
+4. **Sichtbarkeit für andere Space-Mitglieder:** ein angehängtes Todo liegt ggf. in einem geteilten
+   Space. Mitglied B kann A's Session-Doc nicht lesen — brauchen wir ein **denormalisiertes Label**
+   (Host/Ordner) am Todo für die Anzeige, oder reicht „an eine Session gebunden"? *Empfehlung:
+   schlankes Label denormalisieren.*
+5. **Darf Claude die Bindung selbst ändern?** *Empfehlung: nein* — Anhängen/Lösen nur via UI; die
+   Session darf nur `update-todo`/`handoff`/`complete-todo`, nicht `attachedSession` setzen.
+7. **Vertrauen/Prompt-Injection (Rest):** Die technische Eingrenzung steht (4.8). Offen bleibt die
+   *Erwartungshaltung*: Soll eine aido-Antwort grundsätzlich als „bitte prüfen" markiert sein, bevor
+   sie als erledigt gilt — und kennzeichnen wir die Herkunft eines gebundenen Todos (wer hat es
+   erstellt), damit der Loop fremdem Inhalt nicht blind folgt?
+8. **Session-Lifecycle:** Wann gilt eine Session als „weg" (TTL auf `lastSeenAt`)? Werden Todos
+   einer entfernten Session automatisch auf `bei dir` zurückgesetzt?

--- a/docs/02-ist-analyse-aido-sessions.md
+++ b/docs/02-ist-analyse-aido-sessions.md
@@ -1,0 +1,170 @@
+# Ist-Analyse: Todos an eine Claude-Code-Session binden und abarbeiten lassen
+
+Bezug: [Konzept](01-konzept-aido-sessions.md). Diese Analyse hält den heutigen Stand der
+Codebasis gegen die im Konzept geplanten Bausteine (Sessions, `next-todo` mit Claim/Lease,
+`update-todo` Markdown→Tiptap, Attach-UI, Settings, Allowlist).
+
+## 1. Aktueller Zustand
+
+### 1.1 MCP-Server (Pull-Schicht)
+
+- **Transport:** `src/app/api/mcp/sse/route.ts` nutzt `createMcpHandler` (`mcp-handler`) im
+  **stateless** Streamable-HTTP-Modus (`disableSse: true`). Tools werden **inline** mit Zod-Schemas
+  registriert (`server.tool(name, desc, schema, handler)`, Zeilen 45–111); die SDK validiert die
+  Eingaben **vor** dem Handler. `safe()` (Z. 33–41) mappt `McpToolError` → `errorResult`.
+  > Hinweis: Der Kommentar in `CLAUDE.md` über einen in-memory Session-Map / `node-mocks-http`-Shim
+  > ist **veraltet** — der aktuelle Endpoint ist stateless.
+- **Auth:** `src/lib/mcp/auth.ts` → `authenticateMcp` liefert `McpPrincipal = {kind:'user',uid} |
+  {kind:'shared'}`. Drei Credential-Typen: Shared-Secret (`MCP_AUTH_TOKEN`, identitätslos),
+  Personal-API-Key (`aido_…`, SHA-256-Hash-Lookup in `userApiKeys`, doc-id = uid) und OAuth-JWT
+  (claude.ai-Connector). **Daten-Tools brauchen `kind:'user'`** (`requireUserUid` in
+  `tool-logic.ts:34`).
+- **Per-Request-Identität:** `src/lib/mcp/context.ts` bindet den Principal via `AsyncLocalStorage`
+  an den Request (nicht an die Session-id — bewusst, Z. 4–11).
+- **Daten-/Member-Gate:** `src/lib/mcp/data.ts` (Admin SDK) — `requireMember(uid, spaceId)`
+  (Z. 103) ist das Tor jedes per-User-Tools; alle Reads/Writes sind **pro Space**. Schreib-Tools
+  laufen durch `enforceWriteRateLimit` (30/min/uid, `tool-logic.ts:48`).
+- **Vorhandene Tools:** `list-spaces`, `list-todos`, `add-todo`, `complete-todo`, `set-waiting-on`,
+  `list-daily`, `add-daily`, `delete-todo`, `whoami`, `list-members`.
+
+### 1.2 Lücken gegenüber dem Konzept (MCP)
+
+- **`TodoView` (`data.ts:52`) enthält keinen `body`** — nur `id/title/completed/waitingOn/tags/
+  order`. Claude kann die eigentliche Aufgabe/Frage **nicht lesen**. → `next-todo`/`get` müssen den
+  Body liefern.
+- **Kein Schreib-Tool für `title`/`body`.** `addTodo` erzeugt den Body nur aus Plain-Text
+  (`bodyFromText`, `data.ts:214` → ein Paragraph) — **keine Codeblöcke**. → `update-todo` fehlt
+  komplett.
+- **Keine Session-Begriffe** (Registrierung, Bindung, Claim, Lease, Turn) — alles neu.
+- **Kein `collectionGroup`-Query** in `src/` (bestätigt) und **keine `firestore.indexes.json`**.
+  `next-todo` ist das **erste** space-übergreifende Query-Muster und braucht einen
+  Collection-Group-(Composite-)Index, den es heute nicht gibt.
+
+### 1.3 Datenmodell & Sicherheitsregeln
+
+- **Todo** (`src/lib/types.ts:32`): `spaceId, title, body (TiptapContent|null), completed,
+  waitingOn (uid|null), tags[], mentions[], createdBy, modifiedBy, createdAt, order`. **Kein**
+  `assignedTo`/Session-/Turn-/Claim-Feld.
+- **Regeln** (`firestore.rules`, `match /todos/{todoId}`): jedes Mitglied darf create/update/delete;
+  `modifiedBy == auth.uid` Pflicht; `createdBy` immutabel; `waitingOn` null oder Mitglied; **`body`
+  ist bereits als `map|null` erlaubt** (`hasValidTodoFields`). Die Regeln **prüfen die bekannten
+  Felder per Shape**, beschränken aber **nicht** auf einen geschlossenen Schlüssel-Satz — neue
+  Felder wären schreibbar, aber **unvalidiert**.
+- **Sessions:** keine Collection vorhanden. `users/{uid}` ist **owner-only** und trägt heute schon
+  Settings (theme, notifications, language, timezone) ohne Feld-Enumeration in den Regeln — d.h.
+  ein Lease-TTL-Default ließe sich dort **ohne** Regeländerung ablegen.
+
+### 1.4 Rich-Text (Tiptap)
+
+- **Codeblöcke sind bereits aktiviert.** `useTiptapConfig` (`src/lib/hooks/useTiptapConfig.ts`)
+  registriert `CustomCodeBlock` (Z. 25–54, 147), Listen, TaskList/TaskItem, Underline, gehärtete
+  `Link` (Allowlist via `linkSecurity`), Highlight, Mention, Hashtag. **Inline-`code` ist
+  deaktiviert** (`code:false`, Z. 131). Read-only-Render läuft XSS-sicher über `<EditorContent>`
+  (`TodoBody.tsx`), Edit über `TodoEditor.tsx`.
+- **Aber:** `useTiptapConfig` ist ein **Client-/React-Hook** (`@tiptap/react`, `getContacts`) — im
+  **serverseitigen** Admin-Kontext der MCP-Tools **nicht nutzbar**. Es gibt **keine
+  Markdown↔Tiptap-Konvertierung** und **keine** Serializer-Library in `package.json`
+  (`tiptap-markdown`/`prosemirror-markdown`/`marked`/`markdown-it` — alle nicht vorhanden). Der
+  einzige Text→Tiptap-Pfad ist `bodyFromText` (Plain-Text). → Markdown→Tiptap (inkl. Codeblock) ist
+  **Greenfield** und muss als eigenständige, vom React-Editor unabhängige Funktion entstehen, die
+  **nur die oben erlaubten Node-/Mark-Typen** erzeugt.
+
+### 1.5 Web-UI & Client-Schreibwege
+
+- **Aktion-Muster „Verschieben…"** (#201/#202) ist die Blaupause für „An Session anhängen…":
+  - Liste: `src/components/shell/list/TodoActions.tsx` öffnet `MoveToSpaceMenu`
+    (`src/components/shell/MoveToSpaceMenu.tsx`, ruft `TodosContext.moveTodo`).
+  - Board: `src/components/shell/board/TodoCard.tsx` (`onMoveToSpace`) → `BoardView.tsx` öffnet
+    `MoveToSpaceMenu` in einer `BottomSheet`.
+- **`TodosContext`** (`src/lib/contexts/TodosContext.tsx`) abonniert `spaces/{spaceId}/todos` live
+  (`subscribeTodosForSpace`, orderBy `order`) und exponiert `createTodo/editContent/setCompleted/
+  setWaitingOn/setStatus/remove/moveTodo` + Tag-Filter. **Pro aktivem Space**, nicht
+  space-übergreifend.
+- **`firebaseUtils`** Schreibhelfer (`createTodo`, `editTodoContent`, `setTodoCompleted`,
+  `setTodoWaitingOn`, `setTodoStatus`, `deleteTodo`, `moveTodoToSpace`) setzen **alle**
+  `modifiedBy: uid` und leiten `tags`/`mentions` neu ab (`deriveTags`/`deriveMentions`).
+- **Settings:** `src/components/UserSettings.tsx` schreibt `users/{uid}` via `updateDoc` und bindet
+  `ApiKeySettings` + `SessionSettings` ein. **Namenskollision:** `SessionSettings.tsx` /
+  `tests/device-login.test.mts` / `/api/auth/sessions/revoke` meinen **Geräte-/Login-Sessions** —
+  ein völlig anderes Konzept als die hier geplanten **Claude-Code-Sessions**. Die neue UI braucht
+  einen **eindeutig anderen Namen** (z.B. „Agent-Sessions" / „Claude-Code-Sessions").
+
+### 1.6 Tests
+
+- Emulator-basiert in `tests/`: `firestore-rules.test.mjs` (Rules), `mcp-tools.test.mts`
+  (`npm run test:mcp`, fährt echten `src/lib/mcp/*`-Code gegen den Emulator), zusätzlich
+  `device-login`, `migration-admin`, `oauth`, `storage-rules`. Neue Tools/Felder müssen hier
+  mitgezogen werden (Rules **und** MCP-Tool-Tests, je in Parität).
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/app/api/mcp/sse/route.ts` | Tool-Registrierung (inline Zod), stateless Handler | Neue Tools `register-session`/`next-todo`/`update-todo`/`handoff` registrieren |
+| `src/lib/mcp/tool-logic.ts` | Handler, `requireUserUid`, Rate-Limit | Neue Handler + Allowlist-Enforcement |
+| `src/lib/mcp/data.ts` | Admin-SDK-Datenzugriff, `requireMember`, `TodoView` | Session-Funktionen, Claim/Lease (Transaction), `collectionGroup`-Query, Body in View |
+| `src/lib/mcp/auth.ts` / `context.ts` | Principal (uid) je Request | Session-Identität aus uid + host+cwd ableiten; unverändert |
+| `firestore.rules` | Autorität des Datenmodells | `users/{uid}/sessions`; Validierung `attachedSession`/`aidoTurn`/`claimedBy`/`claimedAt` |
+| `tests/firestore-rules.test.mjs` | Rules-Tests | Neue Felder/Collection abdecken |
+| `tests/mcp-tools.test.mts` | MCP-Tool-Tests gg. Emulator | Claim/Lease/Allowlist/`update-todo` abdecken |
+| `src/lib/types.ts` | `Todo`-Typ | `Session`-Typ; Todo-Felder ergänzen |
+| **`firestore.indexes.json` (fehlt)** | Index-Definitionen | **Neu anlegen** für Collection-Group-Index `next-todo` |
+| `src/lib/tiptap/linkSecurity.ts` | Link-Allowlist | Von Markdown→Tiptap wiederverwenden |
+| (neu) `src/lib/tiptap/markdown.ts` | — existiert nicht — | Markdown↔Tiptap (serverfähig, nur erlaubte Nodes) |
+| `src/lib/hooks/useTiptapConfig.ts` | Client-Editor-Config (CodeBlock aktiv) | Referenz für erlaubte Node-/Mark-Typen; **nicht** serverseitig nutzbar |
+| `src/components/shell/list/TodoActions.tsx`, `shell/MoveToSpaceMenu.tsx` | Listen-Aktionen/Picker | Muster für „An Session anhängen…", „Zurück an aido" |
+| `src/components/shell/board/{TodoCard,BoardView}.tsx` | Board-Karte/Aktionen | Attach/Status auf Karten |
+| `src/lib/contexts/TodosContext.tsx` | Todo-CRUD + Live-Abo (pro Space) | Attach/Turn-Setter, Status-Badge, ggf. Filter |
+| `src/lib/firebase/firebaseUtils.ts` | Schreibhelfer (setzen `modifiedBy`) | `bindTodoToSession`/`returnToAido` ergänzen |
+| `src/components/UserSettings.tsx` | Settings-Schreibweg `users/{uid}` | Lease-TTL-Default; Einbinden des Sessions-Panels |
+| `src/components/SessionSettings.tsx` | **Geräte-Login**-Sessions | **Namenskollision** — neue Komponente klar abgrenzen |
+
+## 3. Bestehende Abhängigkeiten
+
+- **Extern:** `mcp-handler`, `@modelcontextprotocol/sdk`, `zod` (MCP); `firebase-admin` (Admin-SDK,
+  Transaktionen für Claim/Lease); `firebase` (Client-SDK, Live-Abos); `@tiptap/*` (Editor/Render).
+  **Neu nötig:** ein Markdown-Parser/-Serializer (oder Eigenbau) für die Body-Konvertierung.
+- **Intern (Parität!):** `data.ts` muss die Constraints aus `firestore.rules` **selbst** erzwingen
+  (Admin-SDK umgeht die Regeln). `firebaseUtils` ↔ Regeln (`modifiedBy`, `tags`/`mentions`).
+  `TodosContext` ↔ `firebaseUtils`. Markdown→Tiptap ↔ die in `useTiptapConfig` erlaubten Typen
+  (sonst rendert/serialisiert der Body inkonsistent).
+
+## 4. Bekannte Einschränkungen
+
+- **Admin-SDK umgeht die Regeln** → jede neue Schreiblogik in `data.ts` muss die Regeln spiegeln;
+  neue Felder müssen in **beiden** Welten validiert werden (Muster aus #71/#198).
+- **Stateless/Serverless** → keine serverseitige Session-Speicherung über Requests hinweg; die
+  Session-Identität muss pro Request **herleitbar** sein (host+cwd) — passt zum Konzept, ist aber
+  zwingend.
+- **Kein serverseitiges Tiptap, keine Markdown-Lib** → Konvertierung ist Neubau und
+  XSS-sensibel (nur erlaubte Nodes, Links durch `linkSecurity`).
+- **Kein Index-Setup** (`firestore.indexes.json` fehlt, kein `collectionGroup`) → `next-todo`
+  erfordert neue Index-Infrastruktur + Deploy.
+- **Inline-`code` deaktiviert** (`code:false`) → Markdown-Inline-Code muss bewusst behandelt werden
+  (Extension aktivieren **oder** auf Codeblock mappen) — Entscheidung in der Spezifikation.
+- **Rate-Limit 30 Writes/min/uid, pro Instanz** → ein enger `/loop` (`next-todo` claimt = Write)
+  kann anlaufen; Loop-Takt muss das respektieren bzw. `next-todo`-Claim ggf. vom Write-Limit
+  ausnehmen/separat takten.
+- **„Session" ist semantisch belegt** (Geräte-Login) → konsequent abweichende Benennung nötig.
+
+## 5. Risiken bei Änderung
+
+- **Regel-/Code-Parität bricht:** Neue Todo-Felder ohne gleichzeitige Regel-Validierung erlauben
+  entweder Hostile-Writes (unvalidiert) oder brechen bestehende Clients (zu strenge Shape-Checks
+  auf Teil-Updates, die in die volle Doc-Form mergen). → Regeln + Tests **im selben Schritt**.
+- **Claim/Lease-Races:** `next-todo` schreibt beim Lesen (Claim). Ohne **Transaktion** könnten zwei
+  Aufrufe dasselbe Todo claimen oder ein abgelaufener Lease inkonsistent überschrieben werden.
+- **Cross-Space-Leak:** Der `collectionGroup`-Query über `attachedSession` trifft Todos in **allen**
+  Spaces. Da Admin die Regeln umgeht, muss jeder Treffer **gegen aktuelle Mitgliedschaft** geprüft
+  werden (z.B. nach Verlassen eines Space), sonst liest/bearbeitet der Loop Fremd-Todos.
+- **XSS/Body-Integrität:** Eine schlecht gebaute Markdown→Tiptap-Konvertierung könnte unerlaubte
+  Nodes/Attribute oder ungeprüfte Links erzeugen. Der Render-Pfad muss `<EditorContent>` bleiben
+  (nie `dangerouslySetInnerHTML`/`generateHTML`).
+- **UX-Verwechslung:** „Sessions" in den Settings ohne klare Abgrenzung zu Geräte-Login-Sessions.
+- **Lease-TTL-Read:** Konfigurierbarer TTL bedeutet einen zusätzlichen Settings-Read beim Claim
+  (oder Caching) — kleiner, aber zu bedenkender Overhead.
+
+## 6. Referenzen
+
+- [Konzept](01-konzept-aido-sessions.md)
+- Verwandtes Konzept (Push-Weg): [Claude Code Channels](01-konzept-claude-code-channels.md)

--- a/docs/03-anforderungsanalyse-aido-sessions.md
+++ b/docs/03-anforderungsanalyse-aido-sessions.md
@@ -1,0 +1,123 @@
+# Anforderungsanalyse: Todos an eine Agent-Session binden und abarbeiten lassen
+
+Bezug: [Konzept](01-konzept-aido-sessions.md), [Ist-Analyse](02-ist-analyse-aido-sessions.md).
+Priorität: **Muss** = MVP, **Soll** = wichtig, aber nachgelagert, **Kann** = optional.
+
+## 1. Funktionale Anforderungen
+
+### Agent-Sessions (Registrierung & Verwaltung)
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Session registrieren | Muss | MCP-Tool `register-session(spaceId, hostname, workingFolder, label?, allowedTools?)`. Member-gegated (`requireMember`); **Upsert** mit deterministischer `sessionId = hash(spaceId+host+cwd)`; legt/aktualisiert `users/{uid}/sessions/{sessionId}` und setzt `lastSeenAt`. Gibt `sessionId` zurück. |
+| FA-02 | Sessions speichern | Muss | Collection `users/{uid}/sessions/{sessionId}` (**owner-only**) mit `spaceId, hostname, workingFolder, label?, allowedTools, leaseTtlSeconds, createdAt, lastSeenAt`. Vom Owner (Client-SDK) lesbar für die UI. |
+| FA-03 | Sessions verwalten (UI) | Soll | Settings-Panel **„Agent-Sessions"** (klar getrennt von Geräte-`SessionSettings`): auflisten (mit „zuletzt aktiv"), umbenennen (`label`), entfernen; `allowedTools` und `leaseTtlSeconds` je Session setzen. |
+| FA-04 | Heartbeat / Aktivität | Soll | Jeder `next-todo`-Aufruf frischt `lastSeenAt`; die UI zeigt aktive vs. stale Sessions. |
+
+### Bindung (Attach)
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-05 | Todo an Session anhängen (Liste) | Muss | Aktion „An Agent-Session anhängen…" in `TodoActions`; bietet nur die für **diesen Space** registrierten Sessions an; setzt `attachedSession` und `aidoTurn='aido'`. |
+| FA-06 | Anhängen im Board | Soll | Gleiche Aktion im Board-Karten-Menü (`TodoCard`/`BoardView`, Muster #202). |
+| FA-07 | Bindung lösen | Muss | „Lösen" entfernt `attachedSession` (Status zurück auf normal); nur via UI. |
+| FA-08 | „Zurück an aido" | Muss | Bei `aidoTurn='user'` setzt ein expliziter Button `aidoTurn='aido'` (kein Auto-on-edit in v1). |
+| FA-09 | Statusanzeige | Soll | Badge je Todo: `bei aido` / `in Arbeit` / `bei dir`, in Liste und Board. |
+
+### Abholen & Bearbeiten (Loop)
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-10 | Nächstes Todo holen (Claim) | Muss | `next-todo` (Identität aus host+cwd+space): **Per-Space-Query** nach dem **ältesten (`createdAt` asc) offenen** Todo mit `attachedSession==self && aidoTurn=='aido'` und freiem/abgelaufenem Claim; **atomarer Claim** (Transaction): `claimedBy=sessionId, claimedAt=now`. Liefert `spaceId`, `todoId`, `title`, **Body als Markdown + Tiptap-JSON**, sonst „leer". |
+| FA-11 | Ein Claim je Session | Muss | Eine Session hält höchstens einen aktiven Claim; hält sie bereits einen, liefert `next-todo` idempotent dieses Todo (strikt seriell). |
+| FA-12 | Lease / Crash-Recovery | Muss | Ein Claim, dessen `claimedAt` älter als `leaseTtlSeconds` ist, gilt als frei und ist neu claimbar. |
+| FA-13 | Body bearbeiten | Muss | `update-todo(bodyMarkdown, mode?)`: **Markdown→Tiptap** (inkl. Codeblock; **Inline-Code → Codeblock**); Modi **`append`** (Default, „💬 Antwort von aido"-Block) und `replace`; leitet `tags`/`mentions` neu ab; setzt `modifiedBy`; **kein** Auto-Handoff. |
+| FA-14 | Zurückgeben (handoff) | Muss | `handoff`: `aidoTurn='user'`, Claim lösen — Todo bleibt **offen** („Frage beantwortet, ohne zu schließen"). |
+| FA-15 | Abschließen | Muss | `complete-todo` (vorhanden) schließt das geclaimte Todo; **nur** wenn per Allowlist erlaubt. |
+| FA-16 | „Von aido"-Kennzeichnung | Soll | Angehängte Antworten tragen einen sichtbaren Marker (Body-Block und/oder `lastAidoEditAt`), damit Mitglieder die Herkunft erkennen (da `modifiedBy` = Nutzer-uid). |
+
+### Sicherheit / Wirkungs-Eingrenzung
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-17 | Scope auf das geclaimte Todo | Muss | `update-todo`/`handoff`/`complete-todo` wirken **nur** auf das Todo mit `claimedBy==self` (gültiger Lease); jeder andere Ziel-Todo wird abgewiesen. |
+| FA-18 | Per-Session-Allowlist | Muss | `allowedTools` wird **serverseitig** für die Session-Tools erzwungen; Default einer neuen Session: `['update-todo','handoff']` (ohne `complete-todo`). |
+| FA-19 | Bindung nicht durch Claude änderbar | Soll | Die Session kann `attachedSession` **nicht** selbst setzen/lösen (nur UI); sie darf nur `update-todo`/`handoff`/`complete-todo` im erlaubten Rahmen. |
+
+### Konvertierung & Datenmodell
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-20 | Markdown↔Tiptap (serverfähig) | Muss | Eigenständige, vom React-Editor unabhängige Funktion (`src/lib/tiptap/markdown.ts`): Tiptap→Markdown (Lesen) und Markdown→Tiptap (Schreiben), erzeugt **ausschließlich** die in `useTiptapConfig` erlaubten Node-/Mark-Typen; Links über `linkSecurity`. |
+| FA-21 | Neue Felder + Regeln | Muss | `Todo` um `attachedSession, aidoTurn, claimedBy, claimedAt, lastAidoEditAt` (optional/`null`) erweitern; `firestore.rules` validiert sie (Typ/Wert) **und** `users/{uid}/sessions`; Regeln + Tests im selben Schritt. |
+| FA-22 | Lease-TTL-Default in Settings | Soll | `leaseTtlSeconds` je Session, mit nutzerweitem Default (in `users/{uid}`-Settings, regelseitig ohne Schema-Zwang). |
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Regel-/Code-Parität | Sicherheit | Admin-SDK umgeht `firestore.rules`; `data.ts` erzwingt dieselben Constraints (Member, `modifiedBy`, Feld-Shapes). Neue Felder in **beiden** validiert (Muster #71/#198). |
+| NFA-02 | XSS-Sicherheit | Sicherheit | Body nur über `<EditorContent>` rendern (nie `dangerouslySetInnerHTML`/`generateHTML`); der Konverter erzeugt nur erlaubte Nodes; Links gehärtet. |
+| NFA-03 | Konsistenz Claim/Lease | Zuverlässigkeit | Claim ausschließlich **transaktional**; keine Doppel-Claims, kein Überschreiben eines noch gültigen Claims. |
+| NFA-04 | Performance | Performance | `next-todo` ist Per-Space-Query (kein Collection-Group); höchstens **ein** einfacher Composite-Index; Lease-TTL-Read günstig (ein Settings-/Session-Read). |
+| NFA-05 | Zustandslosigkeit | Architektur | Keine serverseitige Session-Speicherung über Requests; Identität pro Request aus host+cwd+space herleitbar; Crash-Recovery via Lease. |
+| NFA-06 | Rate-Limit-Verträglichkeit | Performance | `next-todo`-Claim ist ein Write → Loop-Takt muss das 30/min-Limit respektieren; ggf. Claim separat takten/zählen. |
+| NFA-07 | Abwärtskompatibilität | Wartbarkeit | Neue Felder optional/`null`; **keine** Migration/Backfill; bestehende Tools (`list-todos` etc.) unverändert nutzbar. |
+| NFA-08 | Verständlichkeit (UX) | Usability | „Agent-Sessions" überall klar von Geräte-/Login-Sessions abgegrenzt. |
+| NFA-09 | Testabdeckung | Qualität | Rules-Tests (`firestore-rules.test.mjs`) und MCP-Tool-Tests (`mcp-tools.test.mts`) decken neue Felder, Claim/Lease, Allowlist und Konvertierung ab. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] `register-session(spaceId, host, cwd)` legt eine owner-only Session an; erneuter Aufruf mit
+      gleichem host+cwd+space liefert **dieselbe** `sessionId` und aktualisiert `lastSeenAt`.
+- [ ] `register-session` für einen Space, in dem der Nutzer **kein** Mitglied ist, wird abgewiesen.
+- [ ] In der Liste lässt sich ein Todo einer Session **desselben Space** anhängen; danach Status
+      `bei aido`. Sessions **anderer** Spaces erscheinen nicht im Picker.
+- [ ] `next-todo` liefert das **älteste offene** angehängte Todo der Session inkl. Body als Markdown
+      **und** Tiptap-JSON und claimt es; ein direkt folgender `next-todo` liefert das **nächste**
+      Todo (nie dasselbe), bis keines mit `aidoTurn=='aido'` mehr offen ist → „leer".
+- [ ] Zwei (theoretisch) gleichzeitige `next-todo` claimen **nicht** dasselbe Todo (Transaction).
+- [ ] `update-todo` mit Markdown inkl. ```` ```code``` ```` schreibt einen **Codeblock**; Inline-Code
+      landet ebenfalls als Codeblock; der Body rendert in der Web-UI korrekt und XSS-sicher.
+- [ ] `update-todo` im Default-Modus **hängt an** (Original/Frage bleibt erhalten, „von aido"-Marker
+      sichtbar); `replace` ersetzt.
+- [ ] `update-todo`/`handoff`/`complete-todo` gegen ein **nicht** von der Session geclaimtes Todo
+      werden abgewiesen.
+- [ ] `handoff` setzt `aidoTurn='user'`, lässt das Todo **offen**; es verschwindet aus `next-todo`,
+      bis der Nutzer „Zurück an aido" klickt.
+- [ ] Ein Claim, älter als `leaseTtlSeconds`, ist erneut claimbar.
+- [ ] Eine Session mit Default-Allowlist kann `complete-todo` **nicht** ausführen, bis es in den
+      Settings freigeschaltet ist.
+- [ ] Neue Todo-Felder sind in `firestore.rules` typ-/wert-validiert; Rules- und MCP-Tool-Tests
+      grün im Emulator.
+- [ ] Bestehende Tools/Flows (Liste, Board, `list-todos`, `add-todo`) funktionieren unverändert.
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- **MCP-Server (Epic #124)** — diese Anforderung erweitert dessen Tool-Set und Datenzugriff.
+- **Komplementär:** [Channels-Push-Weg](01-konzept-claude-code-channels.md) — eigenständig, kein
+  Blocker.
+- **UI-Muster:** „Verschieben…" (#201/#202) als Vorlage für Attach in Liste & Board.
+- **Regel-Muster:** `modifiedBy`-Keying (#198/#199), Move-Preserve-`createdBy` (#200), Feld-Shapes
+  (#71) — werden für die neuen Felder fortgeschrieben.
+- **Tiptap-Härtung:** `linkSecurity` (#17) wird vom Markdown-Konverter wiederverwendet.
+
+## 5. Priorisierung
+
+**MVP (Muss) — der durchgehende Loop-Pfad:**
+FA-01, FA-02, FA-05, FA-07, FA-08, FA-10, FA-11, FA-12, FA-13, FA-14, FA-15, FA-17, FA-18, FA-20,
+FA-21. Damit ist „registrieren → anhängen → `next-todo` → antworten (Markdown/Codeblock) →
+handoff/complete" Ende-zu-Ende möglich, sicher eingegrenzt und regelkonform.
+
+**Soll — Komfort & Sichtbarkeit:**
+FA-03 (Sessions-Panel), FA-04 (Heartbeat-Anzeige), FA-06 (Board-Attach), FA-09 (Status-Badges),
+FA-16 („von aido"-Marker), FA-19 (Bindung nicht durch Claude änderbar), FA-22 (Lease-TTL-Setting).
+
+**Kann — später:**
+Denormalisiertes Session-Label am Todo für Fremd-Mitglieder (Offene Frage #4), automatische
+Rücksetzung von Todos einer entfernten Session (#8), Auto-„zurück an aido" bei Body-Änderung.
+
+## 6. Referenzen
+
+- [Konzept](01-konzept-aido-sessions.md)
+- [Ist-Analyse](02-ist-analyse-aido-sessions.md)

--- a/docs/04-spezifikation-aido-sessions.md
+++ b/docs/04-spezifikation-aido-sessions.md
@@ -1,0 +1,242 @@
+# Spezifikation: Todos an eine Agent-Session binden und abarbeiten lassen
+
+Bezug: [Konzept](01-konzept-aido-sessions.md), [Ist-Analyse](02-ist-analyse-aido-sessions.md),
+[Anforderungsanalyse](03-anforderungsanalyse-aido-sessions.md).
+
+## 1. Übersicht
+
+Eine **Agent-Session** ist ein an genau einen Space gebundenes Objekt unter
+`users/{uid}/sessions/{sessionId}`. Eine Claude-Code-Session registriert sich (`register-session`),
+der Nutzer hängt Todos dieses Space an die Session (UI), und die Session holt sie per `next-todo`
+(Claim + Lease), beantwortet/ergänzt den Body (`update-todo`, Markdown→Tiptap) und gibt sie offen
+zurück (`handoff`) oder schließt sie ab (`complete-todo`). Die Wirkung ist durch **Scope auf das
+geclaimte Todo** und eine **Per-Session-Allowlist** eingegrenzt. Kein Datenmodell-Bruch: alle neuen
+Felder sind optional/`null`, kein Backfill.
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+- Alle Server-Tools leben weiter im bestehenden MCP-Endpoint (`route.ts` → `tool-logic.ts` →
+  `data.ts`, Admin-SDK, per-Request-Principal). Es kommt **kein** neuer Prozess/Service dazu.
+- `next-todo` ist ein **Per-Space-Query** (Session ist space-gebunden) → **kein** Collection-Group,
+  **kein** Spezial-Index. Die Kandidaten werden wie in `listTodos` geladen und **in-memory**
+  gefiltert/sortiert (Anzahl angehängter Todos je Session ist klein).
+- Markdown↔Tiptap ist ein **serverfähiges Modul** (`src/lib/tiptap/markdown.ts`), unabhängig von
+  `useTiptapConfig`/`@tiptap/react`.
+
+### 2.2 Datenmodell
+
+**Neuer Typ `AgentSession`** (`src/lib/types.ts`), Collection `users/{uid}/sessions/{sessionId}`:
+
+```ts
+export type AgentToolName = 'update-todo' | 'handoff' | 'complete-todo';
+
+export interface AgentSession {
+  id: string;                 // = sessionId = sha256(spaceId|hostname|workingFolder) (hex, gekürzt)
+  spaceId: string;
+  hostname: string;
+  workingFolder: string;
+  label: string | null;
+  allowedTools: AgentToolName[];   // Default ['update-todo','handoff']
+  leaseTtlSeconds: number;         // Default aus User-Setting (z.B. 600)
+  createdAt: Timestamp | null;
+  lastSeenAt: Timestamp | null;
+}
+```
+
+**`Todo`-Erweiterung** (`src/lib/types.ts`, alle optional/`null`):
+
+```ts
+attachedSession: string | null;    // sessionId, oder null = nicht gebunden
+aidoTurn: 'aido' | 'user' | null;  // wessen Zug (nur sinnvoll wenn attached)
+claimedBy: string | null;          // sessionId, die den Claim hält
+claimedAt: Timestamp | null;       // Claim-Zeitpunkt (Lease-Basis)
+lastAidoEditAt: Timestamp | null;  // Marker „von aido"
+```
+
+**Zustands-Ableitung** (für UI-Badge & `next-todo`):
+
+| Zustand | Bedingung |
+|---|---|
+| nicht gebunden | `attachedSession == null` |
+| `bei aido` (Queue) | attached & `aidoTurn=='aido'` & (`claimedBy==null` **oder** Lease abgelaufen) |
+| `in Arbeit` | attached & `aidoTurn=='aido'` & `claimedBy!=null` & Lease gültig |
+| `bei dir` | attached & `aidoTurn=='user'` |
+| erledigt | `completed==true` |
+
+**User-Setting** (`users/{uid}`): `agentSessionDefaults: { leaseTtlSeconds: number }` (z.B. 600).
+
+### 2.3 Schnittstellen (MCP-Tools)
+
+Session-Identität wird in `register-session`/`next-todo` aus `(spaceId, hostname, workingFolder)`
+**deterministisch** abgeleitet; die mutierenden Session-Tools nehmen die `sessionId` (aus
+`register-session`/`next-todo`) entgegen.
+
+| Tool | Zod-Eingabe | Rückgabe / Wirkung |
+|---|---|---|
+| `register-session` | `{ spaceId, hostname, workingFolder, label?, allowedTools? }` | `requireMember`; Upsert `users/{uid}/sessions/{sha}`; setzt `lastSeenAt`; `allowedTools` Default `['update-todo','handoff']`, `leaseTtlSeconds` aus User-Default. → `{ sessionId, spaceId, allowedTools, leaseTtlSeconds }` |
+| `next-todo` | `{ spaceId, hostname, workingFolder }` | `requireMember`; löst `sessionId`, Session muss existieren; **claimt** (s. 2.4); Heartbeat `lastSeenAt`. → `{ todo: { spaceId, todoId, title, bodyMarkdown, body, tags, createdBy } } \| { todo: null }` |
+| `update-todo` | `{ sessionId, spaceId, todoId, bodyMarkdown, mode? }` (`mode` ∈ `append`\|`replace`, Default `append`) | Scope+Allowlist (`update-todo`); Markdown→Tiptap; `append` fügt „💬 Antwort von aido"-Block + Antwort an, `replace` ersetzt; `tags`/`mentions` neu ableiten; `modifiedBy=uid`, `lastAidoEditAt=now`. → aktualisierte `TodoView` |
+| `handoff` | `{ sessionId, spaceId, todoId }` | Scope+Allowlist (`handoff`); `aidoTurn='user'`, `claimedBy=null`,`claimedAt=null`. Todo bleibt offen. → `TodoView` |
+| `complete-todo` | **erweitert:** `{ spaceId, todoId, completed, sessionId? }` | Ohne `sessionId`: bisheriges Verhalten (member-gegated). Mit `sessionId`: zusätzlich Scope+Allowlist (`complete-todo`) und Claim lösen. |
+
+`requireUserUid()` + `enforceWriteRateLimit(uid)` gelten wie bei den bestehenden Schreib-Tools.
+`next-todo`-Claim ist ein Write — wird gezählt; bei engem Loop-Takt das 30/min-Limit beachten
+(NFA-06).
+
+### 2.4 Claim/Lease-Algorithmus (`nextTodo` in `data.ts`)
+
+```
+1. session = getSession(uid, sha(spaceId,host,cwd));  // McpToolError not_found falls fehlt
+   requireMember(uid, spaceId); touch lastSeenAt.
+2. Lade Kandidaten: spaces/{spaceId}/todos where attachedSession == sessionId
+   (Einzelfeld-Filter, auto-indexiert). In-memory:
+   a. self = Kandidaten mit completed==false && aidoTurn=='aido' && claimedBy==sessionId
+            && lease gültig  → falls vorhanden: ältestes (createdAt) zurückgeben (idempotenter Self-Claim).
+   b. frei = completed==false && aidoTurn=='aido' && (claimedBy==null || claimedAt < now-leaseTtl)
+   c. sortiere `frei` nach createdAt asc.
+3. Für jeden Kandidaten in `frei` (ältester zuerst): runTransaction:
+   - re-read doc; prüfe Eligibilität erneut (nicht von anderem gültig geclaimt, noch aidoTurn=='aido', offen);
+   - falls ok: set claimedBy=sessionId, claimedAt=serverTimestamp, modifiedBy=uid; commit; return.
+   - falls inzwischen weg-geclaimt: nächster Kandidat.
+4. Keiner → { todo: null }.
+```
+
+Transaktion garantiert **kein Doppel-Claim** (NFA-03). „Höchstens ein Claim je Session" entsteht aus
+Schritt 2a (Self-Claim wird vor Neu-Claim bevorzugt) + striktem Loop-Muster (handoff/complete vor
+nächstem `next-todo`).
+
+### 2.5 Markdown ↔ Tiptap (`src/lib/tiptap/markdown.ts`)
+
+Erzeugt/liest **ausschließlich** die in `useTiptapConfig` registrierten Typen: `doc, paragraph,
+heading, bulletList, orderedList, listItem, codeBlock, taskList, taskItem, blockquote` sowie Marks
+`bold, italic, strike, link, highlight`. **Keine** Inline-`code`-Mark, **kein** `horizontalRule`,
+**kein** `hardBreak`.
+
+```ts
+export function markdownToTiptap(md: string): TiptapContent | null; // null bei leer
+export function tiptapToMarkdown(doc: TiptapContent | null): string;
+export function appendAnswer(existing: TiptapContent | null, answerMd: string, opts: { at: Date }): TiptapContent;
+```
+
+- **Parser:** `markdown-it` (neue Dependency) → Token-Stream → Tiptap-JSON-Mapping.
+- **Codeblock:** ` ```lang … ``` ` → `codeBlock` (Attr `language`). **Inline-Code** (kein Inline-Mark
+  verfügbar): wird zu einem **eigenen `codeBlock`** befördert; steht Inline-Code mitten im Satz, wird
+  der Absatz an dieser Stelle getrennt (Code als eigener Block). *Tool-Beschreibung weist den Agenten
+  an, für Code bevorzugt fenced Blocks zu nutzen.*
+- **Links:** nur wenn `isSafeLinkUrl(url)` (aus `linkSecurity`) — sonst als Klartext.
+- **Nicht abbildbares** (`---`, harte Umbrüche) wird verworfen/zu Absätzen normalisiert.
+- **`appendAnswer`:** `existing.content` + Marker-Block (`heading`/`paragraph` „💬 Antwort von aido ·
+  {Zeit}") + konvertierte Antwort.
+- **Lesen (`tiptapToMarkdown`):** Walk über die Nodes; `mention`→`@label`, `hashtag`/Text bleibt
+  Text; `codeBlock`→fenced. `tags`/`mentions` werden beim Schreiben weiterhin über
+  `deriveTags`/`deriveMentions` aus Title+Body abgeleitet (unverändert).
+
+### 2.6 Sicherheitsregeln (`firestore.rules`)
+
+**Sessions** unter `match /users/{userId}`:
+
+```
+match /sessions/{sessionId} {
+  allow read, write, delete: if isOwner(userId);
+}
+```
+
+(MCP schreibt via Admin-SDK ohnehin an den Regeln vorbei; die Regel deckt das **UI**-Lesen/-Editieren
+durch den Owner ab — Umbenennen, `allowedTools`/`leaseTtlSeconds`, Löschen.)
+
+**Todo-Felder** — `hasValidTodoFields` (bzw. neue Hilfsfunktion) um Shape-Checks erweitern, auf
+create **und** update (Teil-Updates mergen in die volle Doc-Form):
+
+```
+&& (!('attachedSession' in d) || d.attachedSession == null || d.attachedSession is string)
+&& (!('aidoTurn' in d)        || d.aidoTurn == null || d.aidoTurn in ['aido','user'])
+&& (!('claimedBy' in d)       || d.claimedBy == null || d.claimedBy is string)
+&& (!('claimedAt' in d)       || d.claimedAt == null || d.claimedAt is timestamp)
+&& (!('lastAidoEditAt' in d)  || d.lastAidoEditAt == null || d.lastAidoEditAt is timestamp)
+```
+
+`modifiedBy == auth.uid` und `createdBy`-Immutabilität bleiben unverändert (die Data-Layer setzt
+`modifiedBy=uid`). *Residual (Offene Frage):* ein Member könnte per Client-SDK `claimedBy` fälschen;
+für v1 nur Shape-Validierung, optional später Admin-only-Restriktion via `diff()`.
+
+### 2.7 Web-UI
+
+| Komponente (neu/geändert) | Aufgabe |
+|---|---|
+| `src/lib/types.ts` | `AgentSession`, Todo-Felder |
+| `src/lib/firebase/firebaseUtils.ts` | `attachTodoToSession(spaceId,todoId,sessionId,uid)`, `detachTodoSession(...)`, `setTodoAidoTurn(...,'aido',uid)` („zurück an aido"); je `modifiedBy=uid` |
+| `src/lib/firebase/firebaseUtils.ts` | `subscribeAgentSessionsForSpace(uid,spaceId,cb)`, `renameSession`, `deleteSession`, `setSessionConfig(allowedTools,leaseTtlSeconds)` |
+| `src/lib/contexts/TodosContext.tsx` | `attachToSession`, `detach`, `returnToAido` ergänzen |
+| `src/components/shell/AttachToSessionMenu.tsx` (neu) | Picker (analog `MoveToSpaceMenu`), zeigt Sessions des **aktiven Space** |
+| `src/components/shell/list/TodoActions.tsx` | Einträge „An Agent-Session anhängen…", „Lösen", „Zurück an aido" (bei `aidoTurn=='user'`) |
+| `src/components/shell/board/{TodoCard,BoardView}.tsx` | Attach-Eintrag + Status-Badge |
+| `src/components/shell/StatusBadge` (neu, klein) | leitet Badge `bei aido`/`in Arbeit`/`bei dir` aus Todo-Feldern + Lease ab |
+| `src/components/AgentSessionsSettings.tsx` (neu) | in `UserSettings` neben `ApiKeySettings`; **klar von `SessionSettings` (Geräte) getrennt**; Liste, Umbenennen, Entfernen, `allowedTools`/`leaseTtlSeconds` |
+| `src/components/UserSettings.tsx` | `agentSessionDefaults.leaseTtlSeconds` lesen/schreiben |
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `types.ts` + `firestore.rules` + `tests/firestore-rules.test.mjs` | Felder, `AgentSession`, Sessions-Regel, Shape-Checks + Tests | Mittel |
+| `src/lib/tiptap/markdown.ts` (+ `markdown-it` dep) | Markdown↔Tiptap, `appendAnswer`, Inline-Code→Codeblock, Link-Härtung | Mittel–Groß |
+| `src/lib/mcp/data.ts` | `registerSession`, `nextTodo` (Claim/Lease-Txn), `updateTodo`, `handoffTodo`, `completeTodo(sessionId?)`; `TodoView`/Body | Groß |
+| `src/lib/mcp/tool-logic.ts` + `route.ts` | Handler, Zod-Schemas, Tool-Registrierung, Allowlist-Enforcement | Mittel |
+| `tests/mcp-tools.test.mts` | Claim/Lease, Allowlist, Scope, `update-todo`-Modi, Konvertierung | Mittel–Groß |
+| `firebaseUtils.ts` + `TodosContext.tsx` | Attach/Detach/Return-Helfer + Sessions-Abo | Mittel |
+| Liste/Board-UI + `AttachToSessionMenu` + `StatusBadge` | Attach-Aktionen + Badges | Mittel |
+| `AgentSessionsSettings.tsx` + `UserSettings.tsx` | Sessions-Panel + Lease-TTL-Default | Mittel |
+| `CLAUDE.md`/`README`/`.env.example` | Tool-Liste, `/loop`-Setup, Benennung | Klein |
+
+### 3.2 Reihenfolge (issue-fähig geschnitten)
+
+1. **Datenmodell + Regeln + Rules-Tests** (Felder, `AgentSession`, Sessions-Collection). *Fundament.*
+2. **Markdown↔Tiptap-Modul** (+ Unit-Tests). *Unabhängig, parallel zu 1.*
+3. **MCP-Datenzugriff** (`registerSession`, `nextTodo`-Claim/Lease, `updateTodo`, `handoff`,
+   `completeTodo(sessionId?)`, Body in `TodoView`). *Abh.: 1, 2.*
+4. **MCP-Tools/Dispatch** (Zod, `route.ts`, Allowlist) + **MCP-Tool-Tests**. *Abh.: 3.*
+5. **Client-Schreibhelfer + `TodosContext` + Sessions-Abo.** *Abh.: 1.*
+6. **Liste/Board-UI** (Attach-Menü, „zurück an aido", Status-Badges). *Abh.: 5.*
+7. **Agent-Sessions-Settings-Panel + Lease-TTL-Default.** *Abh.: 5.*
+8. **Doku** (`CLAUDE.md`/`README`/`.env`, `/loop`-Anleitung). *Abschluss.*
+
+Schritte 1–4 liefern den **MVP-Loop end-to-end** (über MCP testbar); 5–7 die Web-UX.
+
+→ Als **Epic** mit Sub-Issues anlegen (CLAUDE.md „Spec → Issues"), Deploy-Reihenfolge wie oben.
+
+## 4. Testplan
+
+- **Rules-Tests** (`firestore-rules.test.mjs`): `users/{uid}/sessions` owner-only; gültige/ungültige
+  `aidoTurn`/`claimedBy`/`claimedAt`-Shapes; Member darf `attachedSession`/`aidoTurn` setzen;
+  `modifiedBy`-Pflicht bleibt.
+- **MCP-Tool-Tests** (`mcp-tools.test.mts`, Emulator): `register-session` deterministische id +
+  Upsert + Member-Gate; `next-todo` liefert ältestes, claimt, zweiter Aufruf → nächstes; Self-Claim
+  idempotent; Lease-Ablauf reclaim; kein Doppel-Claim (parallele Txn-Simulation); `update-todo`
+  append/replace + Markdown→Codeblock + Tags-Rederivation + **Scope-Reject** (nicht geclaimt) +
+  **Allowlist-Reject**; `handoff` setzt `aidoTurn='user'` + löst Claim; `complete-todo` mit
+  `sessionId` Allowlist-gegated.
+- **Markdown-Modul-Tests:** Überschriften/Listen/Codeblock/Links (safe & unsafe)/Inline-Code→Codeblock;
+  `tiptapToMarkdown` Grund-Roundtrip; `appendAnswer` erhält Original + Marker.
+- **Manuell:** echte Claude-Code-Session: `register-session` → UI-Attach → `/loop` mit `next-todo`/
+  `update-todo`/`handoff` → Badge-Wechsel + formatierter Body in der Web-UI.
+
+## 5. Migration / Deployment
+
+- **Keine Datenmigration** (Felder optional/`null`, kein Backfill).
+- **Kein neuer Index** (In-memory-Filter in `nextTodo`); `firestore.indexes.json` nur anlegen, falls
+  später ein Composite-Index gewünscht ist.
+- **Deploy-Reihenfolge:** App zuerst (Vercel, enthält den MCP-Endpoint), dann
+  `npx -y firebase-tools@13 deploy --only firestore:rules` (Sessions-Regel + Feld-Shapes; alte
+  Clients verletzen nichts, da Felder optional).
+- **Keine neuen Env-Variablen** — Sessions laufen über den vorhandenen Personal-API-Key.
+- **Neue Dependency:** `markdown-it` (+ Types) in `package.json`.
+
+## 6. Referenzen
+
+- [Konzept](01-konzept-aido-sessions.md)
+- [Ist-Analyse](02-ist-analyse-aido-sessions.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-aido-sessions.md)


### PR DESCRIPTION
Vier Dokumente unter `docs/` für das Feature **„Todos an eine Claude-Code-(Agent-)Session binden und abarbeiten lassen"**:

- `01-konzept-aido-sessions.md`
- `02-ist-analyse-aido-sessions.md`
- `03-anforderungsanalyse-aido-sessions.md`
- `04-spezifikation-aido-sessions.md`

Erstellt über den `concept-analysis-spec`-Flow. Reine Dokumentation (kein App-Code) → kann sofort gemergt werden (CLAUDE.md). Die Sub-Issues des zugehörigen Epics referenzieren diese Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)