### PR TITLE
feat(model): Agent-Session-Datenmodell + Firestore-Regeln + Rules-Tests

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -146,7 +146,26 @@ service cloud.firestore {
               && request.resource.data.spaceId == spaceId
               && (!('body' in request.resource.data)
                   || request.resource.data.body == null
-                  || request.resource.data.body is map);
+                  || request.resource.data.body is map)
+              // Agent-Sessions (issue #213, epic #212): binding + turn + claim/
+              // lease fields. The MCP server sets claimedBy/claimedAt/lastAidoEditAt
+              // via the Admin SDK (past these rules); the shape-checks here keep a
+              // later client merge-update (which re-validates the full doc) valid.
+              && (!('attachedSession' in request.resource.data)
+                  || request.resource.data.attachedSession == null
+                  || request.resource.data.attachedSession is string)
+              && (!('aidoTurn' in request.resource.data)
+                  || request.resource.data.aidoTurn == null
+                  || request.resource.data.aidoTurn in ['aido', 'user'])
+              && (!('claimedBy' in request.resource.data)
+                  || request.resource.data.claimedBy == null
+                  || request.resource.data.claimedBy is string)
+              && (!('claimedAt' in request.resource.data)
+                  || request.resource.data.claimedAt == null
+                  || request.resource.data.claimedAt is timestamp)
+              && (!('lastAidoEditAt' in request.resource.data)
+                  || request.resource.data.lastAidoEditAt == null
+                  || request.resource.data.lastAidoEditAt is timestamp);
         }
 
         allow read: if isMemberOfThisSpace();
@@ -200,6 +219,14 @@ service cloud.firestore {
       // Owner-only: contains PII (email, timezone, notification settings)
       allow read: if isOwner(userId);
       allow write: if isOwner(userId); // Owner can write their own user doc
+
+      // Agent-Sessions (issue #213, epic #212): a running Claude-Code session
+      // bound to one space. Owner-only — the owner reads them for the attach
+      // picker and edits label/allowedTools/leaseTtlSeconds in settings; the MCP
+      // server writes them via the Admin SDK (which bypasses these rules).
+      match /sessions/{sessionId} {
+        allow read, write, delete: if isOwner(userId);
+      }
 
       // Reads on todos are governed solely by the collection group rule below
       // (/{path=**}/todos/{todoId}) — it also matches direct document reads.

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -176,6 +176,14 @@ const mapTodo = (d: QueryDocumentSnapshot<DocumentData>): Todo => {
           : "",
     createdAt: data.createdAt ?? null,
     order: typeof data.order === "number" ? data.order : 0,
+    // Agent-Sessions (epic #212): absent on todos that were never bound.
+    attachedSession:
+      typeof data.attachedSession === "string" ? data.attachedSession : null,
+    aidoTurn:
+      data.aidoTurn === "aido" || data.aidoTurn === "user" ? data.aidoTurn : null,
+    claimedBy: typeof data.claimedBy === "string" ? data.claimedBy : null,
+    claimedAt: data.claimedAt ?? null,
+    lastAidoEditAt: data.lastAidoEditAt ?? null,
   };
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,23 @@ export interface Todo {
    * so it is set once and not mutated afterwards.
    */
   order: number;
+  /**
+   * Agent-Sessions (epic #212): the Claude-Code session this todo is bound to
+   * (a sessionId under `users/{uid}/sessions`), or null. Set/cleared only via
+   * the web UI; the MCP session tools never change the binding.
+   */
+  attachedSession: string | null;
+  /**
+   * Whose turn it is while attached: `aido` = queued for the session to pick up,
+   * `user` = the session handed it back (still open). null when not attached.
+   */
+  aidoTurn: "aido" | "user" | null;
+  /** sessionId currently holding the claim (`next-todo`), or null. */
+  claimedBy: string | null;
+  /** When the claim was taken; basis for the lease (see `leaseTtlSeconds`). */
+  claimedAt: Timestamp | null;
+  /** Last time a session wrote the body — drives the "von aido" marker. */
+  lastAidoEditAt: Timestamp | null;
 }
 
 /**
@@ -74,4 +91,31 @@ export interface Daily {
   /** userId of the author; immutable after creation. */
   author: string;
   createdAt: Timestamp | null;
+}
+
+/** Tool actions a session may perform; enforced server-side by the MCP layer. */
+export type AgentToolName = "update-todo" | "handoff" | "complete-todo";
+
+/**
+ * Agent-Session (epic #212) — a running Claude-Code session bound to ONE space,
+ * stored owner-only at `users/{uid}/sessions/{sessionId}` (the id is derived
+ * deterministically from spaceId+hostname+workingFolder). Deliberately named
+ * "Agent-Session" to avoid confusion with the device-/login sessions.
+ */
+export interface AgentSession {
+  /** Firestore document id = sha256(spaceId|hostname|workingFolder). */
+  id: string;
+  /** The single space this session works in. */
+  spaceId: string;
+  hostname: string;
+  workingFolder: string;
+  /** Optional human label shown in the attach picker. */
+  label: string | null;
+  /** Actions this session may perform; default `['update-todo','handoff']`. */
+  allowedTools: AgentToolName[];
+  /** Claim lease in seconds; default from the user's `agentSessionDefaults`. */
+  leaseTtlSeconds: number;
+  createdAt: Timestamp | null;
+  /** Heartbeat: refreshed by `register-session` and `next-todo`. */
+  lastSeenAt: Timestamp | null;
 }

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -484,6 +484,45 @@ await check('user may not query deviceLoginCodes', assertFails(
   getDocs(query(collection(db(ALICE), 'deviceLoginCodes'),
     where('userCode', '==', 'WDJBMJHT')))));
 
+console.log('Agent-Sessions collection (issue #213, epic #212):');
+const SESSION_PATH = `users/${ALICE}/sessions/sess-1`;
+const seedSession = {
+  spaceId: TS, hostname: 'macbook', workingFolder: '/home/alice/proj',
+  label: null, allowedTools: ['update-todo', 'handoff'], leaseTtlSeconds: 600,
+};
+await check('owner may create their own agent session', assertSucceeds(
+  setDoc(doc(db(ALICE), SESSION_PATH), seedSession)));
+await check('owner may read their own agent session', assertSucceeds(
+  getDoc(doc(db(ALICE), SESSION_PATH))));
+await check('owner may edit session config (label/leaseTtlSeconds)', assertSucceeds(
+  updateDoc(doc(db(ALICE), SESSION_PATH), { label: 'Laptop', leaseTtlSeconds: 1200 })));
+await check('other user may not read a foreign agent session', assertFails(
+  getDoc(doc(db(BOB), SESSION_PATH))));
+await check('other user may not create a foreign agent session', assertFails(
+  setDoc(doc(db(BOB), `users/${ALICE}/sessions/sess-x`), seedSession)));
+await check('owner may delete their own agent session', assertSucceeds(
+  deleteDoc(doc(db(ALICE), SESSION_PATH))));
+
+console.log('Agent-Session todo fields (issue #213, epic #212):');
+await resetSpaceTodos();
+await check('member may bind a todo to a session (attachedSession + aidoTurn)', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO2_PATH), {
+    attachedSession: 'sess-1', aidoTurn: 'aido', modifiedBy: ALICE })));
+await check('member may set claim fields (claimedBy + claimedAt timestamp)', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO2_PATH), {
+    claimedBy: 'sess-1', claimedAt: new Date(), modifiedBy: ALICE })));
+await check('member may clear the binding (nulls)', assertSucceeds(
+  updateDoc(doc(db(ALICE), TODO2_PATH), {
+    attachedSession: null, aidoTurn: null, claimedBy: null, claimedAt: null, modifiedBy: ALICE })));
+await check('member may not set an invalid aidoTurn', assertFails(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { aidoTurn: 'maybe', modifiedBy: ALICE })));
+await check('member may not set a non-string attachedSession', assertFails(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { attachedSession: 42, modifiedBy: ALICE })));
+await check('member may not set a non-string claimedBy', assertFails(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { claimedBy: 42, modifiedBy: ALICE })));
+await check('member may not set a non-timestamp claimedAt', assertFails(
+  updateDoc(doc(db(ALICE), TODO2_PATH), { claimedAt: 'soon', modifiedBy: ALICE })));
+
 await testEnv.cleanup();
 
 if (failures > 0) {


### PR DESCRIPTION
Teil von Epic #212 · **Closes #213** (Schritt 1/8, Fundament).

### Änderungen
- `src/lib/types.ts`: `AgentSession`/`AgentToolName`; `Todo` um `attachedSession`, `aidoTurn`, `claimedBy`, `claimedAt`, `lastAidoEditAt`.
- `src/lib/firebase/firebaseUtils.ts`: `mapTodo` liest die neuen Felder (null-Defaults) → `tsc` bleibt grün.
- `firestore.rules`: `users/{uid}/sessions/{sessionId}` **owner-only**; Shape-Checks der neuen Todo-Felder (create **und** update, merge-fest).
- `tests/firestore-rules.test.mjs`: Sessions owner-only + Feld-Validierung (gültig/ungültig).

### Verifikation
- `npx tsc --noEmit`: grün (nur stale `.next/types`).
- `firebase-tools@13 emulators:exec … firestore-rules.test.mjs`: **All rules tests passed** (inkl. neuer Agent-Session-Fälle) + Storage-Rules grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)