### PR TITLE
feat(tiptap): serverfähiges Markdown↔Tiptap-Modul (markdown.ts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "firebase-admin": "^13.10.0",
         "framer-motion": "^11.3.31",
         "lucide-react": "^0.436.0",
+        "markdown-it": "^14.2.0",
         "mcp-handler": "^1.1.0",
         "next": "^15.5.19",
         "node-mocks-http": "^1.17.2",
@@ -45,6 +46,7 @@
       "devDependencies": {
         "@firebase/rules-unit-testing": "^5.0.1",
         "@playwright/cli": "^0.1.13",
+        "@types/markdown-it": "^14.1.2",
         "@types/qrcode": "^1.5.6",
         "eslint": "8.57.0",
         "eslint-config-next": "^15.5.19",
@@ -3083,6 +3085,7 @@
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:mcp": "firebase emulators:exec --only firestore --project demo-mcp \"node --conditions=react-server --import tsx tests/mcp-tools.test.mts\"",
     "test:oauth": "firebase emulators:exec --only firestore,auth --project demo-oauth \"node --conditions=react-server --import tsx tests/oauth.test.mts\"",
     "test:device-login": "firebase emulators:exec --only firestore,auth --project demo-device-login \"node --conditions=react-server --import tsx tests/device-login.test.mts\"",
-    "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs"
+    "migrate:legacy": "node scripts/migrate-legacy-todos-admin.mjs",
+    "test:markdown": "node --import tsx tests/markdown.test.mts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -39,6 +40,7 @@
     "firebase-admin": "^13.10.0",
     "framer-motion": "^11.3.31",
     "lucide-react": "^0.436.0",
+    "markdown-it": "^14.2.0",
     "mcp-handler": "^1.1.0",
     "next": "^15.5.19",
     "node-mocks-http": "^1.17.2",
@@ -55,6 +57,7 @@
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",
     "@playwright/cli": "^0.1.13",
+    "@types/markdown-it": "^14.1.2",
     "@types/qrcode": "^1.5.6",
     "eslint": "8.57.0",
     "eslint-config-next": "^15.5.19",

--- a/src/lib/tiptap/markdown.ts
+++ b/src/lib/tiptap/markdown.ts
@@ -1,0 +1,332 @@
+// Server-safe Markdown <-> Tiptap conversion (issue #214, epic #212).
+//
+// The MCP session tools let Claude read a todo body as Markdown and write one
+// back. The web editor stores Tiptap/ProseMirror JSON, so we convert in both
+// directions WITHOUT pulling in `@tiptap/react` / the DOM (`useTiptapConfig` is
+// a client hook). This module is pure and runs in the Admin/server context.
+//
+// It emits ONLY the node/mark types the editor registers (see useTiptapConfig):
+// doc, paragraph, heading, bulletList, orderedList, listItem, codeBlock,
+// blockquote; marks bold, italic, strike, link, highlight. There is no inline
+// `code` mark in the editor, so inline code is promoted to its own codeBlock
+// (the surrounding paragraph is split). Links are filtered through linkSecurity.
+
+import MarkdownIt from "markdown-it";
+import { isSafeLinkUrl } from "./linkSecurity";
+import type { TiptapContent } from "../types";
+
+const md = new MarkdownIt({ html: false, linkify: false, breaks: false });
+
+// --- Minimal shapes (avoids importing markdown-it's Token type name) ---
+
+interface MdToken {
+  type: string;
+  tag: string;
+  nesting: number;
+  content: string;
+  info: string;
+  children: MdToken[] | null;
+  attrGet(name: string): string | null;
+}
+
+type Mark = { type: string; attrs?: Record<string, unknown> };
+type PMNode = {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: PMNode[];
+  text?: string;
+  marks?: Mark[];
+};
+
+// Index of the token that closes the open token at `openIdx`, by balancing
+// nesting (+1 open / -1 close; self-closing tokens are 0 and don't shift depth).
+function matchingClose(tokens: MdToken[], openIdx: number): number {
+  let depth = 0;
+  for (let i = openIdx; i < tokens.length; i++) {
+    depth += tokens[i].nesting;
+    if (depth === 0) return i;
+  }
+  return tokens.length - 1;
+}
+
+function uniqueMarks(stack: Mark[]): Mark[] | undefined {
+  const real = stack.filter((m) => !m.type.startsWith("__"));
+  if (!real.length) return undefined;
+  // Keep the last occurrence of each mark type (links carry attrs).
+  const byType = new Map<string, Mark>();
+  for (const m of real) byType.set(m.type, m);
+  return [...byType.values()].map((m) => ({ ...m }));
+}
+
+function textNode(text: string, stack: Mark[]): PMNode {
+  const node: PMNode = { type: "text", text };
+  const marks = uniqueMarks(stack);
+  if (marks) node.marks = marks;
+  return node;
+}
+
+function codeBlockNode(content: string, language: string | null): PMNode {
+  const node: PMNode = { type: "codeBlock" };
+  if (language) node.attrs = { language };
+  const text = content.replace(/\n+$/, "");
+  node.content = text ? [{ type: "text", text }] : [];
+  return node;
+}
+
+// Inline emphasis/link tokens from markdown-it are strictly nested, so a simple
+// push/pop stack reconstructs the active marks. (code_inline is handled by the
+// callers, since it may turn into a block-level codeBlock.)
+function handleInlineToken(c: MdToken, out: PMNode[], stack: Mark[]): void {
+  switch (c.type) {
+    case "text":
+      if (c.content) out.push(textNode(c.content, stack));
+      return;
+    case "softbreak":
+    case "hardbreak":
+      // hardBreak is disabled in the editor — collapse to a space.
+      out.push(textNode(" ", stack));
+      return;
+    case "strong_open":
+      stack.push({ type: "bold" });
+      return;
+    case "em_open":
+      stack.push({ type: "italic" });
+      return;
+    case "s_open":
+      stack.push({ type: "strike" });
+      return;
+    case "link_open": {
+      const href = c.attrGet("href");
+      stack.push(href && isSafeLinkUrl(href) ? { type: "link", attrs: { href } } : { type: "__skip__" });
+      return;
+    }
+    case "strong_close":
+    case "em_close":
+    case "s_close":
+    case "link_close":
+      stack.pop();
+      return;
+    default:
+      return; // image, html_inline, … dropped
+  }
+}
+
+// Inline content where code_inline degrades to plain text (used for headings,
+// which cannot contain a codeBlock).
+function inlineToContent(children: MdToken[] | null): PMNode[] {
+  const out: PMNode[] = [];
+  const stack: Mark[] = [];
+  for (const c of children ?? []) {
+    if (c.type === "code_inline") {
+      if (c.content) out.push(textNode(c.content, stack));
+      continue;
+    }
+    handleInlineToken(c, out, stack);
+  }
+  return out;
+}
+
+// Inline content for a paragraph: code_inline is promoted to its own codeBlock,
+// splitting the paragraph at that point (issue #214 decision).
+function inlineToBlocks(children: MdToken[] | null): PMNode[] {
+  const blocks: PMNode[] = [];
+  let buf: PMNode[] = [];
+  const stack: Mark[] = [];
+  const flush = () => {
+    if (buf.length) {
+      blocks.push({ type: "paragraph", content: buf });
+      buf = [];
+    }
+  };
+  for (const c of children ?? []) {
+    if (c.type === "code_inline") {
+      flush();
+      blocks.push(codeBlockNode(c.content, null));
+      continue;
+    }
+    handleInlineToken(c, buf, stack);
+  }
+  flush();
+  return blocks;
+}
+
+function listItemsToNodes(tokens: MdToken[]): PMNode[] {
+  const items: PMNode[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    if (tokens[i].type === "list_item_open") {
+      const close = matchingClose(tokens, i);
+      let content = blockTokensToNodes(tokens.slice(i + 1, close));
+      if (!content.length) content = [{ type: "paragraph" }];
+      items.push({ type: "listItem", content });
+      i = close + 1;
+    } else {
+      i += 1;
+    }
+  }
+  return items;
+}
+
+function blockTokensToNodes(tokens: MdToken[]): PMNode[] {
+  const nodes: PMNode[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    switch (t.type) {
+      case "paragraph_open": {
+        const inline = tokens[i + 1];
+        const blocks = inline && inline.type === "inline" ? inlineToBlocks(inline.children) : [];
+        for (const b of blocks) nodes.push(b);
+        i = matchingClose(tokens, i) + 1;
+        break;
+      }
+      case "heading_open": {
+        const level = Math.min(6, Math.max(1, Number(t.tag.replace("h", "")) || 1));
+        const inline = tokens[i + 1];
+        const content = inline && inline.type === "inline" ? inlineToContent(inline.children) : [];
+        nodes.push({ type: "heading", attrs: { level }, content });
+        i = matchingClose(tokens, i) + 1;
+        break;
+      }
+      case "fence":
+      case "code_block": {
+        const lang = t.type === "fence" ? (t.info || "").trim().split(/\s+/)[0] || null : null;
+        nodes.push(codeBlockNode(t.content, lang));
+        i += 1;
+        break;
+      }
+      case "bullet_list_open":
+      case "ordered_list_open": {
+        const close = matchingClose(tokens, i);
+        const items = listItemsToNodes(tokens.slice(i + 1, close));
+        nodes.push({
+          type: t.type === "bullet_list_open" ? "bulletList" : "orderedList",
+          content: items,
+        });
+        i = close + 1;
+        break;
+      }
+      case "blockquote_open": {
+        const close = matchingClose(tokens, i);
+        nodes.push({ type: "blockquote", content: blockTokensToNodes(tokens.slice(i + 1, close)) });
+        i = close + 1;
+        break;
+      }
+      default:
+        // horizontalRule (disabled), html_block, … are dropped.
+        i += 1;
+    }
+  }
+  return nodes;
+}
+
+/**
+ * Parse Markdown into a Tiptap document, or null when empty. Only the editor's
+ * registered node/mark types are produced; inline code becomes a codeBlock and
+ * unsafe link URLs are stripped to plain text.
+ */
+export function markdownToTiptap(input: string | null | undefined): TiptapContent | null {
+  const src = (input ?? "").replace(/\r\n/g, "\n").trim();
+  if (!src) return null;
+  const tokens = md.parse(src, {}) as unknown as MdToken[];
+  const content = blockTokensToNodes(tokens);
+  if (!content.length) return null;
+  return { type: "doc", content } as TiptapContent;
+}
+
+// --- Tiptap -> Markdown (for reading a body back to the agent) ---
+
+function applyMarks(text: string, marks: Mark[] | undefined): string {
+  if (!marks?.length) return text;
+  let s = text;
+  for (const m of marks) {
+    if (m.type === "bold") s = `**${s}**`;
+    else if (m.type === "italic") s = `*${s}*`;
+    else if (m.type === "strike") s = `~~${s}~~`;
+    else if (m.type === "link") s = `[${s}](${String(m.attrs?.href ?? "")})`;
+  }
+  return s;
+}
+
+function inlineToMd(content: PMNode[] | undefined): string {
+  if (!content?.length) return "";
+  return content
+    .map((n) => {
+      if (n.type === "text") return applyMarks(n.text ?? "", n.marks);
+      if (n.type === "mention") return `@${String(n.attrs?.label ?? n.attrs?.id ?? "")}`;
+      if (n.type === "hardBreak") return " ";
+      return "";
+    })
+    .join("");
+}
+
+function codeText(node: PMNode): string {
+  return (node.content ?? []).map((c) => c.text ?? "").join("");
+}
+
+function blockToMd(node: PMNode): string {
+  switch (node.type) {
+    case "paragraph":
+      return inlineToMd(node.content);
+    case "heading": {
+      const level = Math.min(6, Math.max(1, Number(node.attrs?.level ?? 1)));
+      return `${"#".repeat(level)} ${inlineToMd(node.content)}`;
+    }
+    case "codeBlock": {
+      const lang = node.attrs?.language ? String(node.attrs.language) : "";
+      return `\`\`\`${lang}\n${codeText(node)}\n\`\`\``;
+    }
+    case "bulletList":
+      return (node.content ?? [])
+        .map((li) => `- ${inlineToMd((li.content ?? [])[0]?.content)}`)
+        .join("\n");
+    case "orderedList":
+      return (node.content ?? [])
+        .map((li, idx) => `${idx + 1}. ${inlineToMd((li.content ?? [])[0]?.content)}`)
+        .join("\n");
+    case "blockquote":
+      return (node.content ?? [])
+        .map((b) => `> ${blockToMd(b)}`)
+        .join("\n");
+    default:
+      return "";
+  }
+}
+
+/** Serialize a Tiptap document to Markdown (best-effort, for the agent to read). */
+export function tiptapToMarkdown(doc: TiptapContent | null | undefined): string {
+  const d = doc as PMNode | null | undefined;
+  if (!d || !Array.isArray(d.content)) return "";
+  return d.content
+    .map((n) => blockToMd(n))
+    .filter((s) => s !== "")
+    .join("\n\n")
+    .trim();
+}
+
+function formatStamp(at: Date | undefined): string {
+  if (!(at instanceof Date) || Number.isNaN(at.getTime())) return "";
+  return at.toISOString().slice(0, 16).replace("T", " ");
+}
+
+/**
+ * Append an answer (Markdown) to an existing body, preserving the original and
+ * prefixing a "von aido" marker block. Used by update-todo in append mode.
+ */
+export function appendAnswer(
+  existing: TiptapContent | null | undefined,
+  answerMarkdown: string,
+  opts: { at?: Date; label?: string } = {}
+): TiptapContent {
+  const answer = markdownToTiptap(answerMarkdown);
+  const answerBlocks = (answer as PMNode | null)?.content ?? [];
+  const stamp = formatStamp(opts.at);
+  const label = opts.label ?? "Antwort von aido";
+  const marker: PMNode = {
+    type: "paragraph",
+    content: [{ type: "text", text: `💬 ${label}${stamp ? ` · ${stamp}` : ""}`, marks: [{ type: "bold" }] }],
+  };
+  const base = (existing as PMNode | null)?.content ?? [];
+  const content = [...base, marker, ...answerBlocks];
+  return { type: "doc", content: content.length ? content : [{ type: "paragraph" }] } as TiptapContent;
+}

--- a/tests/markdown.test.mts
+++ b/tests/markdown.test.mts
@@ -1,0 +1,165 @@
+// Unit tests for the Markdown <-> Tiptap module (issue #214, epic #212).
+// Run via: npm run test:markdown  (no emulator needed)
+import { markdownToTiptap, tiptapToMarkdown, appendAnswer } from "../src/lib/tiptap/markdown";
+
+let failures = 0;
+function check(name: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${(e as Error).message}`);
+  }
+}
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(msg);
+}
+
+type N = { type: string; attrs?: Record<string, unknown>; content?: N[]; text?: string; marks?: { type: string; attrs?: Record<string, unknown> }[] };
+
+function findNode(node: N | null | undefined, type: string): N | null {
+  if (!node) return null;
+  if (node.type === type) return node;
+  for (const c of node.content ?? []) {
+    const r = findNode(c, type);
+    if (r) return r;
+  }
+  return null;
+}
+function collectTypes(node: N | null | undefined, nodeTypes: Set<string>, markTypes: Set<string>): void {
+  if (!node) return;
+  nodeTypes.add(node.type);
+  for (const m of node.marks ?? []) markTypes.add(m.type);
+  for (const c of node.content ?? []) collectTypes(c, nodeTypes, markTypes);
+}
+function allText(node: N | null | undefined): string {
+  if (!node) return "";
+  if (node.type === "text") return node.text ?? "";
+  return (node.content ?? []).map(allText).join("");
+}
+
+const ALLOWED_NODES = new Set([
+  "doc", "paragraph", "heading", "bulletList", "orderedList", "listItem", "codeBlock", "blockquote", "text",
+]);
+const ALLOWED_MARKS = new Set(["bold", "italic", "strike", "link", "highlight"]);
+
+console.log("markdownToTiptap:");
+
+check("heading with level", () => {
+  const doc = markdownToTiptap("# Title") as N;
+  const h = findNode(doc, "heading");
+  assert(h, "no heading");
+  assert(h!.attrs?.level === 1, `level was ${h!.attrs?.level}`);
+  assert(allText(h) === "Title", `text was '${allText(h)}'`);
+});
+
+check("bold / italic / strike marks", () => {
+  const doc = markdownToTiptap("**b** *i* ~~s~~") as N;
+  const marks = new Set<string>();
+  collectTypes(doc, new Set(), marks);
+  assert(marks.has("bold") && marks.has("italic") && marks.has("strike"), `marks: ${[...marks]}`);
+});
+
+check("fenced code block keeps language + content", () => {
+  const doc = markdownToTiptap("```ts\nconst x = 1\n```") as N;
+  const cb = findNode(doc, "codeBlock");
+  assert(cb, "no codeBlock");
+  assert(cb!.attrs?.language === "ts", `language was ${cb!.attrs?.language}`);
+  assert(allText(cb) === "const x = 1", `code was '${allText(cb)}'`);
+});
+
+check("inline code is promoted to a codeBlock", () => {
+  const doc = markdownToTiptap("Run `npm run build` first") as N;
+  const cb = findNode(doc, "codeBlock");
+  assert(cb, "inline code did not become a codeBlock");
+  assert(allText(cb) === "npm run build", `code was '${allText(cb)}'`);
+  // The surrounding prose survives as paragraphs.
+  assert(allText(doc).includes("Run"), "lost surrounding text");
+});
+
+check("bullet + ordered lists", () => {
+  const b = markdownToTiptap("- a\n- b") as N;
+  const bl = findNode(b, "bulletList");
+  assert(bl && (bl.content ?? []).length === 2, "bulletList should have 2 items");
+  const o = markdownToTiptap("1. a\n2. b") as N;
+  const ol = findNode(o, "orderedList");
+  assert(ol && (ol.content ?? []).length === 2, "orderedList should have 2 items");
+});
+
+check("safe link becomes a link mark", () => {
+  const doc = markdownToTiptap("[x](https://example.com)") as N;
+  const txt = findNode(doc, "text");
+  const link = txt?.marks?.find((m) => m.type === "link");
+  assert(link, "no link mark");
+  assert(link!.attrs?.href === "https://example.com", `href was ${link!.attrs?.href}`);
+});
+
+check("unsafe link is stripped to plain text", () => {
+  const doc = markdownToTiptap("[x](javascript:alert(1))") as N;
+  const marks = new Set<string>();
+  collectTypes(doc, new Set(), marks);
+  assert(!marks.has("link"), "javascript: link must not produce a link mark");
+  assert(allText(doc).includes("x"), "link text should survive");
+});
+
+check("blockquote", () => {
+  const doc = markdownToTiptap("> quote") as N;
+  assert(findNode(doc, "blockquote"), "no blockquote");
+});
+
+check("empty input -> null", () => {
+  assert(markdownToTiptap("") === null, "empty should be null");
+  assert(markdownToTiptap("   \n  ") === null, "whitespace should be null");
+});
+
+check("only allowed node/mark types are emitted", () => {
+  const doc = markdownToTiptap(
+    "# H\n\ntext **b** [l](https://e.com) `c`\n\n- one\n- two\n\n> q\n\n```js\nx\n```"
+  ) as N;
+  const nodes = new Set<string>();
+  const marks = new Set<string>();
+  collectTypes(doc, nodes, marks);
+  for (const t of nodes) assert(ALLOWED_NODES.has(t), `disallowed node type: ${t}`);
+  for (const t of marks) assert(ALLOWED_MARKS.has(t), `disallowed mark type: ${t}`);
+});
+
+console.log("tiptapToMarkdown:");
+
+check("round-trips headings and bold", () => {
+  const doc = markdownToTiptap("# H\n\nsome **b** text");
+  const out = tiptapToMarkdown(doc);
+  assert(out.includes("# H"), `missing heading: ${out}`);
+  assert(out.includes("**b**"), `missing bold: ${out}`);
+});
+
+check("serializes a code block fence", () => {
+  const doc = markdownToTiptap("```ts\nconst x = 1\n```");
+  const out = tiptapToMarkdown(doc);
+  assert(out.includes("```ts") && out.includes("const x = 1"), `bad fence: ${out}`);
+});
+
+console.log("appendAnswer:");
+
+check("preserves original, adds marker + answer", () => {
+  const existing = markdownToTiptap("Was ist 2+2?");
+  const result = appendAnswer(existing, "Die Antwort ist `4`.", { at: new Date("2026-06-21T10:00:00Z") }) as N;
+  const text = allText(result);
+  assert(text.includes("Was ist 2+2?"), "lost the original question");
+  assert(text.includes("Antwort von aido"), "missing aido marker");
+  // The answer's inline code became a codeBlock containing "4".
+  const cbs = (result.content ?? []).filter((n) => n.type === "codeBlock");
+  assert(cbs.some((cb) => allText(cb) === "4"), "answer code block missing");
+});
+
+check("append onto an empty body still works", () => {
+  const result = appendAnswer(null, "Hallo", {}) as N;
+  assert(allText(result).includes("Hallo"), "answer missing");
+  assert(allText(result).includes("Antwort von aido"), "marker missing");
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} markdown test(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll markdown tests passed");


### PR DESCRIPTION
Teil von Epic #212 · **Closes #214** (Schritt 2/8). Unabhängig von #213.

### Änderungen
- Neu `src/lib/tiptap/markdown.ts`: `markdownToTiptap`, `tiptapToMarkdown`, `appendAnswer` — `markdown-it` → ProseMirror-JSON, **nur** die in `useTiptapConfig` erlaubten Node-/Mark-Typen; **Inline-Code → eigener Codeblock**; Links über `isSafeLinkUrl`. Serverfähig (kein `@tiptap/react`/DOM).
- Dependency `markdown-it@^14` (+ `@types/markdown-it` dev).
- `tests/markdown.test.mts` + Script `test:markdown` (kein Emulator nötig).

### Verifikation
- `npm run test:markdown`: **All markdown tests passed** (14 Fälle: Überschriften/Listen/Codeblock/Links safe+unsafe/Inline-Code→Codeblock/Roundtrip/appendAnswer/Node-Allowlist).
- `npx tsc --noEmit` + `eslint`: grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)