### PR TITLE
feat(mcp): register-session/next-todo/update-todo/handoff Tools + Tests

### DIFF
--- a/src/app/api/mcp/sse/route.ts
+++ b/src/app/api/mcp/sse/route.ts
@@ -16,6 +16,10 @@ import {
   handleDeleteTodo,
   handleWhoami,
   handleListMembers,
+  handleRegisterSession,
+  handleNextTodo,
+  handleUpdateTodo,
+  handleHandoff,
   errorResult,
 } from "@/lib/mcp/tool-logic";
 
@@ -70,8 +74,13 @@ const mcpHandler = createMcpHandler(
     );
     server.tool(
       "complete-todo",
-      "Marks a todo complete or open again.",
-      { spaceId: z.string().min(1), todoId: z.string().min(1), completed: z.boolean() },
+      "Marks a todo complete or open again. Pass sessionId when completing the todo your agent session has claimed (requires the 'complete-todo' allowlist entry).",
+      {
+        spaceId: z.string().min(1),
+        todoId: z.string().min(1),
+        completed: z.boolean(),
+        sessionId: z.string().optional(),
+      },
       (args) => safe(() => handleCompleteTodo(args))
     );
     server.tool(
@@ -108,6 +117,43 @@ const mcpHandler = createMcpHandler(
       "Lists the members (uid + display name) of a space you belong to.",
       { spaceId: z.string().min(1) },
       (args) => safe(() => handleListMembers(args))
+    );
+    // --- Agent-Sessions (epic #212): the work loop ---
+    server.tool(
+      "register-session",
+      "Registers (or refreshes) a Claude-Code agent session bound to one space. Call this FIRST; returns a sessionId for update-todo/handoff. Default allowlist is ['update-todo','handoff'].",
+      {
+        spaceId: z.string().min(1),
+        hostname: z.string().min(1),
+        workingFolder: z.string().min(1),
+        label: z.string().optional(),
+        allowedTools: z.array(z.enum(["update-todo", "handoff", "complete-todo"])).optional(),
+      },
+      (args) => safe(() => handleRegisterSession(args))
+    );
+    server.tool(
+      "next-todo",
+      "Claims and returns the oldest open todo bound to this session (identified by hostname+workingFolder+spaceId), with its body as Markdown. Returns {todo:null} when nothing is queued.",
+      { spaceId: z.string().min(1), hostname: z.string().min(1), workingFolder: z.string().min(1) },
+      (args) => safe(() => handleNextTodo(args))
+    );
+    server.tool(
+      "update-todo",
+      "Writes the body of the todo your session currently has claimed, from Markdown (code blocks supported). mode 'append' (default) preserves the original and adds an answer block; 'replace' overwrites.",
+      {
+        sessionId: z.string().min(1),
+        spaceId: z.string().min(1),
+        todoId: z.string().min(1),
+        bodyMarkdown: z.string(),
+        mode: z.enum(["append", "replace"]).optional(),
+      },
+      (args) => safe(() => handleUpdateTodo(args))
+    );
+    server.tool(
+      "handoff",
+      "Hands the claimed todo back to the human (keeps it open) and releases the claim.",
+      { sessionId: z.string().min(1), spaceId: z.string().min(1), todoId: z.string().min(1) },
+      (args) => safe(() => handleHandoff(args))
     );
   },
   { serverInfo: { name: "aido-mcp-server", version: "0.2.0" } },

--- a/src/lib/mcp/tool-logic.ts
+++ b/src/lib/mcp/tool-logic.ts
@@ -13,6 +13,10 @@ import {
   deleteTodo,
   whoami,
   listMembers,
+  registerSession,
+  nextTodo,
+  updateTodo,
+  handoffTodo,
 } from "./data";
 
 // Firestore-backed MCP tool handlers (issue #119). Each handler resolves the
@@ -90,10 +94,11 @@ export async function handleCompleteTodo(args: {
   spaceId: string;
   todoId: string;
   completed: boolean;
+  sessionId?: string;
 }): Promise<CallToolResult> {
   const uid = requireUserUid();
   enforceWriteRateLimit(uid);
-  return jsonResult(await completeTodo(uid, args.spaceId, args.todoId, args.completed));
+  return jsonResult(await completeTodo(uid, args.spaceId, args.todoId, args.completed, args.sessionId));
 }
 
 export async function handleSetWaitingOn(args: {
@@ -140,4 +145,52 @@ export async function handleWhoami(): Promise<CallToolResult> {
 export async function handleListMembers(args: { spaceId: string }): Promise<CallToolResult> {
   const uid = requireUserUid();
   return jsonResult(await listMembers(uid, args.spaceId));
+}
+
+// --- Agent-Sessions (epic #212, issue #216) ---
+
+export async function handleRegisterSession(args: {
+  spaceId: string;
+  hostname: string;
+  workingFolder: string;
+  label?: string;
+  allowedTools?: string[];
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  return jsonResult(await registerSession(uid, args));
+}
+
+// next-todo claims a todo (a write) but is the loop's polling mechanism, so it is
+// deliberately NOT subject to the write rate limit — only the content-mutating
+// tools below are (issue #216, NFA-06).
+export async function handleNextTodo(args: {
+  spaceId: string;
+  hostname: string;
+  workingFolder: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  const todo = await nextTodo(uid, args);
+  return jsonResult({ todo });
+}
+
+export async function handleUpdateTodo(args: {
+  sessionId: string;
+  spaceId: string;
+  todoId: string;
+  bodyMarkdown: string;
+  mode?: "append" | "replace";
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await updateTodo(uid, args));
+}
+
+export async function handleHandoff(args: {
+  sessionId: string;
+  spaceId: string;
+  todoId: string;
+}): Promise<CallToolResult> {
+  const uid = requireUserUid();
+  enforceWriteRateLimit(uid);
+  return jsonResult(await handoffTodo(uid, args));
 }

--- a/tests/mcp-tools.test.mts
+++ b/tests/mcp-tools.test.mts
@@ -13,7 +13,7 @@
 // module; tsx transpiles the TS + resolves the @/* path alias from tsconfig.
 
 import { initializeApp } from "firebase-admin/app";
-import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { getFirestore, FieldValue, Timestamp } from "firebase-admin/firestore";
 
 if (!process.env.FIRESTORE_EMULATOR_HOST) {
   console.error("FIRESTORE_EMULATOR_HOST is not set — run inside emulators:exec.");
@@ -29,7 +29,7 @@ const db = getFirestore(adminApp);
 
 // Import the real tool code AFTER the app exists (functions only touch Firestore
 // when called, so import order vs. init is safe, but keep it explicit).
-const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, listDaily, addDaily, deleteTodo, whoami, listMembers, McpToolError } =
+const { requireMember, listSpacesForUid, listTodos, addTodo, completeTodo, setWaitingOn, listDaily, addDaily, deleteTodo, whoami, listMembers, registerSession, nextTodo, updateTodo, handoffTodo, McpToolError } =
   await import("../src/lib/mcp/data.ts");
 const { handleListSpaces } = await import("../src/lib/mcp/tool-logic.ts");
 const { runWithPrincipal } = await import("../src/lib/mcp/context.ts");
@@ -144,6 +144,67 @@ async function run() {
   check("list-members returns the space members with names",
     members.length === 2 && members.some((m) => m.uid === BOB && m.displayName === "Bob"));
   await expectError("list-members rejects non-members", "unauthorized", () => listMembers(CAROL, S1));
+
+  // --- Agent-Sessions (epic #212): register → next-todo (claim/lease) → update/handoff/complete ---
+  const HOST = "macbook";
+  const CWD = "/home/alice/proj";
+  const todoRef = (id: string) => db.collection("spaces").doc(S1).collection("todos").doc(id);
+
+  const sess = await registerSession(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("register-session returns a 64-char sessionId", typeof sess.sessionId === "string" && sess.sessionId.length === 64);
+  check("register-session default allowlist is update-todo+handoff (no complete-todo)",
+    sess.allowedTools.includes("update-todo") && sess.allowedTools.includes("handoff") && !sess.allowedTools.includes("complete-todo"));
+  const sess2 = await registerSession(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("register-session is deterministic (same id on re-register)", sess2.sessionId === sess.sessionId);
+  await expectError("register-session rejects non-members", "unauthorized",
+    () => registerSession(CAROL, { spaceId: S1, hostname: HOST, workingFolder: CWD }));
+  await expectError("next-todo without a registered session → not_found", "not_found",
+    () => nextTodo(ALICE, { spaceId: S1, hostname: "elsewhere", workingFolder: "/x" }));
+
+  // Two attached todos, explicit createdAt so "oldest first" is deterministic.
+  const attached = (createdAtMs: number) => ({
+    spaceId: S1, body: null, completed: false, waitingOn: null, tags: [], mentions: [],
+    createdBy: BOB, modifiedBy: BOB, createdAt: Timestamp.fromMillis(createdAtMs), order: 10,
+    attachedSession: sess.sessionId, aidoTurn: "aido", claimedBy: null, claimedAt: null,
+  });
+  await todoRef("a1").set({ ...attached(1000), title: "First question", order: 10 });
+  await todoRef("a2").set({ ...attached(2000), title: "Second question", order: 11 });
+
+  const first = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("next-todo returns the oldest attached todo", first?.todoId === "a1" && first?.title === "First question");
+  const again = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("next-todo self-claim is idempotent (same todo)", again?.todoId === "a1");
+
+  const upd = await updateTodo(ALICE, { sessionId: sess.sessionId, spaceId: S1, todoId: "a1", bodyMarkdown: "Antwort: `42`", mode: "append" });
+  check("update-todo keeps it open (not completed)", upd.completed === false);
+  const a1d = (await todoRef("a1").get()).data()!;
+  check("update-todo writes a Tiptap doc body", (a1d.body as { type?: string })?.type === "doc");
+  check("update-todo append keeps the claim", a1d.claimedBy === sess.sessionId);
+  check("update-todo stamps lastAidoEditAt", !!a1d.lastAidoEditAt);
+  await expectError("update-todo on an unclaimed todo → unauthorized", "unauthorized",
+    () => updateTodo(ALICE, { sessionId: sess.sessionId, spaceId: S1, todoId: "a2", bodyMarkdown: "x" }));
+
+  const ho = await handoffTodo(ALICE, { sessionId: sess.sessionId, spaceId: S1, todoId: "a1" });
+  check("handoff sets aidoTurn=user", ho.aidoTurn === "user");
+  check("handoff clears the claim", (await todoRef("a1").get()).data()!.claimedBy === null);
+
+  const second = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("next-todo advances to the next todo after handoff", second?.todoId === "a2");
+
+  await expectError("complete-todo via session blocked by default allowlist", "unauthorized",
+    () => completeTodo(ALICE, S1, "a2", true, sess.sessionId));
+  await registerSession(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD, allowedTools: ["update-todo", "handoff", "complete-todo"] });
+  const comp = await completeTodo(ALICE, S1, "a2", true, sess.sessionId);
+  check("complete-todo via session works once allowed", comp.completed === true);
+  check("complete-todo via session clears the claim", (await todoRef("a2").get()).data()!.claimedBy === null);
+
+  // Lease: a stale claim by a DIFFERENT session is reclaimable.
+  await todoRef("a3").set({ ...attached(3000), title: "Stale", order: 12, claimedBy: "other-session", claimedAt: Timestamp.fromMillis(1) });
+  const reclaimed = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("next-todo reclaims a todo whose lease expired", reclaimed?.todoId === "a3");
+  await handoffTodo(ALICE, { sessionId: sess.sessionId, spaceId: S1, todoId: "a3" });
+  const none = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
+  check("next-todo returns null when nothing is queued", none === null);
 
   // --- principal gate (tool-logic): data tools require a user principal ---
   await expectError("no principal → unauthorized", "unauthorized", () => handleListSpaces());


### PR DESCRIPTION
Teil von Epic #212 · **Closes #216** (Schritt 4/8). Schließt den **MVP-Loop** ab (über MCP end-to-end nutzbar). Baut auf #215.

### Änderungen
- `tool-logic.ts`: Handler für `register-session`/`next-todo`/`update-todo`/`handoff`; `complete-todo` um `sessionId` erweitert. `next-todo` (Claim = Polling) **nicht** rate-limitiert, die mutierenden Tools schon (NFA-06).
- `route.ts`: vier neue Tools registriert (Zod-Schemas); `complete-todo` um optionales `sessionId`.
- `tests/mcp-tools.test.mts`: voller Loop gegen den Firestore-Emulator.

### Verifikation
- `npm run test:mcp` (firebase-tools@13): **All MCP tool tests passed** — inkl. register-session (deterministische id, Default-Allowlist, Member-Gate), next-todo (oldest-first, idempotenter Self-Claim, not_found ohne Session), update-todo (offen/Tiptap-Body/Claim/lastAidoEditAt/**Scope-Reject**), handoff (turn=user/Claim gelöst/Advance), complete-todo via Session (**Allowlist-Reject** → erlaubt), **Lease-Reclaim**, leere Queue → null.
- `npx tsc --noEmit` + `eslint`: grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)