### PR TITLE
feat(todos): attach/detach/returnToAido + Agent-Sessions-Abo

### DIFF
--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -23,6 +23,9 @@ import {
   setTodoStatus,
   deleteTodo,
   moveTodoToSpace,
+  attachTodoToSession,
+  detachTodoSession,
+  returnTodoToAido,
 } from "@/lib/firebase/firebaseUtils";
 import type { MentionMember } from "@/lib/utils/textUtils";
 import type { Todo, TiptapContent } from "@/lib/types";
@@ -59,6 +62,12 @@ interface TodosContextType {
    * when the target doesn't have that member.
    */
   moveTodo: (id: string, targetSpaceId: string) => Promise<boolean>;
+  /** Agent-Sessions (epic #212): bind a todo to a session ("bei aido"). */
+  attachToSession: (id: string, sessionId: string) => Promise<void>;
+  /** Remove a todo's session binding. */
+  detachSession: (id: string) => Promise<void>;
+  /** Re-queue a handed-off todo for the session ("Zurück an aido"). */
+  returnToAido: (id: string) => Promise<void>;
 }
 
 const TodosContext = createContext<TodosContextType | undefined>(undefined);
@@ -294,6 +303,45 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     [user, todos, spaces, showToast, showError]
   );
 
+  const attachToSession = useCallback(
+    async (id: string, sessionId: string) => {
+      if (!activeSpaceId || !user) return;
+      try {
+        await attachTodoToSession(activeSpaceId, id, sessionId, user.uid);
+      } catch (e) {
+        console.error("attachToSession failed", e);
+        showError("An Agent-Session anhängen fehlgeschlagen.");
+      }
+    },
+    [activeSpaceId, user, showError]
+  );
+
+  const detachSession = useCallback(
+    async (id: string) => {
+      if (!activeSpaceId || !user) return;
+      try {
+        await detachTodoSession(activeSpaceId, id, user.uid);
+      } catch (e) {
+        console.error("detachSession failed", e);
+        showError("Lösen der Agent-Session fehlgeschlagen.");
+      }
+    },
+    [activeSpaceId, user, showError]
+  );
+
+  const returnToAido = useCallback(
+    async (id: string) => {
+      if (!activeSpaceId || !user) return;
+      try {
+        await returnTodoToAido(activeSpaceId, id, user.uid);
+      } catch (e) {
+        console.error("returnToAido failed", e);
+        showError("Zurück an aido fehlgeschlagen.");
+      }
+    },
+    [activeSpaceId, user, showError]
+  );
+
   const value: TodosContextType = {
     todos,
     loading,
@@ -310,6 +358,9 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     setStatus,
     remove,
     moveTodo,
+    attachToSession,
+    detachSession,
+    returnToAido,
   };
 
   return <TodosContext.Provider value={value}>{children}</TodosContext.Provider>;

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -30,7 +30,7 @@ import {
 } from "firebase/firestore";
 import { getSpaceColor } from "../theme/colors";
 import { deriveTags, deriveMentions, extractPlainText, type MentionMember } from "../utils/textUtils";
-import type { Space, Todo, Daily, TiptapContent } from "../types";
+import type { Space, Todo, Daily, TiptapContent, AgentSession, AgentToolName } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
 
@@ -337,6 +337,83 @@ export const moveTodoToSpace = async (
   await batch.commit();
   return targetRef.id;
 };
+
+// --- Agent-Sessions (epic #212, issue #217) ---
+// Binding a todo to a Claude-Code session is a normal member update on the todo
+// doc; managing the session docs is owner-only under users/{uid}/sessions.
+
+// Attach a todo to a session (sets it to "bei aido"). Clears any stale claim.
+export const attachTodoToSession = (
+  spaceId: string,
+  todoId: string,
+  sessionId: string,
+  uid: string
+) =>
+  updateDoc(todoRef(spaceId, todoId), {
+    attachedSession: sessionId,
+    aidoTurn: "aido",
+    claimedBy: null,
+    claimedAt: null,
+    modifiedBy: uid,
+  });
+
+// Remove the binding entirely.
+export const detachTodoSession = (spaceId: string, todoId: string, uid: string) =>
+  updateDoc(todoRef(spaceId, todoId), {
+    attachedSession: null,
+    aidoTurn: null,
+    claimedBy: null,
+    claimedAt: null,
+    modifiedBy: uid,
+  });
+
+// "Zurück an aido": re-queue a handed-off (aidoTurn='user') todo for the session.
+export const returnTodoToAido = (spaceId: string, todoId: string, uid: string) =>
+  updateDoc(todoRef(spaceId, todoId), { aidoTurn: "aido", modifiedBy: uid });
+
+const sessionsCol = (uid: string) => collection(db, "users", uid, "sessions");
+const sessionRef = (uid: string, sessionId: string) => doc(db, "users", uid, "sessions", sessionId);
+
+const mapAgentSession = (d: QueryDocumentSnapshot<DocumentData>): AgentSession => {
+  const data = d.data();
+  return {
+    id: d.id,
+    spaceId: typeof data.spaceId === "string" ? data.spaceId : "",
+    hostname: typeof data.hostname === "string" ? data.hostname : "",
+    workingFolder: typeof data.workingFolder === "string" ? data.workingFolder : "",
+    label: typeof data.label === "string" ? data.label : null,
+    allowedTools: Array.isArray(data.allowedTools) ? (data.allowedTools as AgentToolName[]) : [],
+    leaseTtlSeconds: typeof data.leaseTtlSeconds === "number" ? data.leaseTtlSeconds : 600,
+    createdAt: data.createdAt ?? null,
+    lastSeenAt: data.lastSeenAt ?? null,
+  };
+};
+
+// Live list of the user's agent sessions for one space (for the attach picker /
+// settings panel). Single-field `where` — no composite index needed.
+export const subscribeAgentSessionsForSpace = (
+  uid: string,
+  spaceId: string,
+  onChange: (sessions: AgentSession[]) => void,
+  onError?: (e: Error) => void
+): Unsubscribe =>
+  onSnapshot(
+    query(sessionsCol(uid), where("spaceId", "==", spaceId)),
+    (snap) => onChange(snap.docs.map(mapAgentSession)),
+    (err) => onError?.(err)
+  );
+
+export const renameAgentSession = (uid: string, sessionId: string, label: string) =>
+  updateDoc(sessionRef(uid, sessionId), { label: label.trim() || null });
+
+export const deleteAgentSession = (uid: string, sessionId: string) =>
+  deleteDoc(sessionRef(uid, sessionId));
+
+export const setAgentSessionConfig = (
+  uid: string,
+  sessionId: string,
+  config: { allowedTools?: AgentToolName[]; leaseTtlSeconds?: number }
+) => updateDoc(sessionRef(uid, sessionId), { ...config });
 
 // --- Daily "Heute" items (space-scoped, issue #41) ---
 // Short-lived items, deliberately separate from todos (never appear in the list).

--- a/src/lib/hooks/useAgentSessions.ts
+++ b/src/lib/hooks/useAgentSessions.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { subscribeAgentSessionsForSpace } from "@/lib/firebase/firebaseUtils";
+import type { AgentSession } from "@/lib/types";
+
+// Live list of the current user's Agent-Sessions for a space (epic #212, #217).
+// Used by the attach picker (#218) and the settings panel (#219).
+export function useAgentSessions(spaceId: string | null): {
+  sessions: AgentSession[];
+  loading: boolean;
+} {
+  const { user } = useAuth();
+  const [sessions, setSessions] = useState<AgentSession[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user || !spaceId) {
+      setSessions([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const unsub = subscribeAgentSessionsForSpace(
+      user.uid,
+      spaceId,
+      (s) => {
+        setSessions(s);
+        setLoading(false);
+      },
+      (e) => {
+        console.error("agent sessions subscription failed", e);
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [user, spaceId]);
+
+  return { sessions, loading };
+}


### PR DESCRIPTION
Teil von Epic #212 · **Closes #217** (Schritt 5/8). Baut auf #213.

### Änderungen
- `firebaseUtils`: `attachTodoToSession` / `detachTodoSession` / `returnTodoToAido` (Member-Updates, `modifiedBy`); `subscribeAgentSessionsForSpace` (live, single-field `where`, kein Index), `renameAgentSession`, `deleteAgentSession`, `setAgentSessionConfig` (owner-only).
- Neu `src/lib/hooks/useAgentSessions.ts` — Live-Sessions je Space für die UI (#218/#219).
- `TodosContext`: `attachToSession` / `detachSession` / `returnToAido`.

### Verifikation
- `npx tsc --noEmit` + `eslint`: grün. (Client-Code; verhaltensseitig via #218/#219-UI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)