### PR TITLE
feat(ui): Attach + „zurück an aido“ + Status-Badges (Liste & Board)

### DIFF
--- a/src/components/shell/AttachToSessionMenu.tsx
+++ b/src/components/shell/AttachToSessionMenu.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React from "react";
+import { useTodos } from "@/lib/contexts/TodosContext";
+import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useAgentSessions } from "@/lib/hooks/useAgentSessions";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Picker that binds a todo to one of the user's Agent-Sessions registered for
+ * the active space (epic #212, issue #218). Shared by the list actions and the
+ * board card sheet. Offers "Lösen" when the todo is already attached.
+ */
+export default function AttachToSessionMenu({ todo, onDone }: { todo: Todo; onDone: () => void }) {
+  const { attachToSession, detachSession } = useTodos();
+  const { activeSpaceId } = useSpaces();
+  const { sessions, loading } = useAgentSessions(activeSpaceId);
+  const item = "rounded-lg px-3 py-2 text-left text-sm hover:bg-row-hover";
+
+  const attach = async (sessionId: string) => {
+    await attachToSession(todo.id, sessionId);
+    onDone();
+  };
+  const detach = async () => {
+    await detachSession(todo.id);
+    onDone();
+  };
+
+  if (loading) {
+    return <p className="px-3 py-2 text-sm text-text-dim">Lädt …</p>;
+  }
+  if (sessions.length === 0) {
+    return (
+      <p className="px-3 py-2 text-sm text-text-dim">
+        Keine Agent-Session in diesem Space registriert.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {sessions.map((s) => {
+        const attached = todo.attachedSession === s.id;
+        const title = s.label || `${s.hostname} · ${s.workingFolder}`;
+        return (
+          <button
+            key={s.id}
+            type="button"
+            className={`flex items-center justify-between gap-2 ${item}`}
+            style={{ minHeight: 44 }}
+            onClick={() => attach(s.id)}
+          >
+            <span className="min-w-0 flex-1 truncate">{title}</span>
+            {attached && <span className="text-accent">✓</span>}
+          </button>
+        );
+      })}
+      {todo.attachedSession && (
+        <button
+          type="button"
+          className={item}
+          style={{ minHeight: 44, color: "var(--danger)" }}
+          onClick={detach}
+        >
+          Lösen
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shell/StatusBadge.tsx
+++ b/src/components/shell/StatusBadge.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import type { Todo } from "@/lib/types";
+
+/**
+ * Agent-Session state badge (epic #212): derives "bei aido" / "in Arbeit" /
+ * "bei dir" from a todo's binding fields. Renders nothing when not attached.
+ * (The exact lease isn't known client-side; a present `claimedBy` is treated as
+ * "in Arbeit" — good enough for the badge.)
+ */
+export default function StatusBadge({ todo }: { todo: Todo }) {
+  if (!todo.attachedSession) return null;
+
+  const state =
+    todo.aidoTurn === "user"
+      ? { label: "bei dir", dot: "var(--accent)" }
+      : todo.claimedBy
+        ? { label: "in Arbeit", dot: "var(--wait-text)" }
+        : { label: "bei aido", dot: "var(--text-dim)" };
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-semibold"
+      style={{ border: "1px solid var(--border)", color: "var(--text-dim)" }}
+      title={`Agent-Session: ${state.label}`}
+    >
+      <span aria-hidden style={{ width: 6, height: 6, borderRadius: 3, background: state.dot }} />
+      {state.label}
+    </span>
+  );
+}

--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import BottomSheet from "../BottomSheet";
 import MoveToSpaceMenu from "../MoveToSpaceMenu";
+import AttachToSessionMenu from "../AttachToSessionMenu";
 import BoardGroupToggle from "./BoardGroupToggle";
 import ColumnHeader from "./ColumnHeader";
 import TodoCard from "./TodoCard";
@@ -22,6 +23,7 @@ export default function BoardView() {
   // picker to move to another space (issue #202). All board todos are in the
   // active space, so "another space exists" is global.
   const [moveSpaceCard, setMoveSpaceCard] = useState<Todo | null>(null);
+  const [attachCard, setAttachCard] = useState<Todo | null>(null);
   const canMoveToSpace = spaces.length > 1;
 
   const onDrop = async (col: BoardColumn) => {
@@ -76,6 +78,7 @@ export default function BoardView() {
                   draggable
                   onDragStart={() => setDragId(t.id)}
                   onMoveToSpace={canMoveToSpace ? () => setMoveSpaceCard(t) : undefined}
+                  onAttach={() => setAttachCard(t)}
                 />
               ))}
               {col.todos.length === 0 && col.apply && (
@@ -97,6 +100,16 @@ export default function BoardView() {
             nameOf={nameOf}
             onDone={() => setMoveSpaceCard(null)}
           />
+        )}
+      </BottomSheet>
+
+      <BottomSheet
+        open={!!attachCard}
+        onClose={() => setAttachCard(null)}
+        title="An Agent-Session anhängen"
+      >
+        {attachCard && (
+          <AttachToSessionMenu todo={attachCard} onDone={() => setAttachCard(null)} />
         )}
       </BottomSheet>
     </div>

--- a/src/components/shell/board/TodoCard.tsx
+++ b/src/components/shell/board/TodoCard.tsx
@@ -5,6 +5,7 @@ import { useTodos } from "@/lib/contexts/TodosContext";
 import { checklistProgress } from "@/lib/utils/checklist";
 import Avatar from "../Avatar";
 import TokenizedText from "../TokenizedText";
+import StatusBadge from "../StatusBadge";
 import type { Todo } from "@/lib/types";
 
 interface TodoCardProps {
@@ -17,10 +18,12 @@ interface TodoCardProps {
   onMove?: () => void;
   /** Open the "In Space" target-space picker for this card (issue #202). */
   onMoveToSpace?: () => void;
+  /** Open the "An Agent-Session anhängen" picker for this card (issue #218). */
+  onAttach?: () => void;
 }
 
 /** Board card (issue #46): title + progress + "bei X" chip + check circle. */
-export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove, onMoveToSpace }: TodoCardProps) {
+export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove, onMoveToSpace, onAttach }: TodoCardProps) {
   const { setCompleted } = useTodos();
   const progress = checklistProgress(todo.body);
 
@@ -51,7 +54,7 @@ export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart,
         </span>
       </div>
 
-      {(progress.total > 0 || todo.waitingOn) && (
+      {(progress.total > 0 || todo.waitingOn || todo.attachedSession) && (
         <div className="flex flex-wrap items-center gap-2 pl-7">
           {todo.waitingOn && (
             <span className="flex items-center gap-1 text-xs text-text-dim">
@@ -63,11 +66,22 @@ export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart,
               {progress.done}/{progress.total}
             </span>
           )}
+          <StatusBadge todo={todo} />
         </div>
       )}
 
-      {(onMove || onMoveToSpace) && (
+      {(onMove || onMoveToSpace || onAttach) && (
         <div className="flex flex-wrap justify-end gap-2">
+          {onAttach && (
+            <button
+              type="button"
+              onClick={onAttach}
+              className="rounded-full border border-border px-3 py-1 text-xs font-semibold"
+              style={{ minHeight: 32 }}
+            >
+              An Session
+            </button>
+          )}
           {onMove && (
             <button
               type="button"

--- a/src/components/shell/list/TodoActions.tsx
+++ b/src/components/shell/list/TodoActions.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
 import MoveToSpaceMenu from "../MoveToSpaceMenu";
+import AttachToSessionMenu from "../AttachToSessionMenu";
 import type { Todo } from "@/lib/types";
 
 /**
@@ -23,10 +24,11 @@ export default function TodoActions({
   onEdit: () => void;
   onClose: () => void;
 }) {
-  const { setWaitingOn, remove } = useTodos();
+  const { setWaitingOn, remove, returnToAido } = useTodos();
   const { activeSpace, spaces } = useSpaces();
   const [waitOpen, setWaitOpen] = useState(false);
   const [moveOpen, setMoveOpen] = useState(false);
+  const [attachOpen, setAttachOpen] = useState(false);
   const members = activeSpace?.members ?? [];
 
   // FA-08: hide the move entry when there is nowhere to move the todo to.
@@ -102,6 +104,34 @@ export default function TodoActions({
             </div>
           )}
         </>
+      )}
+
+      {todo.aidoTurn === "user" && (
+        <button
+          type="button"
+          className={item}
+          style={{ minHeight: 44 }}
+          onClick={async () => {
+            await returnToAido(todo.id);
+            onClose();
+          }}
+        >
+          Zurück an aido
+        </button>
+      )}
+
+      <button
+        type="button"
+        className={`flex items-center justify-between ${item}`}
+        style={{ minHeight: 44 }}
+        onClick={() => setAttachOpen((o) => !o)}
+      >
+        An Agent-Session anhängen … <span className="text-text-dim">{attachOpen ? "⌄" : "›"}</span>
+      </button>
+      {attachOpen && (
+        <div className="border-l border-border pl-2">
+          <AttachToSessionMenu todo={todo} onDone={onClose} />
+        </div>
       )}
 
       <button

--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -8,6 +8,7 @@ import TodoTitle from "./TodoTitle";
 import TodoBody from "./TodoBody";
 import TodoEditor from "./TodoEditor";
 import TodoActions from "./TodoActions";
+import StatusBadge from "../StatusBadge";
 import { checklistProgress } from "@/lib/utils/checklist";
 import type { Todo } from "@/lib/types";
 
@@ -80,7 +81,7 @@ export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActio
           onClick={() => hasBody && setExpanded((e) => !e)}
         >
           <TodoTitle title={todo.title} completed={todo.completed} />
-          {(todo.waitingOn || progress.total > 0) && (
+          {(todo.waitingOn || progress.total > 0 || todo.attachedSession) && (
             <div className="mt-1 flex flex-wrap items-center gap-2">
               {todo.waitingOn && (
                 <span
@@ -95,6 +96,7 @@ export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActio
                   {progress.done}/{progress.total}
                 </span>
               )}
+              <StatusBadge todo={todo} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Teil von Epic #212 · **Closes #218** (Schritt 6/8). Baut auf #217.

### Änderungen
- Neu `StatusBadge` — `bei aido` / `in Arbeit` / `bei dir` aus den Todo-Feldern.
- Neu `AttachToSessionMenu` — Picker via `useAgentSessions` (Sessions des aktiven Space), attach + „Lösen“; geteilt von Liste & Board.
- `TodoActions`: „An Agent-Session anhängen …“-Submenü + „Zurück an aido“ (bei `aidoTurn='user'`).
- `TodoRow` & `TodoCard`: Badge in der Meta-Zeile.
- `BoardView`/`TodoCard`: „An Session“-Button + `BottomSheet` mit dem Picker (Muster #202).

### Verifikation
- `npx tsc --noEmit` + `eslint`: grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)