### PR TITLE
docs: Spezifikation – Todos manuell nach Reihenfolge ordnen

### DIFF
--- a/docs/01-konzept-todo-reihenfolge.md
+++ b/docs/01-konzept-todo-reihenfolge.md
@@ -1,0 +1,107 @@
+# Konzept: Todos manuell nach Reihenfolge ordnen
+
+## 1. Zusammenfassung
+
+Nutzer sollen die Reihenfolge der Todos in der **Liste** selbst bestimmen können,
+indem sie ein Todo per Drag & Drop (bzw. „nach oben/unten") an eine andere
+Position ziehen. Das Datenmodell trägt bereits ein `order`-Feld, nach dem die
+Liste sortiert wird — es fehlt bislang nur die **UI zum Umsortieren** und die
+Schreiblogik, die die neuen `order`-Werte persistiert.
+
+## 2. Problemstellung
+
+Heute ergibt sich die Reihenfolge der Todos ausschließlich aus dem **Anlege-
+Zeitpunkt**: Beim Erstellen bekommt jedes Todo `order = maxOrder + 1`, und die
+Liste sortiert per `orderBy("order","asc")`. Der Typ-Kommentar in `src/lib/types.ts`
+hält das ausdrücklich fest: *„There is no manual reordering UI."*
+
+Damit kann ein Nutzer ein wichtiges Todo nicht nach oben holen oder eine logische
+Abarbeitungsreihenfolge herstellen. Die einzige Möglichkeit, etwas „nach oben" zu
+bekommen, wäre es zu löschen und neu anzulegen — mit Verlust von Body, Tags,
+„Wartet auf" und Erstelldatum. Das ist unbrauchbar.
+
+## 3. Zielsetzung
+
+- Ein Todo kann mit Drag & Drop an eine beliebige andere Position innerhalb der
+  offenen Liste gezogen werden; die neue Reihenfolge wird **sofort persistiert**
+  und ist für alle Space-Mitglieder live sichtbar (`onSnapshot`).
+- Die Aktion funktioniert auf **Desktop und Mobile** (Touch).
+- Die Reihenfolge ist **stabil** und **kollisionsfrei** — keine doppelten oder
+  „springenden" Positionen, auch bei realer Zusammenarbeit.
+- Neue Todos landen weiterhin **am Ende** der Liste (unverändertes Verhalten).
+- Keine Regression: bestehende Sortierung, Filter, „Erledigt"-Sektion und Board
+  funktionieren unverändert weiter.
+
+## 4. Lösungsidee
+
+**Datenseite (bereits vorhanden, wird genutzt):**
+- Das Feld `order: number` und die `orderBy("order","asc")`-Abfragen bleiben die
+  Quelle der Sortierung. Es ist **kein** neues Feld und **keine** Migration nötig.
+- Die Firestore-Regeln erlauben Mitgliedern bereits, `order` zu ändern (sie
+  validieren nur `order is number` zusammen mit `modifiedBy == caller` und
+  unveränderlichem `createdBy`) → voraussichtlich **keine** Regeländerung.
+
+**Persistierung der neuen Reihenfolge:** Beim Loslassen werden die betroffenen
+Todos in einem **`writeBatch`** mit neuen, sauberen ganzzahligen `order`-Werten
+neu durchnummeriert (die Listen sind klein — typischerweise wenige bis einige
+Dutzend Todos pro Space). Das ist robust und kollisionsfrei; eine alternative
+Fractional-/Midpoint-Indizierung (nur ein Doc-Write pro Move, aber
+Float-Präzisionsgrenzen) wird in den offenen Fragen abgewogen.
+
+**UI / Interaktion:** Drag & Drop in der Liste (`shell/list`). Als Bibliothek
+bietet sich **`framer-motion`** mit der `Reorder`-Komponente an — sie ist
+**bereits Dependency**, unterstützt **Touch und Maus** und bringt flüssige
+Animationen mit (das handgebaute HTML5-DnD des Boards funktioniert nicht auf
+Touch). Ergänzend bzw. als Barrierefreiheits-Fallback können „Nach oben"/„Nach
+unten"-Einträge im bestehenden Aktionsmenü (`TodoActions`) angeboten werden.
+
+**Geltungsbereich:** Umsortiert wird die **offene** Liste. Die „Erledigt"-Sektion
+bleibt nach `order` sortiert, ist aber selbst nicht umsortierbar. Bei aktivem
+**Tag-Filter** sieht der Nutzer nur eine Teilmenge — hier wird das Umsortieren
+deaktiviert (oder bewusst gehandhabt, siehe offene Fragen), um keine unsichtbaren
+Positionen zu zerstören.
+
+## 5. Betroffene Komponenten
+
+| Bereich | Datei(en) | Art der Änderung |
+|---|---|---|
+| Firestore-Schreiblogik | `src/lib/firebase/firebaseUtils.ts` | Neue Funktion `reorderTodos(spaceId, orderedIds, uid)` (Batch: neue `order`-Werte für die betroffenen Todos) |
+| Todos-State | `src/lib/contexts/TodosContext.tsx` | Neue Context-Methode `reorder(orderedIds)`; ggf. optimistisches lokales Update |
+| Listen-UI | `src/components/shell/list/TodoSections.tsx`, `TodoRow.tsx`, `ListView.tsx`, `MobileTodos.tsx` | Drag & Drop / `Reorder.Group`+`Reorder.Item`, Drag-Handle, Touch-Support |
+| Aktionsmenü (optional) | `src/components/shell/list/TodoActions.tsx` | „Nach oben"/„Nach unten" als Fallback (A11y/Mobile) |
+| Typen | `src/lib/types.ts` | Kommentar zu `order` aktualisieren (es gibt nun eine Reorder-UI) |
+| Tests | `tests/firestore-rules.test.mjs` | Regeltest: Mitglied darf `order` ändern; Nicht-Mitglied nicht |
+
+## 6. Abgrenzung
+
+Nicht Teil dieser Anforderung:
+
+- **Umsortieren der „Erledigt"-Sektion** — erledigte Todos bleiben order-sortiert,
+  werden aber nicht per Hand umsortiert.
+- **Umsortieren über Spaces hinweg** — das ist „Verschieben" (Feature
+  `todo-verschieben`), nicht „Reihenfolge".
+- **Umsortieren von „Heute"/Daily-Items** — nur strukturierte Todos.
+- **Sortier-Modi** (nach Fälligkeit, Alphabet, Priorität …) — hier geht es rein um
+  die **manuelle** Reihenfolge.
+- **Reordering via MCP/Agent-Tools** — kein neues MCP-Tool in diesem Feature.
+
+## 7. Offene Fragen (entschieden)
+
+1. **Interaktionsmodell:** → **Drag & Drop mit `framer-motion` `Reorder`** (Touch +
+   Maus, bereits Dependency, animiert). Kein handgebautes HTML5-DnD für die Liste.
+2. **Persistenz-Schema:** → **Fractional/Midpoint-`order`** — beim Move bekommt das
+   verschobene Todo den Mittelwert der `order`-Werte seiner neuen Nachbarn; nur
+   **ein** Doc-Write pro Move. Die Float-Präzisionsgrenze wird durch eine
+   **Normalisierung/Neuvergabe** abgefangen, wenn der Abstand zweier Nachbarn zu
+   klein wird (siehe Spezifikation).
+3. **Verhalten bei aktivem Tag-Filter:** → **Gefiltert umordnen erlauben.** Beim
+   Drop im gefilterten Zustand werden nur die **sichtbaren** Todos relativ
+   zueinander geordnet (Midpoint zwischen den sichtbaren Nachbarn); unsichtbare
+   Todos behalten ihre `order` und ordnen sich global mit ein.
+4. **Mobile-Bedienung:** → **Touch-Drag** über `framer-motion` (langes Drücken/Ziehen
+   am Handle). „Nach oben/unten"-Buttons sind **optional** als A11y-Ergänzung, kein
+   harter Bestandteil.
+5. **Board-Reordering:** → **Board macht mit.** Auch *innerhalb* einer Board-Spalte
+   ist die Reihenfolge per Hand änderbar (zusätzlich zum bestehenden Spaltenwechsel
+   = Status/Person). Das Zusammenspiel von Intra-Spalten-Reorder und
+   Inter-Spalten-Move wird in der Spezifikation entworfen.

--- a/docs/02-ist-analyse-todo-reihenfolge.md
+++ b/docs/02-ist-analyse-todo-reihenfolge.md
@@ -1,0 +1,102 @@
+# Ist-Analyse: Todos manuell nach Reihenfolge ordnen
+
+## 1. Aktueller Zustand
+
+Todos werden ausschließlich nach dem Feld **`order: number`** sortiert, das beim
+Anlegen einmalig auf `maxOrder + 1` gesetzt wird (Insertion-Order). Es existiert
+**keine UI**, um die Reihenfolge nachträglich zu ändern — der Typ-Kommentar hält
+das fest: *„There is no manual reordering UI."*
+
+Konkret:
+
+- **Datenmodell:** `spaces/{spaceId}/todos/{id}` trägt `order: number`
+  (`src/lib/types.ts`, Z. 55–59).
+- **Schreiben:** `createTodo(...)` schreibt `order: input.order ?? 0`
+  (`firebaseUtils.ts`, Z. 215). `TodosContext.createTodo` berechnet
+  `maxOrder + 1` über alle geladenen Todos (Z. 178–182).
+- **Lesen/Sortieren:** `getTodosForSpace` und `subscribeTodosForSpace` fragen mit
+  `orderBy("order","asc")` ab (`firebaseUtils.ts`, Z. 222 / 234). Die Live-
+  Subscription (`onSnapshot`, issue #72) hält die Liste bei allen Mitgliedern
+  aktuell.
+- **Listen-Render:** `TodoSections` teilt `filtered` in `open`/`done` und rendert
+  je eine `TodoRow` in der gegebenen (order-)Reihenfolge — kein Drag, kein Handle.
+- **Board-Render:** `buildColumns` (`board/columns.ts`) gruppiert dieselben Todos
+  nach Person/Status in Spalten; innerhalb jeder Spalte bleibt die order-
+  Reihenfolge erhalten. `BoardView` nutzt **HTML5-Drag&Drop** (`onDragStart`/
+  `onDrop`), um Karten **zwischen Spalten** zu ziehen → das ändert `waitingOn`
+  bzw. `completed` (via `col.apply`), **nicht** `order`. HTML5-DnD funktioniert
+  **nicht auf Touch**.
+- **Regeln:** `firestore.rules` erlaubt jedem Space-Mitglied ein `update`, sofern
+  `order is number`, `modifiedBy == caller` und `createdBy` unverändert bleibt
+  (Z. 182–187, `hasValidTodoFields`). Eine `order`-Änderung ist damit **bereits
+  regelkonform** — es fehlt nur Client-Logik und UI.
+
+## 2. Relevante Dateien und Komponenten
+
+| Datei/Komponente | Beschreibung | Relevanz |
+|---|---|---|
+| `src/lib/types.ts` | `Todo`-Typ inkl. `order: number` (+ Kommentar „kein Reorder-UI") | Kommentar aktualisieren; Typ bleibt |
+| `src/lib/firebase/firebaseUtils.ts` | `createTodo` (order-Vergabe), `getTodosForSpace`/`subscribeTodosForSpace` (orderBy), `editTodoContent`/`setTodoStatus` (Update-Muster mit `modifiedBy`) | **Neue** `reorderTodo(...)`-Schreibfunktion; Muster für `modifiedBy` übernehmen |
+| `src/lib/contexts/TodosContext.tsx` | Lädt/mutiert die Todos des aktiven Space; CRUD-Methoden; berechnet `maxOrder+1` | **Neue** Methode `reorder(...)`; optimistisches Update optional |
+| `src/components/shell/list/TodoSections.tsx` | Rendert offene + erledigte Rows | Offene Liste in `Reorder.Group` wandeln |
+| `src/components/shell/list/TodoRow.tsx` | Einzelne Listenzeile (Desktop/Mobile) | Drag-Handle ergänzen; `Reorder.Item` |
+| `src/components/shell/list/ListView.tsx`, `MobileTodos.tsx` | Desktop-/Mobile-Rahmen der Liste | Einbindung der Reorder-fähigen Sektion |
+| `src/components/shell/list/TodoActions.tsx` | Aktionsmenü (Popover/Sheet) | Optional „Nach oben/unten" als A11y-Fallback |
+| `src/components/shell/board/columns.ts` | `buildColumns`: Spalten + `apply`-Drop | Spalten-Todos bleiben order-sortiert; Intra-Spalten-Reorder einhängen |
+| `src/components/shell/board/BoardView.tsx`, `MobileBoard.tsx`, `TodoCard.tsx` | Board-DnD zwischen Spalten | Intra-Spalten-Reorder ergänzen (zus. zum Spaltenwechsel) |
+| `firestore.rules` | Erlaubt order-Update bereits | **Keine** Änderung; nur Test ergänzen |
+| `tests/firestore-rules.test.mjs` | Regeltests Todos | Test: Mitglied darf `order` ändern, Typ erzwungen |
+| `package.json` | `framer-motion ^11` vorhanden | `Reorder` nutzbar, **keine neue Dependency** |
+
+## 3. Bestehende Abhängigkeiten
+
+- **`framer-motion ^11.3.31`** ist bereits installiert und bietet
+  `Reorder.Group`/`Reorder.Item` (Maus **und** Touch, animiert) — Grundlage der
+  geplanten Liste-DnD ohne neue Abhängigkeit.
+- **Firebase Client SDK** (`writeBatch`/`updateDoc`, `serverTimestamp`,
+  `onSnapshot`) — `writeBatch` wird bereits in `moveTodoToSpace` genutzt; das
+  Update-Muster mit `modifiedBy: uid` ist etabliert.
+- **Live-Subscription (`onSnapshot`, #72):** order-Änderungen propagieren ohne
+  Zusatzaufwand an alle Mitglieder.
+- **Board-DnD** basiert heute auf nativem HTML5-Drag&Drop (eigene
+  `dragId`/`dragOver`-State in `BoardView`) — ein zweites, paralleles
+  Drag-System zur geplanten framer-motion-Liste.
+
+## 4. Bekannte Einschränkungen
+
+- **HTML5-DnD ≠ Touch:** Das bestehende Board-Drag funktioniert nicht auf Touch.
+  Für eine touch-fähige Reihenfolge in der Liste ist framer-motion `Reorder` (oder
+  ein pointer-basiertes Verfahren) erforderlich.
+- **Zwei Drag-Welten im Board:** Inter-Spalten-Move (HTML5-DnD, ändert Status/
+  Person) und der gewünschte Intra-Spalten-Reorder (Reihenfolge) müssen koexistieren,
+  ohne sich gegenseitig zu stören — die zentrale Designaufgabe des Board-Teils.
+- **`order` ist heute ganzzahlig** (`maxOrder+1`). Fractional/Midpoint führt
+  gebrochene Werte ein; mehrfaches Halbieren zwischen zwei festen Nachbarn stößt
+  irgendwann an die **Float-Präzision** → Normalisierungsstrategie nötig.
+- **Tag-Filter zeigt nur Teilmenge:** Beim Umsortieren im gefilterten Zustand sind
+  nicht alle Nachbarn sichtbar; die gewählte Midpoint-Variante ordnet nur die
+  sichtbaren relativ zueinander (unsichtbare behalten ihre `order`).
+- **Keine serverseitige Transaktion über mehrere Docs nötig** für Midpoint (1
+  Doc-Write/Move) — aber eine spätere Normalisierung betrifft mehrere Docs (Batch).
+
+## 5. Risiken bei Änderung
+
+- **Float-Präzisionsverlust:** Ohne Normalisierung kann nach vielen Moves zwischen
+  denselben Nachbarn `(a+b)/2 == a` werden → zwei gleiche `order`-Werte, instabile
+  Sortierung. Mitigation: bei zu kleinem Nachbarabstand Liste neu normalisieren
+  (Batch mit sauberen Ganzzahlen).
+- **Gleichstände/`order`-Kollisionen:** Schon heute können zwei Todos `order==0`
+  haben (Legacy/`?? 0`). `orderBy` ist dann nicht deterministisch → beim ersten
+  Reorder bzugleich normalisieren, um Altbestände zu heilen.
+- **Nebenläufige Reorder (Kollaboration):** Zwei Mitglieder ziehen gleichzeitig →
+  Last-Write-Wins pro Doc; bei Midpoint betrifft jeder Move nur ein Doc, das
+  Risiko sichtbarer „Sprünge" ist klein, aber nicht null (via `onSnapshot` heilt
+  sich die Ansicht).
+- **Regression Board-DnD:** Das Einführen eines zweiten Drag-Systems darf den
+  bestehenden Spaltenwechsel (Status/Person) nicht brechen.
+- **Optimistisches UI vs. Snapshot:** Springt die Liste zwischen lokalem Drop und
+  Firestore-Echo, wirkt es ruckelig → optimistische lokale Sortierung bis zum
+  Snapshot-Echo.
+- **Falsche Felder im Update:** Ein order-Update muss `modifiedBy` mitschreiben und
+  `createdBy`/`spaceId` unangetastet lassen, sonst greift die Regel nicht
+  (`isValidModifiedBy`, `createdBy == resource.createdBy`).

--- a/docs/03-anforderungsanalyse-todo-reihenfolge.md
+++ b/docs/03-anforderungsanalyse-todo-reihenfolge.md
@@ -1,0 +1,62 @@
+# Anforderungsanalyse: Todos manuell nach Reihenfolge ordnen
+
+## 1. Funktionale Anforderungen
+
+| ID | Anforderung | Priorität | Beschreibung |
+|---|---|---|---|
+| FA-01 | Drag & Drop in der Liste | Muss | In der **offenen** Liste lässt sich ein Todo per Drag & Drop an eine andere Position ziehen (Desktop **und** Mobile/Touch), umgesetzt mit `framer-motion` `Reorder`. |
+| FA-02 | Drag-Handle | Muss | Jede Row hat ein klar erkennbares Handle (`≡`) als Greifpunkt, damit Ziehen nicht mit Scrollen, Tippen, Checkbox oder Inline-Edit kollidiert. |
+| FA-03 | Midpoint-Persistenz | Muss | Beim Loslassen erhält das verschobene Todo `order = (orderVorher + orderNachher) / 2` (Ränder: `min−1` bzw. `max+1`); genau **ein** Doc-Write pro Move, `modifiedBy = caller`, `createdBy`/`spaceId` unverändert. |
+| FA-04 | Live-Persistenz | Muss | Die neue Reihenfolge wird in Firestore gespeichert und ist über `onSnapshot` für alle Space-Mitglieder live sichtbar. |
+| FA-05 | Neue Todos ans Ende | Muss | Beim Anlegen landet ein Todo weiterhin am Listenende (`maxOrder + 1`) — unverändertes Verhalten. |
+| FA-06 | Normalisierung | Soll | Wird der `order`-Abstand zweier Nachbarn zu klein (Float-Präzisionsgrenze) **oder** liegen Gleichstände vor (z. B. mehrere `order==0` aus Altbestand), wird die betroffene Liste in einem `writeBatch` mit sauberen Ganzzahlen neu vergeben. |
+| FA-07 | Gefiltertes Umordnen | Soll | Bei aktivem Tag-Filter ordnet ein Drop nur die **sichtbaren** Todos relativ zueinander (Midpoint zwischen den sichtbaren Nachbarn); unsichtbare behalten ihre `order` und ordnen sich global mit ein. |
+| FA-08 | Board: Intra-Spalten-Reorder | Soll | Innerhalb einer Board-Spalte lässt sich die Reihenfolge per Hand ändern — **zusätzlich** zum bestehenden Spaltenwechsel (Drag zwischen Spalten = Status/Person via `apply`). |
+| FA-09 | A11y-/Tasten-Fallback | Kann | „Nach oben" / „Nach unten" im Aktionsmenü (`TodoActions`) als barrierefreie Alternative zum Ziehen. |
+| FA-10 | Optimistisches Update | Kann | Lokale Sortierung wird sofort beim Drop angewandt und vom Snapshot-Echo bestätigt, damit die Liste nicht ruckelt/springt. |
+
+**Nicht gefordert (Abgrenzung):** Umsortieren der „Erledigt"-Sektion, Umsortieren
+von Daily-/„Heute"-Items, Sortier-Modi (Fälligkeit/Alphabet/Priorität),
+Reordering über MCP/Agent-Tools, Reorder über Space-Grenzen (= „Verschieben").
+
+## 2. Nicht-funktionale Anforderungen
+
+| ID | Anforderung | Kategorie | Beschreibung |
+|---|---|---|---|
+| NFA-01 | Wenig Schreiblast | Performance | Ein Reorder kostet **ein** Doc-Write (Midpoint); die Mehr-Doc-Normalisierung (FA-06) tritt nur selten auf. |
+| NFA-02 | Keine Regelaufweichung | Sicherheit | Order-Update läuft über die bestehende `allow update`-Regel; `modifiedBy == caller`, `createdBy`/`spaceId` bleiben unangetastet. **Keine** Lockerung von `firestore.rules`. |
+| NFA-03 | Touch-Bedienbarkeit | Usability | Ziehen funktioniert flüssig auf Touch ohne Konflikt mit dem Seiten-Scroll; Greifen nur am Handle. |
+| NFA-04 | Stabile, eindeutige Ordnung | Konsistenz | Nach jedem Reorder sind die `order`-Werte eindeutig und deterministisch sortierbar (keine Gleichstände, keine Float-Drift bis zur Kollision). |
+| NFA-05 | Barrierefreiheit | A11y | Reihenfolge auch ohne Pointer änderbar (Buttons/Tastatur, FA-09). |
+| NFA-06 | Keine Migration | Wartbarkeit | Nutzt das vorhandene `order`-Feld; kein neues Feld, kein Backfill, keine Datenmigration nötig. |
+| NFA-07 | Keine Board-Regression | Stabilität | Der bestehende Inter-Spalten-Move (Status/Person) bleibt voll funktionsfähig. |
+
+## 3. Akzeptanzkriterien
+
+- [ ] In der offenen Liste lässt sich ein Todo per Maus an eine neue Position ziehen; nach Reload bleibt die Reihenfolge erhalten.
+- [ ] Dasselbe funktioniert per Touch auf Mobile (Greifen am Handle, kein versehentliches Scroll-Ziehen).
+- [ ] Ein zweites, eingeloggtes Mitglied sieht die neue Reihenfolge ohne manuellen Reload (live).
+- [ ] Ein einzelner Move schreibt genau **ein** Todo-Dokument (Midpoint), mit aktualisiertem `modifiedBy`.
+- [ ] Neu angelegte Todos erscheinen am **Ende** der offenen Liste.
+- [ ] Werden zwei Nachbarn „zu eng" (oder existieren Gleichstände), normalisiert ein Reorder die Liste auf saubere Ganzzahlen, ohne sichtbare Sprünge.
+- [ ] Bei aktivem Tag-Filter bleibt die relative Reihenfolge der sichtbaren Todos nach dem Drop korrekt; unsichtbare Todos verschwinden nicht und behalten ihren Platz.
+- [ ] Im Board lässt sich innerhalb einer Spalte umsortieren; das Ziehen **zwischen** Spalten ändert weiterhin Status/Person.
+- [ ] Die „Erledigt"-Sektion ist nicht per Drag umsortierbar (nur lesend order-sortiert).
+- [ ] Der Firestore-Regeltest bestätigt: ein Mitglied darf `order` ändern, ein Nicht-Mitglied nicht; `order` muss eine Zahl sein.
+- [ ] `npm run build`, `npm run lint` und `npx tsc --noEmit` laufen sauber durch.
+
+## 4. Abhängigkeiten zu anderen Anforderungen
+
+- Baut auf dem vorhandenen **`order`-Feld** und der **Live-Subscription** (`onSnapshot`, issue #72) auf.
+- Nutzt **`framer-motion`** (bereits Dependency) — keine neue Abhängigkeit.
+- Unabhängig vom Feature **„Todo verschieben"** (issues #200–#202), berührt aber dieselbe `order`-Logik (`moveTodoToSpace` setzt im Ziel `maxOrder+1`) — kein Konflikt, gleiche Konvention „ans Ende".
+- Das Board-Teilstück (FA-08) baut auf der Liste-Reorder-Mechanik (Context-Methode + Midpoint-Helfer) auf und sollte **nach** dem Liste-Teil umgesetzt werden.
+
+## 5. Priorisierung
+
+1. **Muss (MVP):** FA-01..FA-05 + NFA-01..NFA-04, NFA-06 — Drag & Drop in der
+   Liste (Desktop + Touch) mit Midpoint-Persistenz und Live-Sync. Damit ist das
+   Kernbedürfnis („Reihenfolge selbst bestimmen") erfüllt.
+2. **Soll:** FA-06 (Normalisierung/Robustheit), FA-07 (gefiltertes Umordnen),
+   FA-08 (Board-Reorder, NFA-07). Erhöhen Robustheit und Vollständigkeit.
+3. **Kann:** FA-09 (A11y-Buttons), FA-10 (optimistisches Update als Politur).

--- a/docs/04-spezifikation-todo-reihenfolge.md
+++ b/docs/04-spezifikation-todo-reihenfolge.md
@@ -1,0 +1,186 @@
+# Spezifikation: Todos manuell nach Reihenfolge ordnen
+
+## 1. Übersicht
+
+Manuelle Reihenfolge der Todos per Drag & Drop. Das vorhandene `order`-Feld bleibt
+die Sortierquelle; neu sind (a) eine **Midpoint-Schreiblogik** (`order` = Mittelwert
+der neuen Nachbarn, ein Doc-Write pro Move), (b) eine **`Reorder`-UI** auf Basis von
+`framer-motion` für die Liste (Desktop + Touch), (c) eine **Normalisierung** gegen
+Float-Drift/Gleichstände und (d) **Intra-Spalten-Reorder** im Desktop-Board. Es gibt
+**keine** Datenmigration und **keine** Lockerung der Firestore-Regeln.
+
+Basis: [Konzept](01-konzept-todo-reihenfolge.md) ·
+[Ist-Analyse](02-ist-analyse-todo-reihenfolge.md) ·
+[Anforderungsanalyse](03-anforderungsanalyse-todo-reihenfolge.md).
+
+## 2. Technisches Design
+
+### 2.1 Architektur
+
+Drei Schichten, von unten nach oben:
+
+1. **Schreibschicht** (`firebaseUtils.ts`) — reine Pure-Function für die
+   Order-Berechnung + dünne Firestore-Writes.
+2. **State** (`TodosContext.tsx`) — `reorder(...)`-Methode, die aus der **sichtbaren**
+   Liste die Nachbarn bestimmt, die neue `order` berechnet und persistiert; hält ein
+   optimistisches lokales Abbild bis zum Snapshot-Echo.
+3. **UI** — Liste über `framer-motion` `Reorder`; Desktop-Board erweitert sein
+   bestehendes HTML5-DnD um kartengenaue Drop-Ziele.
+
+### 2.2 Datenmodell
+
+**Keine Schemaänderung.** `order: number` bleibt; künftig auch **gebrochene** Werte.
+`createTodo` vergibt weiterhin `maxOrder + 1` (Ende). Der Typ-Kommentar zu `order`
+in `src/lib/types.ts` wird aktualisiert (es gibt nun eine Reorder-UI).
+
+**Order-Berechnung (Pure Function, testbar):**
+
+```ts
+// src/lib/utils/order.ts (neu)
+export const ORDER_STEP = 1;          // Abstand bei Normalisierung
+export const ORDER_MIN_GAP = 1e-6;    // darunter: vor dem Einfügen normalisieren
+
+/** order für ein Todo, das zwischen prev und next einsortiert wird.
+ *  null = kein Nachbar (Listenrand). Gibt `null` zurück, wenn der Abstand
+ *  zu klein ist und vorher normalisiert werden muss. */
+export function orderBetween(prev: number | null, next: number | null): number | null {
+  if (prev == null && next == null) return ORDER_STEP;   // leere Liste
+  if (prev == null) return next! - ORDER_STEP;           // an den Anfang
+  if (next == null) return prev + ORDER_STEP;            // ans Ende
+  if (next - prev < ORDER_MIN_GAP) return null;          // zu eng → normalisieren
+  return (prev + next) / 2;                              // dazwischen
+}
+```
+
+**Normalisierung:** Liefert `orderBetween` `null` (zu enger Spalt) **oder** liegen
+Gleichstände im Bestand vor (z. B. Legacy-`order==0`), wird die betroffene Liste in
+einem `writeBatch` mit `order = (index+1) * ORDER_STEP` neu vergeben, danach der Move
+auf der frischen Verteilung berechnet.
+
+### 2.3 Schnittstellen
+
+**`firebaseUtils.ts` (neu):**
+
+```ts
+// Ein Doc-Write: order + modifiedBy (Regel verlangt modifiedBy == caller).
+export const setTodoOrder = (spaceId, todoId, order: number, uid) =>
+  updateDoc(todoDocRef(spaceId, todoId), { order, modifiedBy: uid });
+
+// writeBatch: vergibt sauber verteilte Ganzzahlen für die übergebene Reihenfolge.
+export const normalizeTodoOrders = (spaceId, orderedIds: string[], uid) => {
+  const batch = writeBatch(db);
+  orderedIds.forEach((id, i) =>
+    batch.update(todoDocRef(spaceId, id), { order: (i + 1) * ORDER_STEP, modifiedBy: uid }));
+  return batch.commit();
+};
+```
+
+**`TodosContext.tsx` (neu im Context-Typ):**
+
+```ts
+/** Verschiebt `movedId` an seine neue Position. `visibleOrderedIds` ist die
+ *  bereits neu sortierte, SICHTBARE Liste (berücksichtigt den Tag-Filter, FA-07). */
+reorder: (movedId: string, visibleOrderedIds: string[]) => Promise<void>;
+```
+
+Ablauf von `reorder`:
+1. Index von `movedId` in `visibleOrderedIds` bestimmen; sichtbare Nachbarn
+   `prevId`/`nextId` (oder `null` am Rand) ablesen.
+2. Deren globale `order` aus dem `todos`-State holen → `orderBetween(prev, next)`.
+3. Ergebnis `≠ null` → `setTodoOrder(...)`. Ergebnis `= null` →
+   `normalizeTodoOrders(...)` über die neue sichtbare Reihenfolge, fertig.
+4. Fehler → `showError(...)`; `onSnapshot` korrigiert die Ansicht ohnehin.
+
+### 2.4 Liste: framer-motion `Reorder`
+
+- `TodoSections` umschließt die **offene** Sektion mit `Reorder.Group axis="y"
+  values={items} onReorder={setItems}`; jede Row wird `Reorder.Item value={todo}`.
+  `items` ist lokaler State, initialisiert aus `open` und via `useEffect` bei
+  Änderungen von `open` (Snapshot) nachgezogen → **optimistisch** (FA-10).
+- `onReorder` aktualisiert nur den lokalen State; **persistiert** wird im
+  `onDragEnd`/`Reorder.Item`-Abschluss durch `reorder(todo.id, items.map(t => t.id))`
+  (so entsteht genau ein Write pro abgeschlossenem Move statt pro Zwischenfrequenz).
+- **Drag-Handle** (`≡`) in `TodoRow`: `Reorder.Item` mit
+  `dragListener={false}` + `useDragControls()`, das Handle ruft `controls.start(e)`.
+  So lösen Checkbox, Inline-Edit und Scrollen **kein** Ziehen aus (FA-02, NFA-03).
+- Die **„Erledigt"-Sektion** bleibt eine normale Liste (kein `Reorder`).
+
+### 2.5 Board: Intra-Spalten-Reorder (Desktop)
+
+Beibehalten wird das bestehende **HTML5-DnD** (kein zweites Drag-System im Board).
+Erweiterung: jede `TodoCard` wird **zusätzlich** Drop-Ziel.
+
+- Beim `onDrop` auf eine **Karte derselben Spalte**: `order` per `orderBetween`
+  zwischen Zielkarte und deren Nachbar berechnen (Einfügen ober-/unterhalb je nach
+  Cursor-Y relativ zur Kartenmitte) → `reorder(...)`. Status/Person bleiben.
+- Beim `onDrop` auf die **Spaltenfläche** (heutiges Verhalten) bzw. eine Karte einer
+  **anderen** Spalte: weiterhin `col.apply(id)` (Status/Person ändern).
+- Unterscheidung über die Quell-/Ziel-Spalte des gezogenen Todos (`dragId` →
+  dessen aktuelle Spaltenzugehörigkeit vs. Zielspalte).
+- **Mobile-Board** (gestapelte Sektionen ohne DnD) bleibt unverändert; das
+  Umsortieren auf Mobile erfolgt in der Liste/Todos-Tab.
+
+### 2.6 Firestore-Regeln
+
+**Keine Änderung.** Die `allow update`-Regel deckt order-Updates bereits ab
+(`order is number`, `modifiedBy == caller`, `createdBy`/`spaceId` unverändert). Ein
+**neuer Regeltest** verifiziert das positiv (Mitglied darf) und negativ
+(Nicht-Mitglied darf nicht; `order: "x"` wird abgelehnt).
+
+## 3. Implementierungsplan
+
+### 3.1 Änderungen pro Komponente
+
+| Komponente | Änderung | Aufwand |
+|---|---|---|
+| `src/lib/utils/order.ts` (neu) | `orderBetween`, `ORDER_STEP`, `ORDER_MIN_GAP` (pure) | Klein |
+| `src/lib/firebase/firebaseUtils.ts` | `setTodoOrder`, `normalizeTodoOrders` | Klein |
+| `src/lib/contexts/TodosContext.tsx` | `reorder(...)` im Typ + Impl (Nachbarn → order → persist/normalize) | Mittel |
+| `src/lib/types.ts` | Kommentar zu `order` aktualisieren | Klein |
+| `src/components/shell/list/TodoSections.tsx` | offene Sektion als `Reorder.Group`, lokaler `items`-State | Mittel |
+| `src/components/shell/list/TodoRow.tsx` | `Reorder.Item` + `useDragControls` + Drag-Handle | Mittel |
+| `src/components/shell/list/{ListView,MobileTodos}.tsx` | Einbindung/Props der Reorder-Sektion | Klein |
+| `src/components/shell/list/TodoActions.tsx` | „Nach oben/unten" (A11y-Fallback, Kann) | Klein |
+| `src/components/shell/board/{BoardView,TodoCard}.tsx`, `columns.ts` | kartengenaue Drop-Ziele + Intra-Spalten-Reorder | Mittel |
+| `tests/firestore-rules.test.mjs` | Regeltest order-Update (+/−) | Klein |
+
+### 3.2 Reihenfolge der Implementierung
+
+1. **Schreib-/State-Schicht** (`order.ts`, `setTodoOrder`/`normalizeTodoOrders`,
+   `TodosContext.reorder`, Typ-Kommentar) + **Regeltest**. → Issue A.
+2. **Liste Drag & Drop** (framer-motion `Reorder`, Handle, optimistisch,
+   gefiltertes Umordnen). → Issue B. *(hängt an A)*
+3. **Board Intra-Spalten-Reorder** (Desktop). → Issue C. *(hängt an A)*
+4. **A11y-Fallback „Nach oben/unten"**. → Issue D. *(hängt an A, optional)*
+
+## 4. Testplan
+
+- **Unit (pure):** `orderBetween` — leere Liste, Anfang, Ende, Mitte, zu enger
+  Spalt (→ `null`). Klein und schnell; ggf. als `.mjs`/`tsx`-Test analog zu
+  bestehenden Suites oder inline-Assertions.
+- **Firestore-Regeln** (`tests/firestore-rules.test.mjs`, `npm run test:rules`):
+  Mitglied darf `order` (Zahl) ändern; Nicht-Mitglied wird abgelehnt; `order: "x"`
+  wird abgelehnt; `createdBy`/`spaceId` bleiben geprüft.
+- **Manuell (Desktop):** Liste umsortieren, Reload → Reihenfolge bleibt. Mit zweitem
+  Browser/Account: Live-Update sichtbar. Tag-Filter aktiv → relative Reihenfolge der
+  sichtbaren Todos korrekt, unsichtbare bleiben erhalten. Board: innerhalb Spalte
+  umsortieren; zwischen Spalten weiter Status/Person.
+- **Manuell (Touch/Mobile):** Ziehen am Handle, kein versehentliches Scroll-Ziehen.
+- **Robustheit:** wiederholt in denselben Slot droppen → Normalisierung greift,
+  keine doppelten/instabilen Positionen.
+- **Build/Typen:** `npm run build`, `npm run lint`, `npx tsc --noEmit`.
+
+## 5. Migration / Deployment
+
+- **Keine Datenmigration**, **kein** neues Firestore-Feld.
+- **Keine Regeländerung** → kein `firestore:rules`-Deploy nötig (nur ein Test wird
+  ergänzt). Falls sich im Test wider Erwarten doch eine Lücke zeigt, würde die Regel
+  **nach** der App deployt (CLAUDE.md-Reihenfolge).
+- **Keine neue Dependency** (`framer-motion` ist vorhanden).
+- App-Deploy wie üblich über Vercel beim Merge nach `main`.
+
+## 6. Referenzen
+
+- [Konzeptdokument](01-konzept-todo-reihenfolge.md)
+- [Ist-Analyse](02-ist-analyse-todo-reihenfolge.md)
+- [Anforderungsanalyse](03-anforderungsanalyse-todo-reihenfolge.md)


### PR DESCRIPTION
Spec-Set (concept-analysis-spec) für das Feature **Todos manuell nach Reihenfolge ordnen**:

- `docs/01-konzept-todo-reihenfolge.md`
- `docs/02-ist-analyse-todo-reihenfolge.md`
- `docs/03-anforderungsanalyse-todo-reihenfolge.md`
- `docs/04-spezifikation-todo-reihenfolge.md`

Dokumentation only — wird sofort gemergt (kein CI-Wait). Die zugehörigen Issues
referenzieren diese Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)