### PR TITLE
feat(reihenfolge): Schreib-/State-Schicht für manuelles Umsortieren (#235)

### DIFF
--- a/src/lib/contexts/TodosContext.tsx
+++ b/src/lib/contexts/TodosContext.tsx
@@ -23,9 +23,12 @@ import {
   setTodoStatus,
   deleteTodo,
   moveTodoToSpace,
+  setTodoOrder,
+  normalizeTodoOrders,
   attachTodoToSession,
   detachTodoSession,
 } from "@/lib/firebase/firebaseUtils";
+import { orderBetween } from "@/lib/utils/order";
 import type { MentionMember } from "@/lib/utils/textUtils";
 import type { Todo, TiptapContent } from "@/lib/types";
 
@@ -61,6 +64,14 @@ interface TodosContextType {
    * when the target doesn't have that member.
    */
   moveTodo: (id: string, targetSpaceId: string) => Promise<boolean>;
+  /**
+   * Manual reordering (issue #235, epic #234): move `movedId` to its new slot.
+   * `visibleOrderedIds` is the already-reordered list of the *visible* todos
+   * (it honours the active tag filter — only visible neighbours anchor the new
+   * `order`). Persists a single midpoint write, or renumbers when the gap is too
+   * tight or stored orders collide.
+   */
+  reorder: (movedId: string, visibleOrderedIds: string[]) => Promise<void>;
   /** Agent-Sessions (epic #212): bind a todo to a session ("bei aido"). */
   attachToSession: (id: string, sessionId: string) => Promise<void>;
   /** Remove a todo's session binding. */
@@ -300,6 +311,43 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     [user, todos, spaces, showToast, showError]
   );
 
+  const reorder = useCallback(
+    async (movedId: string, visibleOrderedIds: string[]) => {
+      if (!activeSpaceId || !user) return;
+      const idx = visibleOrderedIds.indexOf(movedId);
+      if (idx === -1) return;
+      const byId = new Map(todos.map((t) => [t.id, t]));
+      const orderOf = (id: string | undefined): number | null =>
+        id ? byId.get(id)?.order ?? null : null;
+      // Anchor to the visible neighbours only, so reordering works (and stays
+      // intuitive) while a tag filter hides part of the list (FA-07).
+      const prevOrder = orderOf(visibleOrderedIds[idx - 1]);
+      const nextOrder = orderOf(visibleOrderedIds[idx + 1]);
+      const next = orderBetween(prevOrder, nextOrder);
+      try {
+        if (next !== null) {
+          await setTodoOrder(activeSpaceId, movedId, next, user.uid);
+          return;
+        }
+        // Gap too tight (or stored ties): renumber the whole open list with the
+        // move applied. Rebuild from the globally ordered open todos so the
+        // filtered-out ones keep their relative slots — insert moved before its
+        // visible successor (or at the end when it moved to the bottom).
+        const nextVisibleId = visibleOrderedIds[idx + 1];
+        const open = todos
+          .filter((t) => !t.completed && t.id !== movedId)
+          .map((t) => t.id);
+        const at = nextVisibleId ? open.indexOf(nextVisibleId) : -1;
+        open.splice(at < 0 ? open.length : at, 0, movedId);
+        await normalizeTodoOrders(activeSpaceId, open, user.uid);
+      } catch (e) {
+        console.error("reorder failed", e);
+        showError("Reihenfolge konnte nicht gespeichert werden.");
+      }
+    },
+    [activeSpaceId, user, todos, showError]
+  );
+
   const attachToSession = useCallback(
     async (id: string, sessionId: string) => {
       if (!activeSpaceId || !user) return;
@@ -342,6 +390,7 @@ export const TodosProvider = ({ children }: { children: ReactNode }) => {
     setStatus,
     remove,
     moveTodo,
+    reorder,
     attachToSession,
     detachSession,
   };

--- a/src/lib/firebase/firebaseUtils.ts
+++ b/src/lib/firebase/firebaseUtils.ts
@@ -30,6 +30,7 @@ import {
 } from "firebase/firestore";
 import { getSpaceColor } from "../theme/colors";
 import { deriveTags, deriveMentions, extractPlainText, type MentionMember } from "../utils/textUtils";
+import { ORDER_STEP } from "../utils/order";
 import type { Space, Todo, Daily, TiptapContent, AgentSession, AgentToolName } from "../types";
 // Auth functions
 export const logoutUser = () => signOut(auth);
@@ -301,6 +302,32 @@ export const setTodoStatus = (
     todoRef(spaceId, todoId),
     status.completed ? { ...status, ...releaseBinding, modifiedBy: uid } : { ...status, modifiedBy: uid }
   );
+
+// Manual reordering (issue #235, epic #234): set one todo's `order` to a
+// caller-computed value (the midpoint of its new neighbours — see utils/order).
+// One doc write; modifiedBy must be stamped for the rules (#198).
+export const setTodoOrder = (
+  spaceId: string,
+  todoId: string,
+  order: number,
+  uid: string
+) => updateDoc(todoRef(spaceId, todoId), { order, modifiedBy: uid });
+
+// Renumber a list of todos with clean, evenly spaced integers in one batch
+// (issue #235). Used when the neighbour gap got too small to subdivide, or to
+// heal legacy `order` ties (several todos sharing order 0). `orderedIds` is the
+// desired final order; every write stamps modifiedBy for the rules.
+export const normalizeTodoOrders = (
+  spaceId: string,
+  orderedIds: string[],
+  uid: string
+) => {
+  const batch = writeBatch(db);
+  orderedIds.forEach((id, i) =>
+    batch.update(todoRef(spaceId, id), { order: (i + 1) * ORDER_STEP, modifiedBy: uid })
+  );
+  return batch.commit();
+};
 
 export const deleteTodo = (spaceId: string, todoId: string) =>
   deleteDoc(todoRef(spaceId, todoId));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,9 +52,11 @@ export interface Todo {
   modifiedBy: string;
   createdAt: Timestamp | null;
   /**
-   * Insertion order (`maxOrder + 1` at creation); drives the stable
-   * `orderBy("order","asc")` list/board sort. There is no manual reordering UI,
-   * so it is set once and not mutated afterwards.
+   * Sort key for the stable `orderBy("order","asc")` list/board sort. Set to
+   * `maxOrder + 1` at creation (new todos land at the end) and rewritten on
+   * manual reordering (issue #235, epic #234): a moved todo gets the midpoint of
+   * its new neighbours, so values may be fractional. `normalizeTodoOrders`
+   * renumbers to clean integers when a gap gets too small or ties appear.
    */
   order: number;
   /**

--- a/src/lib/utils/order.ts
+++ b/src/lib/utils/order.ts
@@ -1,0 +1,28 @@
+/**
+ * Fractional ordering for manual todo reordering (issue #235, epic #234).
+ *
+ * Todos are sorted by `order` (`orderBy("order","asc")`). To move a todo between
+ * two neighbours we give it the midpoint of their `order` values, so a single
+ * doc write repositions it. Repeatedly halving the same slot eventually exhausts
+ * float precision; when two neighbours get closer than `ORDER_MIN_GAP`, callers
+ * must renumber the list first (`normalizeTodoOrders`) instead of inserting.
+ */
+
+/** Spacing used when (re)numbering a list with clean integers. */
+export const ORDER_STEP = 1;
+
+/** Smallest neighbour gap we still subdivide; below this, normalize instead. */
+export const ORDER_MIN_GAP = 1e-6;
+
+/**
+ * `order` for a todo inserted between `prev` and `next` — the `order` values of
+ * its new neighbours, or `null` at a list edge. Returns `null` when the gap is
+ * too small to subdivide safely: the caller must normalize the list and retry.
+ */
+export function orderBetween(prev: number | null, next: number | null): number | null {
+  if (prev == null && next == null) return ORDER_STEP; // empty list
+  if (prev == null) return next! - ORDER_STEP; // dropped at the top
+  if (next == null) return prev + ORDER_STEP; // dropped at the end
+  if (next - prev < ORDER_MIN_GAP) return null; // too tight → normalize
+  return (prev + next) / 2; // between two items
+}

--- a/tests/firestore-rules.test.mjs
+++ b/tests/firestore-rules.test.mjs
@@ -356,6 +356,12 @@ await check('member may not update completed to a non-bool', assertFails(
   updateDoc(doc(db(BOB), TODO2_PATH), { completed: 42, modifiedBy: BOB })));
 await check('member may not update order to a non-number', assertFails(
   updateDoc(doc(db(BOB), TODO2_PATH), { order: 'x', modifiedBy: BOB })));
+// Manual reordering (issue #235): a member may rewrite `order` (a fractional
+// midpoint), stamping modifiedBy; a non-member may not.
+await check('member may reorder a todo (fractional order)', assertSucceeds(
+  updateDoc(doc(db(BOB), TODO2_PATH), { order: 2.5, modifiedBy: BOB })));
+await check('non-member may not reorder a todo', assertFails(
+  updateDoc(doc(db(MALLORY), TODO2_PATH), { order: 2.5, modifiedBy: MALLORY })));
 // The seed todo carries no modifiedBy (legacy, pre-#198). NFA-04: it stays
 // editable as long as the update supplies modifiedBy == caller.
 await check('member (non-creator) may edit a legacy todo, stamping modifiedBy', assertSucceeds(


### PR DESCRIPTION
Teil von Epic #234 · Closes #235.

Fundament für die manuelle Todo-Reihenfolge — **noch ohne UI** (die kommt in #236/#237/#238).

## Änderungen
- **`src/lib/utils/order.ts`** (neu): pure `orderBetween(prev, next)` — Midpoint der Nachbarn; `ORDER_STEP` an den Rändern; `null` bei zu engem Spalt (`< ORDER_MIN_GAP`) als Signal zum Normalisieren.
- **`firebaseUtils.ts`**: `setTodoOrder` (ein Doc-Write, stempelt `modifiedBy`) und `normalizeTodoOrders` (`writeBatch` mit sauberen Ganzzahlen — heilt zu enge Spalten **und** Legacy-`order==0`-Gleichstände).
- **`TodosContext.tsx`**: `reorder(movedId, visibleOrderedIds)` — ankert an den **sichtbaren** Nachbarn (Tag-Filter-tauglich, FA-07); Midpoint-Write, sonst Neunummerierung der offenen Liste mit angewandtem Move (gefilterte Todos behalten ihren Platz).
- **`types.ts`**: `order`-Kommentar aktualisiert (Reorder-UI existiert; Werte können fraktional sein).
- **`firestore.rules`**: unverändert (order-Update war bereits regelkonform). **`tests/firestore-rules.test.mjs`**: Regeltest ergänzt — Mitglied darf `order` (fraktional) ändern, Nicht-Mitglied nicht.

## Checks
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende `<img>`-Warnings) · `npm run build` ✅
- `npm run test:rules` ✅ — „All rules tests passed" inkl. der zwei neuen Reorder-Tests.

Spezifikation: `docs/04-spezifikation-todo-reihenfolge.md` (Abschnitte 2.2/2.3/2.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)