### PR TITLE
feat(reihenfolge): Liste per Drag & Drop umsortieren (#236)

### DIFF
--- a/src/components/shell/list/TodoRow.tsx
+++ b/src/components/shell/list/TodoRow.tsx
@@ -24,9 +24,15 @@ interface TodoRowProps {
    * would trap the z-40 popover below the next row and swallow its clicks.
    */
   dimmed?: boolean;
+  /**
+   * Optional drag grip rendered at the row's leading edge (issue #236). Supplied
+   * only for reorderable open rows; it owns the drag gesture (the row itself does
+   * not), so the checkbox/edit/expand stay clickable.
+   */
+  dragHandle?: React.ReactNode;
 }
 
-export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActions, dimmed }: TodoRowProps) {
+export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActions, dimmed, dragHandle }: TodoRowProps) {
   const { setCompleted, editContent } = useTodos();
   const { accent } = useSpaces();
 
@@ -71,6 +77,7 @@ export default function TodoRow({ todo, nameOf, variant = "desktop", onOpenActio
       style={variant === "mobile" ? { border: "1px solid var(--border)" } : undefined}
     >
       <div className="flex items-start gap-3">
+        {dragHandle}
         <div className="flex min-w-0 flex-1 items-start gap-3" style={dim}>
         <button
           type="button"

--- a/src/components/shell/list/TodoSections.tsx
+++ b/src/components/shell/list/TodoSections.tsx
@@ -1,16 +1,87 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Reorder, useDragControls } from "framer-motion";
 import { useTodos } from "@/lib/contexts/TodosContext";
 import { useSpaceMemberNames } from "@/lib/hooks/useMemberProfiles";
 import TodoRow from "./TodoRow";
 import type { Todo } from "@/lib/types";
 
+// Joins ids into a comparable signature; "/" can't appear in a Firestore doc id.
+const SEP = "/";
+
+/** Six-dot drag grip. */
+function GripIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <circle cx="5.5" cy="4" r="1.3" />
+      <circle cx="10.5" cy="4" r="1.3" />
+      <circle cx="5.5" cy="8" r="1.3" />
+      <circle cx="10.5" cy="8" r="1.3" />
+      <circle cx="5.5" cy="12" r="1.3" />
+      <circle cx="10.5" cy="12" r="1.3" />
+    </svg>
+  );
+}
+
+/**
+ * One draggable open todo (issue #236). The grip handle is the ONLY drag
+ * initiator (`dragListener={false}` + `useDragControls`), so the checkbox, body
+ * toggle, inline edit and list scrolling never start a drag. `touch-action: none`
+ * on the handle lets it drag on touch instead of scrolling the page.
+ */
+function ReorderableRow({
+  id,
+  todo,
+  nameOf,
+  variant,
+  onOpenActions,
+  onReorderEnd,
+}: {
+  id: string;
+  todo: Todo;
+  nameOf: (uid: string) => string;
+  variant: "desktop" | "mobile";
+  onOpenActions?: (todo: Todo) => void;
+  onReorderEnd: (movedId: string) => void;
+}) {
+  const controls = useDragControls();
+  return (
+    <Reorder.Item
+      as="div"
+      value={id}
+      dragListener={false}
+      dragControls={controls}
+      whileDrag={{ scale: 1.01 }}
+      onDragEnd={() => onReorderEnd(id)}
+    >
+      <TodoRow
+        todo={todo}
+        nameOf={nameOf}
+        variant={variant}
+        onOpenActions={onOpenActions}
+        dragHandle={
+          <button
+            type="button"
+            aria-label="Zum Umsortieren ziehen"
+            onPointerDown={(e) => controls.start(e)}
+            className="mt-0.5 shrink-0 cursor-grab px-0.5 py-1 text-text-dim hover:text-text active:cursor-grabbing"
+            style={{ touchAction: "none" }}
+          >
+            <GripIcon />
+          </button>
+        }
+      />
+    </Reorder.Item>
+  );
+}
+
 /**
  * Shared open + collapsible "Erledigt" todo sections (issue #82) for the desktop
- * Liste (`ListView`) and the mobile Todos tab (`MobileTodos`). The two views
- * differ only in row chrome: desktop rows use an inline actions popover; mobile
- * rows open a bottom sheet via `onOpenActions` (handled by the caller).
+ * Liste (`ListView`) and the mobile Todos tab (`MobileTodos`). The open section
+ * is drag-reorderable (issue #236); the two views differ only in row chrome:
+ * desktop rows use an inline actions popover; mobile rows open a bottom sheet via
+ * `onOpenActions` (handled by the caller).
  */
 export default function TodoSections({
   variant = "desktop",
@@ -19,24 +90,71 @@ export default function TodoSections({
   variant?: "desktop" | "mobile";
   onOpenActions?: (todo: Todo) => void;
 }) {
-  const { filtered, loading } = useTodos();
+  const { filtered, loading, reorder } = useTodos();
   const nameOf = useSpaceMemberNames();
   const [showDone, setShowDone] = useState(false);
 
-  const open = filtered.filter((t) => !t.completed);
-  const done = filtered.filter((t) => t.completed);
+  const open = useMemo(() => filtered.filter((t) => !t.completed), [filtered]);
+  const done = useMemo(() => filtered.filter((t) => t.completed), [filtered]);
+  const byId = useMemo(() => new Map(open.map((t) => [t.id, t])), [open]);
+
+  // Local, optimistic copy of the open order so a drag stays put until the
+  // Firestore echo arrives (FA-10). Values are ids (stable identity → framer
+  // matches reliably and the list doesn't flash when a fresh snapshot maps new
+  // Todo objects). Re-synced whenever the server order or the tag filter changes.
+  const [orderIds, setOrderIds] = useState<string[]>(() => open.map((t) => t.id));
+  const orderIdsRef = useRef(orderIds);
+  orderIdsRef.current = orderIds;
+  const syncedRef = useRef("");
+  useEffect(() => {
+    const ids = open.map((t) => t.id);
+    setOrderIds(ids);
+    syncedRef.current = ids.join(SEP);
+  }, [open]);
+
+  const onReorderEnd = useCallback(
+    (movedId: string) => {
+      const ids = orderIdsRef.current;
+      // No write when the drag ended back in the original slot.
+      if (ids.join(SEP) === syncedRef.current) return;
+      reorder(movedId, ids);
+    },
+    [reorder]
+  );
+
   const gap = variant === "mobile" ? "gap-2" : "gap-1";
 
   if (loading) return <p className="py-2 text-sm text-text-dim">Lädt …</p>;
 
   return (
     <>
-      <div className={`flex flex-col ${gap}`}>
-        {open.map((t) => (
-          <TodoRow key={t.id} todo={t} nameOf={nameOf} variant={variant} onOpenActions={onOpenActions} />
-        ))}
-        {open.length === 0 && <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>}
-      </div>
+      {orderIds.length === 0 ? (
+        <p className="py-2 text-sm text-text-dim">Keine offenen Todos.</p>
+      ) : (
+        <Reorder.Group
+          as="div"
+          axis="y"
+          values={orderIds}
+          onReorder={setOrderIds}
+          className={`flex flex-col ${gap}`}
+        >
+          {orderIds.map((id) => {
+            const t = byId.get(id);
+            if (!t) return null;
+            return (
+              <ReorderableRow
+                key={id}
+                id={id}
+                todo={t}
+                nameOf={nameOf}
+                variant={variant}
+                onOpenActions={onOpenActions}
+                onReorderEnd={onReorderEnd}
+              />
+            );
+          })}
+        </Reorder.Group>
+      )}
 
       {done.length > 0 && (
         <div className={`flex flex-col ${gap}`}>


### PR DESCRIPTION
Teil von Epic #234 · baut auf #235 · Closes #236.

Drag & Drop in der **offenen** Liste über `framer-motion` `Reorder` (bereits Dependency) — Desktop **und** Touch.

## Änderungen
- **`TodoSections.tsx`**: offene Sektion als `Reorder.Group` mit lokalem, **optimistischem** Order-State. Werte sind **IDs** (stabile Identität → kein Flackern, wenn ein frischer Snapshot neue Todo-Objekte mappt); re-synchronisiert bei Server-Order-/Filter-Wechsel. Persistenz im **`onDragEnd`** via `reorder(movedId, sichtbareIds)`; **kein Write**, wenn der Drop in der Ausgangsposition endet.
- **`ReorderableRow` + Grip-Handle** als **einziger** Drag-Auslöser (`dragListener={false}` + `useDragControls`, `touch-action: none`) — Checkbox, Body-Toggle, Inline-Edit und Scrollen lösen **kein** Ziehen aus.
- **`TodoRow.tsx`**: optionales `dragHandle`-Prop, am führenden Zeilenrand gerendert (nur für reorderbare offene Zeilen; „Erledigt" bleibt statisch).
- **Gefiltertes Umordnen (FA-07):** die sichtbaren IDs ankern die neue `order`; der Context (#235) platziert relativ zu den sichtbaren Nachbarn.

## Checks
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende `<img>`-Warnings) · `npm run build` ✅
- Interaktion (Drag/Touch/Live/gefiltert) bitte auf der Vercel-Preview gegenprüfen — eine authentifizierte E2E-Session war lokal nicht herstellbar.

## Hinweis
Erster Commit enthielt versehentlich ein NUL-Byte im `SEP`-Literal (git sah die Datei als binär); behoben — `SEP = "/"`, Datei ist sauberer UTF-8-Text.

Spezifikation: `docs/04-spezifikation-todo-reihenfolge.md` (Abschnitt 2.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)