### PR TITLE
feat(reihenfolge): Board – Reihenfolge innerhalb einer Spalte (#237)

### DIFF
--- a/src/components/shell/board/BoardView.tsx
+++ b/src/components/shell/board/BoardView.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useSpaces } from "@/lib/contexts/SpacesContext";
+import { useTodos } from "@/lib/contexts/TodosContext";
 import BottomSheet from "../BottomSheet";
 import MoveToSpaceMenu from "../MoveToSpaceMenu";
 import AttachToSessionMenu from "../AttachToSessionMenu";
@@ -17,8 +18,11 @@ export default function BoardView() {
   const [groupBy, setGroupBy] = useState<GroupBy>("person");
   const { columns, loading, accent, nameOf } = useBoardColumns(groupBy);
   const { spaces } = useSpaces();
+  const { reorder } = useTodos();
   const [dragId, setDragId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<string | null>(null);
+  // Card being hovered as a same-column reorder target (issue #237).
+  const [dropCard, setDropCard] = useState<{ id: string; pos: "above" | "below" } | null>(null);
   // Drag & drop moves cards between columns (same space); "In Space" opens a
   // picker to move to another space (issue #202). All board todos are in the
   // active space, so "another space exists" is global.
@@ -26,10 +30,54 @@ export default function BoardView() {
   const [attachCard, setAttachCard] = useState<Todo | null>(null);
   const canMoveToSpace = spaces.length > 1;
 
+  // The dragged card's todo + its current column (issue #237). Reordering is
+  // limited to OPEN todos in the SAME column; completed cards (status "Erledigt")
+  // aren't reorderable — mirrors the list, where the done section is fixed.
+  const draggedTodo = useMemo(
+    () => (dragId ? columns.flatMap((c) => c.todos).find((t) => t.id === dragId) ?? null : null),
+    [columns, dragId]
+  );
+  const draggedColId = useMemo(
+    () => (dragId ? columns.find((c) => c.todos.some((t) => t.id === dragId))?.id ?? null : null),
+    [columns, dragId]
+  );
+  const canReorderDragged = !!draggedTodo && !draggedTodo.completed;
+
+  const dropPos = (e: React.DragEvent<HTMLElement>): "above" | "below" => {
+    const r = e.currentTarget.getBoundingClientRect();
+    return e.clientY < r.top + r.height / 2 ? "above" : "below";
+  };
+
+  // Same-column reorder owns the card's drag events; stopping propagation keeps
+  // the column from also reacting (which would treat it as a status/person drop).
+  const onCardOver = (target: Todo) => (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(null);
+    setDropCard(target.id === dragId ? null : { id: target.id, pos: dropPos(e) });
+  };
+
+  const onCardDrop = (col: BoardColumn, target: Todo) => async (e: React.DragEvent<HTMLElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const moved = dragId;
+    const pos = dropPos(e);
+    setDragId(null);
+    setDragOver(null);
+    setDropCard(null);
+    if (!moved || moved === target.id) return;
+    const ids = col.todos.map((t) => t.id).filter((id) => id !== moved);
+    const at = ids.indexOf(target.id);
+    if (at < 0) return;
+    ids.splice(pos === "above" ? at : at + 1, 0, moved);
+    await reorder(moved, ids);
+  };
+
   const onDrop = async (col: BoardColumn) => {
     const id = dragId;
     setDragId(null);
     setDragOver(null);
+    setDropCard(null);
     if (id && col.apply) await col.apply(id);
   };
 
@@ -38,7 +86,7 @@ export default function BoardView() {
       <div className="flex items-center gap-3">
         <span className="text-[11px] font-extrabold uppercase tracking-[0.1em] text-text-dim">Gruppieren</span>
         <BoardGroupToggle value={groupBy} onChange={setGroupBy} />
-        <span className="ml-auto text-xs text-text-dim">Karten ziehen, um sie zu verschieben</span>
+        <span className="ml-auto text-xs text-text-dim">Karten ziehen, um sie zu verschieben oder umzusortieren</span>
       </div>
 
       {loading ? (
@@ -47,6 +95,11 @@ export default function BoardView() {
         <div
           className="grid gap-3 overflow-x-auto pb-2"
           style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(190px, 1fr))` }}
+          onDragEnd={() => {
+            setDragId(null);
+            setDragOver(null);
+            setDropCard(null);
+          }}
         >
           {columns.map((col) => (
             <div
@@ -55,6 +108,8 @@ export default function BoardView() {
                 if (col.apply) {
                   e.preventDefault();
                   setDragOver(col.id);
+                  // Over the column padding (not a card) → no insertion line.
+                  setDropCard(null);
                 }
               }}
               onDragLeave={() => setDragOver((o) => (o === col.id ? null : o))}
@@ -69,18 +124,24 @@ export default function BoardView() {
               }}
             >
               <ColumnHeader col={col} nameOf={nameOf} className="px-1 pb-1" />
-              {col.todos.map((t) => (
-                <TodoCard
-                  key={t.id}
-                  todo={t}
-                  accent={accent}
-                  nameOf={nameOf}
-                  draggable
-                  onDragStart={() => setDragId(t.id)}
-                  onMoveToSpace={canMoveToSpace ? () => setMoveSpaceCard(t) : undefined}
-                  onAttach={() => setAttachCard(t)}
-                />
-              ))}
+              {col.todos.map((t) => {
+                const reorderable = canReorderDragged && draggedColId === col.id;
+                return (
+                  <TodoCard
+                    key={t.id}
+                    todo={t}
+                    accent={accent}
+                    nameOf={nameOf}
+                    draggable
+                    onDragStart={() => setDragId(t.id)}
+                    onReorderOver={reorderable ? onCardOver(t) : undefined}
+                    onReorderDrop={reorderable ? onCardDrop(col, t) : undefined}
+                    dropHint={dropCard?.id === t.id ? dropCard.pos : null}
+                    onMoveToSpace={canMoveToSpace ? () => setMoveSpaceCard(t) : undefined}
+                    onAttach={() => setAttachCard(t)}
+                  />
+                );
+              })}
               {col.todos.length === 0 && col.apply && (
                 <p className="px-1 py-4 text-center text-xs text-text-dim">Karten hierher ziehen</p>
               )}

--- a/src/components/shell/board/TodoCard.tsx
+++ b/src/components/shell/board/TodoCard.tsx
@@ -14,6 +14,15 @@ interface TodoCardProps {
   nameOf: (uid: string) => string;
   draggable?: boolean;
   onDragStart?: () => void;
+  /**
+   * Intra-column reordering (issue #237): drag-over / drop on this card, plus a
+   * line showing where the dragged card would land. Wired only by the desktop
+   * board for same-column cards; cross-column drops bubble to the column
+   * (status/person change) untouched.
+   */
+  onReorderOver?: (e: React.DragEvent<HTMLElement>) => void;
+  onReorderDrop?: (e: React.DragEvent<HTMLElement>) => void;
+  dropHint?: "above" | "below" | null;
   /** Mobile: open the column "Verschieben" sheet for this card. */
   onMove?: () => void;
   /** Open the "In Space" target-space picker for this card (issue #202). */
@@ -23,7 +32,7 @@ interface TodoCardProps {
 }
 
 /** Board card (issue #46): title + progress + "bei X" chip + check circle. */
-export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onMove, onMoveToSpace, onAttach }: TodoCardProps) {
+export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart, onReorderOver, onReorderDrop, dropHint, onMove, onMoveToSpace, onAttach }: TodoCardProps) {
   const { setCompleted } = useTodos();
   const progress = checklistProgress(todo.body);
 
@@ -31,9 +40,26 @@ export default function TodoCard({ todo, accent, nameOf, draggable, onDragStart,
     <div
       draggable={draggable}
       onDragStart={onDragStart}
-      className="flex flex-col gap-2 bg-bg-card p-3 shadow-soft"
+      onDragOver={onReorderOver}
+      onDrop={onReorderDrop}
+      className="relative flex flex-col gap-2 bg-bg-card p-3 shadow-soft"
       style={{ borderRadius: 12, cursor: draggable ? "grab" : undefined }}
     >
+      {dropHint && (
+        <div
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: 6,
+            right: 6,
+            height: 3,
+            borderRadius: 2,
+            background: accent,
+            top: dropHint === "above" ? -2 : undefined,
+            bottom: dropHint === "below" ? -2 : undefined,
+          }}
+        />
+      )}
       <div className="flex items-start gap-2">
         <button
           type="button"


### PR DESCRIPTION
Teil von Epic #234 · baut auf #235/#236 · Closes #237.

Intra-Spalten-Reorder im **Desktop-Board** — **zusätzlich** zum bestehenden Spaltenwechsel (Status/Person). Erweitert das vorhandene HTML5-DnD (kein zweites Drag-System).

## Änderungen
- **`TodoCard.tsx`**: optionale `onReorderOver`/`onReorderDrop` (Drag-Over/Drop auf die Karte) + `dropHint` → dünne **Einfüge-Linie** (above/below) in Akzentfarbe. Das **Mobile-Board** setzt diese Props nicht und bleibt unverändert.
- **`BoardView.tsx`**:
  - Drop auf eine Karte **derselben Spalte** → `reorder(...)` (order via Midpoint zwischen den neuen Spalten-Nachbarn; ober-/unterhalb je nach Cursor-Y). Die Karte stoppt die Event-Propagation, damit die Spalte nicht gleichzeitig als Status/Person-Ziel reagiert.
  - Drop auf **Spaltenfläche / andere Spalte** → weiterhin `col.apply` (Status/Person, **unverändert**).
  - Reorder nur für **offene** Karten (Status-Spalte „Erledigt" nicht umsortierbar — spiegelt die Liste). `onDragEnd` am Grid räumt den Drag-/Drop-State auf.

## Checks
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ (nur vorbestehende `<img>`-Warnings) · `npm run build` ✅
- Drag-Interaktion (Reorder innerhalb Spalte vs. Spaltenwechsel) bitte auf der Vercel-Preview gegenprüfen.

Spezifikation: `docs/04-spezifikation-todo-reihenfolge.md` (Abschnitt 2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)