### PR TITLE
feat(mcp): next-todo folgt der manuellen Reihenfolge (order) (#243)

### DIFF
--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -590,9 +590,11 @@ export async function registerSession(
   };
 }
 
-// Claims and returns the oldest open todo bound to the caller's session, or null.
-// Per-space query (no collection-group); the claim is taken in a transaction so
-// two concurrent calls can never grab the same todo (NFA-03).
+// Claims and returns the next open todo bound to the caller's session, or null.
+// "Next" follows the manual list order (`order` asc, createdAt as tiebreak,
+// issue #243) so the agent works todos in the sequence the user arranged in the
+// web UI — matching list-todos. Per-space query (no collection-group); the claim
+// is taken in a transaction so two concurrent calls can't grab the same todo.
 export async function nextTodo(
   uid: string,
   input: { spaceId: string; hostname: string; workingFolder: string }
@@ -613,20 +615,32 @@ export async function nextTodo(
   const leaseTtl = session.leaseTtlSeconds;
 
   const open = snap.docs
-    .map((doc) => ({ id: doc.id, createdAt: doc.data().createdAt?.toMillis?.() ?? 0, d: doc.data() }))
+    .map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        order: typeof data.order === "number" ? data.order : 0,
+        createdAt: data.createdAt?.toMillis?.() ?? 0,
+        d: data,
+      };
+    })
     .filter((r) => r.d.completed !== true && r.d.aidoTurn === "aido");
+
+  // Manual list order (issue #243): lowest `order` first, createdAt as tiebreak.
+  const byOrder = (a: { order: number; createdAt: number }, b: { order: number; createdAt: number }) =>
+    a.order - b.order || a.createdAt - b.createdAt;
 
   // Already claimed by this session → return it (idempotent within a lease).
   const selfClaimed = open
     .filter((r) => r.d.claimedBy === sessionId && leaseValid(r.d.claimedAt, leaseTtl, nowMs))
-    .sort((a, b) => a.createdAt - b.createdAt);
+    .sort(byOrder);
   if (selfClaimed.length) {
     return claimedTodoView(input.spaceId, selfClaimed[0].id, selfClaimed[0].d);
   }
 
   const free = open
     .filter((r) => !r.d.claimedBy || !leaseValid(r.d.claimedAt, leaseTtl, nowMs))
-    .sort((a, b) => a.createdAt - b.createdAt);
+    .sort(byOrder);
 
   for (const row of free) {
     const ref = todosCol.doc(row.id);

--- a/tests/mcp-tools.test.mts
+++ b/tests/mcp-tools.test.mts
@@ -161,17 +161,19 @@ async function run() {
   await expectError("next-todo without a registered session → not_found", "not_found",
     () => nextTodo(ALICE, { spaceId: S1, hostname: "elsewhere", workingFolder: "/x" }));
 
-  // Two attached todos, explicit createdAt so "oldest first" is deterministic.
+  // Two attached todos. createdAt is deliberately INVERTED vs. order (a1 is the
+  // NEWER doc but has the LOWER order) so the test proves next-todo follows the
+  // manual order, not createdAt (issue #243).
   const attached = (createdAtMs: number) => ({
     spaceId: S1, body: null, completed: false, waitingOn: null, tags: [], mentions: [],
     createdBy: BOB, modifiedBy: BOB, createdAt: Timestamp.fromMillis(createdAtMs), order: 10,
     attachedSession: sess.sessionId, aidoTurn: "aido", claimedBy: null, claimedAt: null,
   });
-  await todoRef("a1").set({ ...attached(1000), title: "First question", order: 10 });
-  await todoRef("a2").set({ ...attached(2000), title: "Second question", order: 11 });
+  await todoRef("a1").set({ ...attached(2000), title: "First question", order: 10 });
+  await todoRef("a2").set({ ...attached(1000), title: "Second question", order: 11 });
 
   const first = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
-  check("next-todo returns the oldest attached todo", first?.todoId === "a1" && first?.title === "First question");
+  check("next-todo returns the lowest-order attached todo (not the oldest)", first?.todoId === "a1" && first?.title === "First question");
   const again = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
   check("next-todo self-claim is idempotent (same todo)", again?.todoId === "a1");
 
@@ -190,7 +192,7 @@ async function run() {
   check("handoff clears the claim", (await todoRef("a1").get()).data()!.claimedBy === null);
 
   const second = await nextTodo(ALICE, { spaceId: S1, hostname: HOST, workingFolder: CWD });
-  check("next-todo advances to the next todo after handoff", second?.todoId === "a2");
+  check("next-todo advances to the next todo (by order) after handoff", second?.todoId === "a2");
 
   await expectError("complete-todo via session blocked by default allowlist", "unauthorized",
     () => completeTodo(ALICE, S1, "a2", true, sess.sessionId));


### PR DESCRIPTION
Folge zu Epic #234 · Closes #243.

`next-todo` claimte bislang das **älteste** angehängte Todo (`createdAt`). Jetzt folgt es der **manuellen Reihenfolge** (`order` aufsteigend, `createdAt` als Tiebreak) — ein `/loop` arbeitet die Todos in der Sequenz ab, die der Nutzer in der Web-UI per Drag & Drop festgelegt hat. Konsistent mit `list-todos` (sortiert bereits nach `order`).

## Änderungen
- **`src/lib/mcp/data.ts`** (`nextTodo`): beide In-Memory-Sorts (`selfClaimed` + `free`) nutzen `a.order - b.order || a.createdAt - b.createdAt`; `order` ins gemappte Objekt aufgenommen; Kommentare aktualisiert. Transaktion/Lease/Heartbeat unverändert.
- **`tests/mcp-tools.test.mts`**: die zwei angehängten Todos haben jetzt **widersprüchliche** `order`/`createdAt` (niedrigere `order` = neueres `createdAt`), sodass der Test beweist, dass `order` gewinnt.

## Checks
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm run build` ✅
- `npm run test:mcp` ✅ — „All MCP tool tests passed", inkl. „next-todo returns the lowest-order attached todo (not the oldest)".

Keine `firestore.rules`-Änderung, kein neues MCP-Tool, keine Migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)